### PR TITLE
[CLOSED] Fix error in test_filter_second.glm auto test

### DIFF
--- a/gldcore/autotest/test_filter_delay.glm
+++ b/gldcore/autotest/test_filter_delay.glm
@@ -5,7 +5,6 @@ clock {
 	starttime '2000-01-01 00:00:00 PST';
 	stoptime '2000-01-01 01:00:00 PST';
 }
-#set debug=1
 filter delay(z,5min,10s) = 1/z;
 class from {
 	randomvar value;
@@ -21,7 +20,6 @@ object to {
 	name to;
 	value delay(from:value);
 }
-#set debug=0
 module tape;
 object multi_recorder {
 	file output.csv;

--- a/gldcore/transform.c
+++ b/gldcore/transform.c
@@ -194,17 +194,16 @@ TRANSFERFUNCTION *find_filter(char *name)
 int get_source_type(PROPERTY *prop)
 {
 	/* TODO extend this to support multiple sources */
-	int source_type = 0;
 	switch ( prop->ptype ) {
-	case PT_double: source_type = XS_DOUBLE; break;
-	case PT_complex: source_type = XS_COMPLEX; break;
-	case PT_loadshape: source_type = XS_LOADSHAPE; break;
-	case PT_enduse: source_type = XS_ENDUSE; break;
-	case PT_random: source_type = XS_RANDOMVAR; break;
+	case PT_double: return XS_DOUBLE; 
+	case PT_complex: return XS_COMPLEX; 
+	case PT_loadshape: return XS_LOADSHAPE; 
+	case PT_enduse: return XS_ENDUSE; 
+	case PT_random: return XS_RANDOMVAR; 
 	default:
 		output_error("tranform/get_source_type(PROPERTY *prop='%s'): unsupported source property type '%s'",
 			prop->name,property_getspec(prop->ptype)->name);
-		break;
+		return 0;
 	}
 }
 int transform_add_filter(OBJECT *target_obj,		/* pointer to the target object (lhs) */
@@ -369,11 +368,18 @@ TIMESTAMP apply_filter(TRANSFERFUNCTION *f,	///< transfer function
 	unsigned int m = f->m;
 	double *a = f->a;
 	double *b = f->b;
-	double dx[64];
+	static double *dx = NULL;
+	static unsigned int len = 0;
 	unsigned int i;
 
+	// memory check
+	if ( n > len )
+	{
+		len = (n/4+1)*4;
+		dx = (double*)realloc(dx,len);
+	}
+
 	// observable form
-	if ( n>sizeof(dx)/sizeof(double) ) throw_exception("transfer function %s order too high", f->name);
 	for ( i=0 ; i<n ; i++ )
 	{
 		if ( i==0 )


### PR DESCRIPTION
There was a missing return value in gldcore/transform.c:get_source_type().  

The limit on the order of the transform is also removed.
