### PR TITLE
[CLOSED] Add support for multiple property entries in recorder objects

### DIFF
--- a/tape/autotest/test_collector_multiple_properties.glm
+++ b/tape/autotest/test_collector_multiple_properties.glm
@@ -1,0 +1,23 @@
+clock {
+	starttime '2018-01-01 00:00:00';
+	stoptime '2019-01-01 00:00:00';
+}
+
+class test {
+	randomvar x;
+	randomvar y;
+}
+
+module tape;
+object test:..10 {
+	x "type:normal(0,1); refresh:1h";
+	y "type:normal(0,1); refresh:1h";
+}
+
+object collector {
+	group class=test;
+	property mean(x),std(x),min(x),max(x);
+	property mean(y),std(y),min(y),max(y);
+	file test_collector_multiple_properties.csv;
+	interval 1h;
+};

--- a/tape/autotest/test_multi_recorder_multiple_properties.glm
+++ b/tape/autotest/test_multi_recorder_multiple_properties.glm
@@ -1,0 +1,29 @@
+clock {
+	starttime '2018-01-01 00:00:00';
+	stoptime '2019-01-01 00:00:00';
+}
+
+class test {
+	randomvar x;
+	randomvar y;
+}
+
+module tape;
+object test {
+	name test_1;
+	x "type:normal(0,1); refresh:1h";
+	y "type:normal(0,1); refresh:1h";
+}
+
+object test {
+	name test_2;
+	x "type:normal(0,1); refresh:1h";
+	y "type:normal(0,1); refresh:1h";
+}
+
+object multi_recorder {
+	property test_1:x,test_2:x;
+	property test_1:y,test_2:y;
+	file test_multi_recorder_multiple_properties.csv;
+	interval 1h;
+};

--- a/tape/autotest/test_recorder_multiple_properties.glm
+++ b/tape/autotest/test_recorder_multiple_properties.glm
@@ -1,0 +1,21 @@
+clock {
+	starttime '2018-01-01 00:00:00';
+	stoptime '2019-01-01 00:00:00';
+}
+
+class test {
+	randomvar x;
+	randomvar y;
+}
+
+module tape;
+object test {
+	x "type:normal(0,1); refresh:1h";
+	y "type:normal(0,1); refresh:1h";
+	object recorder {
+		property x;
+		property y;
+		file test_recorder_multiple_properties.csv;
+		interval 1h;
+	};
+}

--- a/tape/collector.c
+++ b/tape/collector.c
@@ -164,7 +164,7 @@ EXPORT int method_collector_property(OBJECT *obj, char *value, size_t size)
 {
 	struct collector *my = OBJECTDATA(obj,struct collector);
 	size_t len = strlen(value);
-	gl_verbose("adding property '%s' to recorder:%d",value,obj->id);
+	gl_verbose("adding property '%s' to collector:%d",value,obj->id);
 	if ( my->property_len < len || my->property == NULL )
 	{
 		my->property_len = ((my->property_len+len)/BLOCKSIZE+1)*BLOCKSIZE;

--- a/tape/recorder.c
+++ b/tape/recorder.c
@@ -83,7 +83,6 @@ EXPORT int create_recorder(OBJECT **obj, OBJECT *parent)
 		strcpy(my->filetype,"txt");
 		strcpy(my->mode, "file");
 		strcpy(my->delim,",");
-		strcpy(my->property,"(undefined)");
 		my->interval = -1; /* transients only */
 		my->dInterval = -1.0;
 		my->last.ts = -1;
@@ -95,10 +94,12 @@ EXPORT int create_recorder(OBJECT **obj, OBJECT *parent)
 		my->trigger[0]='\0';
 		my->format = 0;
 		strcpy(my->plotcommands,"");
-		my->target = gl_get_property(*obj,my->property,NULL);
+		my->target = NULL;
 		my->header_units = HU_DEFAULT;
 		my->line_units = LU_DEFAULT;
 		my->flush = -1; /* -1 (default): flush when buffer full, 0 flush each line, >0 flush seconds */
+		my->property = NULL;
+		my->property_len = 0;
 		return 1;
 	}
 	return 0;
@@ -112,6 +113,12 @@ static int recorder_open(OBJECT *obj)
 	TAPEFUNCS *f = 0;
 	struct recorder *my = OBJECTDATA(obj,struct recorder);
 	int retvalue;
+
+	if ( my->property == NULL )
+	{
+		gl_error("at least one property must be specified");
+		return 0;
+	}
 	
 	my->interval = (int64)(my->dInterval/TS_SECOND);
 	if ( my->interval < -1 )
@@ -485,6 +492,32 @@ static TIMESTAMP recorder_write(OBJECT *obj)
 		fprintf(my->multifp, "%s,%s\n", ts, outbuffer);
 	}
 	return TS_NEVER;
