### PR TITLE
Fixed dchassin/issue/3 (introduce --origin command line option)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # http://www.gnu.org/software/automake
 
 Makefile.in
+origin.txt
+*.xml
 
 # http://www.gnu.org/software/autoconf
-custom.mk
 /autom4te.cache
 /autoscan.log
 /autoscan-*.log
@@ -98,15 +99,11 @@ gldcore/config.h.in~
 */*/.dirstamp
 gridlabd.bin
 install/
-install64/
 */autotest/*/
 */*/*/autotest/*/
 validate.txt
 .libs/
-.*.swp
-/.DS_Store
 third_party/xerces*/*
 *.xcbkptlist
-
-# gridlabd configuration control
-configure.opt
+.*.swp
+.DS_Store

--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -182,7 +182,7 @@ endif
 
 BUILT_SOURCES += gldcore/build.h
 
-CLEANFILES += gldcore/build.h
+CLEANFILES += gldcore/build.h origin.txt
 
 pkginclude_HEADERS =
 pkginclude_HEADERS += gldcore/build.h
@@ -200,7 +200,11 @@ pkginclude_HEADERS += gldcore/schedule.h
 pkginclude_HEADERS += gldcore/test.h
 pkginclude_HEADERS += gldcore/version.h
 
+gridlabddir = $(prefix)/share/gridlabd
+gridlabd_DATA = origin.txt
+
 gldcore/build.h: buildnum
 
 buildnum: utilities/build_number
 	/bin/bash -c "source $(top_build_prefix)utilities/build_number $(top_srcdir) $(top_build_prefix)gldcore/build.h"
+	(git remote -v ; git log -n 1 ; git status -s ; git diff ) > origin.txt

--- a/gldcore/cmdarg.c
+++ b/gldcore/cmdarg.c
@@ -1213,6 +1213,43 @@ static int workdir(int argc, char *argv[])
 	return 1;
 }
 
+static int origin(int argc, char *argv[])
+{
+	FILE *fp;
+	char originfile[1024];
+	if ( find_file("origin.txt",NULL,R_OK,originfile,sizeof(originfile)-1) == NULL )
+	{
+		IN_MYCONTEXT output_error("origin file not found");
+		return CMDERR;
+	}
+	fp = fopen(originfile,"r");
+	if ( fp == NULL )
+	{
+		IN_MYCONTEXT output_error("unable to open origin file");
+		return CMDERR;
+	}
+	while ( ! feof(fp) )
+	{
+		char line[1024];
+		size_t len = fread(line,sizeof(line[0]),sizeof(line)-1,fp);
+		if ( ferror(fp) )
+		{
+			IN_MYCONTEXT output_error("error reading origin file");
+			return CMDERR;
+		}
+		if ( len >= 0 )
+		{
+			int old = global_suppress_repeat_messages;
+			global_suppress_repeat_messages = 0;
+			line[len] = '\0';
+			IN_MYCONTEXT output_message("%s",line);
+			global_suppress_repeat_messages = old;
+		}
+	}
+	fclose(fp);
+	return 1;
+}
+
 #include "job.h"
 #include "validate.h"
 
@@ -1249,6 +1286,7 @@ static CMDARG main[] = {
 	{"license",		NULL,	license,		NULL, "Displays the license agreement" },
 	{"version",		"V",	version,		NULL, "Displays the version information" },
 	{"setup",		NULL,	setup,			NULL, "Open simulation setup screen" },
+	{"origin",		NULL,	origin,			NULL, "Display origin information" },
 
 	{NULL,NULL,NULL,NULL, "Test processes"},
 	{"dsttest",		NULL,	dsttest,		NULL, "Perform daylight savings rule test" },


### PR DESCRIPTION
This PR implements the ability to identify in detail the origin of a gridlabd build.  The origin can be viewed by using the --origin command line option.