### PR TITLE
Added support to measure voltage 12 in triplex meter

### DIFF
--- a/powerflow/autotest/test_center_tapped_basic.glm
+++ b/powerflow/autotest/test_center_tapped_basic.glm
@@ -142,6 +142,6 @@ object triplex_meter {
 		interval 3600;
 		limit 30;
 		file "meter_power.csv"; // <- recorder with the results below
-		property indiv_measured_power_1,indiv_measured_power_2,indiv_measured_power_N,measured_power,measured_real_energy;
+		property indiv_measured_power_1,indiv_measured_power_2,indiv_measured_power_N,measured_power,measured_real_energy,measured_voltage_1,measured_voltage_2,measured_voltage_12;
 	 };
 }

--- a/powerflow/triplex_meter.cpp
+++ b/powerflow/triplex_meter.cpp
@@ -81,6 +81,7 @@ triplex_meter::triplex_meter(MODULE *mod) : triplex_node(mod)
 			// added to record last voltage/current
 			PT_complex, "measured_voltage_1[V]", PADDR(measured_voltage[0]),PT_DESCRIPTION,"measured voltage, phase 1 to ground",
 			PT_complex, "measured_voltage_2[V]", PADDR(measured_voltage[1]),PT_DESCRIPTION,"measured voltage, phase 2 to ground",
+			PT_complex, "measured_voltage_12[V]", PADDR(measured_voltage12), PT_DESCRIPTION,"measured voltage, phase 1 to phase 2",
 			PT_complex, "measured_voltage_N[V]", PADDR(measured_voltage[2]),PT_DESCRIPTION,"measured voltage, phase N to ground",
 			PT_double, "measured_real_max_voltage_1_in_interval", PADDR(measured_real_max_voltage_in_interval[0]),PT_DESCRIPTION,"measured real max line-to-ground voltage on phase 1 over a specified interval",
 			PT_double, "measured_real_max_voltage_2_in_interval", PADDR(measured_real_max_voltage_in_interval[1]),PT_DESCRIPTION,"measured real max line-to-ground voltage on phase 2 over a specified interval",
@@ -336,6 +337,7 @@ TIMESTAMP triplex_meter::postsync(TIMESTAMP t0, TIMESTAMP t1)
 	measured_voltage[0].SetPolar(voltageA.Mag(),voltageA.Arg());
 	measured_voltage[1].SetPolar(voltageB.Mag(),voltageB.Arg());
 	measured_voltage[2].SetPolar(voltageC.Mag(),voltageC.Arg());
+	measured_voltage12 = measured_voltage[0] + measured_voltage[1];
 
 	if (t1 > last_t)
 	{

--- a/powerflow/triplex_meter.h
+++ b/powerflow/triplex_meter.h
@@ -13,6 +13,7 @@ class triplex_meter : public triplex_node
 {
 public:
 	complex measured_voltage[3];	///< measured voltage
+	complex measured_voltage12;		///< measure voltage phase 1 to 2
 	complex measured_current[3];	///< measured current
 	double measured_real_energy;	///< metered real energy consumption
 	double measured_real_energy_delta;	///< metered real energy consumption over last interval


### PR DESCRIPTION
The triplex_meter has been modified to publish `measured_voltage_12` which is simply the sum of `measured_voltage_1` and `measured_voltage_2` as complex quantity.

The file `autotest/powerflow/test_center_tapped_basic.glm` was also modified to record this new value so we can verify that it is correctly summing the two values.