+}
+
+#define BLOCKSIZE 1024
+EXPORT int method_recorder_property(OBJECT *obj, char *value, size_t size)
+{
+	struct recorder *my = OBJECTDATA(obj,struct recorder);
+	size_t len = strlen(value);
+	gl_verbose("adding property '%s' to recorder:%d",value,obj->id);
+	if ( my->property_len < len || my->property == NULL )
+	{
+		my->property_len = ((my->property_len+len)/BLOCKSIZE+1)*BLOCKSIZE;
+		my->property = (char*)realloc(my->property,my->property_len);
+		if ( my->property == NULL )
+		{
+			gl_error("memory allocation failed");
+			my->property_len = 0;
+			return 0;
+		}
+		strcpy(my->property,value);
+	}	
+	else
+	{
+		strcat(my->property,",");
+		strcat(my->property,value);
+	}
+	return 1;
 }
 
 PROPERTY *link_properties(struct recorder *rec, OBJECT *obj, char *property_list)

--- a/tape/tape.c
+++ b/tape/tape.c
@@ -183,6 +183,7 @@ TAPEFUNCS *get_ftable(char *mode){
 }
 
 extern int method_recorder_property(OBJECT *obj, char *value, size_t size);
+extern int method_collector_property(OBJECT *obj, char *value, size_t size);
 
 EXPORT CLASS *init(CALLBACKS *fntable, void *module, int argc, char *argv[])
 {
@@ -305,15 +306,14 @@ EXPORT CLASS *init(CALLBACKS *fntable, void *module, int argc, char *argv[])
 	/* register the other classes as needed, */
 	collector_class = gl_register_class(module,"collector",sizeof(struct collector),PC_POSTTOPDOWN|PC_OBSERVER);
 	collector_class->trl = TRL_PROVEN;
-	PUBLISH_STRUCT(collector,char1024,property);
 	PUBLISH_STRUCT(collector,char32,trigger);
 	PUBLISH_STRUCT(collector,char1024,file);
-	//PUBLISH_STRUCT(collector,int64,interval);
 	PUBLISH_STRUCT(collector,int32,limit);
 	PUBLISH_STRUCT(collector,char256,group);
 	PUBLISH_STRUCT(collector,int32,flush);
 	if(gl_publish_variable(collector_class,
 		PT_double, "interval[s]", ((char*)&(my2.dInterval) - (char *)&my2),
+		PT_method, "property", (size_t)method_collector_property,
 			NULL) < 1)
 		GL_THROW("Could not publish property output for collector");
 

--- a/tape/tape.c
+++ b/tape/tape.c
@@ -184,6 +184,7 @@ TAPEFUNCS *get_ftable(char *mode){
 
 extern int method_recorder_property(OBJECT *obj, char *value, size_t size);
 extern int method_collector_property(OBJECT *obj, char *value, size_t size);
+extern int method_multi_recorder_property(OBJECT *obj, char *value, size_t size);
 
 EXPORT CLASS *init(CALLBACKS *fntable, void *module, int argc, char *argv[])
 {
@@ -273,7 +274,7 @@ EXPORT CLASS *init(CALLBACKS *fntable, void *module, int argc, char *argv[])
 	multi_recorder_class->trl = TRL_QUALIFIED;
 	if(gl_publish_variable(multi_recorder_class,
 		PT_double, "interval[s]", ((char*)&(my.dInterval) - (char *)&my),
-		PT_char1024, "property", ((char*)&(my.property) - (char *)&my),
+		PT_method, "property", (size_t)method_multi_recorder_property,
 		PT_char32, "trigger", ((char*)&(my.trigger) - (char *)&my),
 		PT_char1024, "file", ((char*)&(my.file) - (char *)&my),
 		PT_char8, "filetype", ((char*)&(my.filetype) - (char *)&my),

--- a/tape/tape.c
+++ b/tape/tape.c
@@ -182,6 +182,8 @@ TAPEFUNCS *get_ftable(char *mode){
 	return funcs;
 }
 
+extern int method_recorder_property(OBJECT *obj, char *value, size_t size);
+
 EXPORT CLASS *init(CALLBACKS *fntable, void *module, int argc, char *argv[])
 {
 	struct recorder my;
@@ -230,13 +232,11 @@ EXPORT CLASS *init(CALLBACKS *fntable, void *module, int argc, char *argv[])
 	/* register the other classes as needed, */
 	recorder_class = gl_register_class(module,"recorder",sizeof(struct recorder),PC_POSTTOPDOWN|PC_OBSERVER);
 	recorder_class->trl = TRL_PROVEN;
-	PUBLISH_STRUCT(recorder,char1024,property);
 	PUBLISH_STRUCT(recorder,char32,trigger);
 	PUBLISH_STRUCT(recorder,char1024,file);
 	PUBLISH_STRUCT(recorder,char8,filetype);
 	PUBLISH_STRUCT(recorder,char32,mode);
 	PUBLISH_STRUCT(recorder,char1024,multifile);
-	//PUBLISH_STRUCT(recorder,int64,interval);
 	PUBLISH_STRUCT(recorder,int32,limit);
 	PUBLISH_STRUCT(recorder,char1024,plotcommands);
 	PUBLISH_STRUCT(recorder,char32,xdata);
@@ -247,6 +247,7 @@ EXPORT CLASS *init(CALLBACKS *fntable, void *module, int argc, char *argv[])
 	if(gl_publish_variable(recorder_class,
 		PT_double, "interval[s]", ((char*)&(my.dInterval) - (char *)&my),
 		PT_char256,"strftime_format",((char*)&(my.strftime_format) - (char*)&my),
+		PT_method,"property", (size_t)method_recorder_property,
 		PT_enumeration, "output", ((char*)&(my.output) - (char *)&my),
 			PT_KEYWORD, "SCREEN", SCREEN,
 			PT_KEYWORD, "EPS",    EPS,

--- a/tape/tape.h
+++ b/tape/tape.h
@@ -157,7 +157,8 @@ struct recorder {
 	double dInterval;
 	TIMESTAMP interval;
 	int32 limit;
-	char1024 property;
+	char* property;
+	size_t property_len;
 	char1024 out_property;
 	PLOTFILE output; /* {EPS|GIF|JPG|PDF|PNG|SVG} More can be added */
 	char1024 plotcommands;

--- a/tape/tape.h
+++ b/tape/tape.h
@@ -202,7 +202,8 @@ struct collector {
 	double dInterval;
 	TIMESTAMP interval;
 	int32 limit;
-	char1024 property;
+	char *property;
+	size_t property_len;
 	PLOTFILE output; /* {EPS|GIF|JPG|PDF|PNG|SVG} More can be added */
 	char1024 plotcommands;
 	char32 xdata;

--- a/tape_file/tape_file.cpp
+++ b/tape_file/tape_file.cpp
@@ -360,7 +360,7 @@ EXPORT int open_recorder(struct recorder *my, char *fname, char *flags)
 		fprintf(my->fp,"# trigger... %s\n", my->trigger[0]=='\0'?"(none)":my->trigger.get_string());
 		fprintf(my->fp,"# interval.. %d\n", my->interval);
 		fprintf(my->fp,"# limit..... %d\n", my->limit);
-		fprintf(my->fp,"# timestamp,%s\n", my->property.get_string());
+		fprintf(my->fp,"# timestamp,%s\n", (const char*)my->property);
 	}
 
 	return 1;

--- a/tape_file/tape_file.cpp
+++ b/tape_file/tape_file.cpp
@@ -508,7 +508,7 @@ EXPORT int open_collector(struct collector *my, char *fname, char *flags)
 		count += fprintf(my->fp,"# trigger... %s\n", my->trigger[0]=='\0'?"(none)":my->trigger.get_string());
 		count += fprintf(my->fp,"# interval.. %d\n", my->interval);
 		count += fprintf(my->fp,"# limit..... %d\n", my->limit);
-		count += fprintf(my->fp,"# property.. timestamp,%s\n", my->property.get_string());
+		count += fprintf(my->fp,"# property.. timestamp,%s\n", (const char *)my->property);
 	}
 
 	return 1;

--- a/tape_plot/tape_plot.cpp
+++ b/tape_plot/tape_plot.cpp
@@ -381,10 +381,10 @@ EXPORT int open_recorder(struct recorder *my, char *fname, char *flags)
 	fprintf(my->fp,"# trigger... %s\n", my->trigger[0]=='\0'?"(none)":my->trigger.get_string());
 	fprintf(my->fp,"# interval.. %d\n", my->interval);
 	fprintf(my->fp,"# limit..... %d\n", my->limit);
-	fprintf(my->fp,"# timestamp,%s\n", my->property.get_string());
+	fprintf(my->fp,"# timestamp,%s\n", (const char*)my->property);
 
 	/* Split the property list into items */
-  splitString(my->property.get_string(), columns);
+  splitString(my->property, columns);
 	/* Array 'columns' contains the separated items from the property list
 	for (int i=0;i<MAXCOLUMNS;i++){
 		if (strlen(columns[i])>0)

--- a/tape_plot/tape_plot.cpp
+++ b/tape_plot/tape_plot.cpp
@@ -593,9 +593,9 @@ EXPORT int open_collector(struct collector *my, char *fname, char *flags)
 	count += fprintf(my->fp,"# trigger... %s\n", my->trigger[0]=='\0'?"(none)":my->trigger.get_string());
 	count += fprintf(my->fp,"# interval.. %d\n", my->interval);
 	count += fprintf(my->fp,"# limit..... %d\n", my->limit);
-	count += fprintf(my->fp,"# property.. timestamp,%s\n", my->property.get_string());
+	count += fprintf(my->fp,"# property.. timestamp,%s\n", (const char*)my->property);
 
-  splitString(my->property.get_string(), columns);
+  splitString(my->property, columns);
 
 	/* Put gnuplot commands in the header portion */
 	fprintf(my->fp,"# GNUplot commands below:     \n");


### PR DESCRIPTION
This PR adds the ability to list multiple "property" entries on recorders, multi_recorders, collectors, etc.

Progress:

1. recorder is done
1. collector is done
1. multi_recorder is done

Note: group recorder does not require this capability as only one property may be collected over the group. If multiple properties are needed, this is a completely different problem and should probably be entered as a new issue.

This addresses issue #51 and issue #20 as a work-around.