### PR TITLE
[CLOSED] Add ability to configure and build from any directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,10 +8,11 @@ CC = $(PTHREAD_CC)
 CXX = $(PTHREAD_CXX)
 
 AM_CPPFLAGS =
-AM_CPPFLAGS += -I$(top_srcdir)/gldcore
+AM_CPPFLAGS += -I$(top_srcdir)/gldcore -I$(top_srcdir)/build-dir/gldcore
 AM_CPPFLAGS += $(GLD_CPPFLAGS)
 
 AM_CFLAGS =
+AM_CFLAGS +=  -I$(top_srcdir)/gldcore -I$(top_srcdir)/build-dir/gldcore
 AM_CFLAGS += $(PTHREAD_CFLAGS)
 AM_CFLAGS += $(GLD_CFLAGS)
 

--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -214,5 +214,5 @@ gldcore/gridlabd.in: gldcore/gridlabd.m4sh
 gldcore/build.h: buildnum
 
 buildnum: utilities/build_number
-	/bin/bash -c "source $(top_build_prefix)utilities/build_number $(top_srcdir) $(top_build_prefix)gldcore/build.h"
+	/bin/bash -c "source $(top_srcdir)/utilities/build_number $(top_srcdir) gldcore/build.h"
 	(git remote -v ; git log -n 1 ; git status -s ; git diff ) > origin.txt


### PR DESCRIPTION
This fix makes it possible to build and install from any folder and keep the source tree intact.

For example, now we can do the follow to keep all the build files in `build-dir` and generation all the install files in `install`.
~~~
host% git clone https://github.com/dchassin/gridlabd -b dchassin/build_dir
host% autoreconf -isf
host% mkdir build-dir
host% cd build-dir
host% ../configure --prefix=$(pwd)/../install
host% make install
~~~