### PR TITLE
[CLOSED] Added support for recording globals using '::' syntax

### DIFF
--- a/tape/autotest/test_multirecorder_global.glm
+++ b/tape/autotest/test_multirecorder_global.glm
@@ -1,0 +1,26 @@
+// Exercise 2.2.2
+
+module tape;
+module residential {
+	implicit_enduses NONE;
+}
+
+clock {
+	timezone PST+8PDT;
+	starttime '2001-01-01 00:00:00 PST';
+	stoptime '2001-02-01 00:00:00 PST';
+}
+
+object house {
+	name house_1;
+	object waterheater {
+		name heater_1;
+		object multi_recorder {
+			property "::clock, temperature[degC], house_1:air_temperature[degC]";
+			file "multirecorder.csv";
+			interval -1;
+			limit 100;
+		};
+	};
+}
+

--- a/tape/autotest/test_recorder_global.glm
+++ b/tape/autotest/test_recorder_global.glm
@@ -1,0 +1,23 @@
+// Exercise 2.2.2
+
+module tape;
+module residential {
+	implicit_enduses NONE;
+}
+
+clock {
+	timezone PST+8PDT;
+	starttime '2001-01-01 00:00:00';
+	stoptime '2002-01-01 00:00:00';
+}
+
+object house {
+	object waterheater {
+		object recorder {
+			property "::clock";
+			file "clock.csv";
+			interval -1;
+			limit 100;
+		};
+	};
+}

--- a/tape/multi_recorder.c
+++ b/tape/multi_recorder.c
@@ -554,112 +554,153 @@ static TIMESTAMP multi_recorder_write(OBJECT *obj)
 
 RECORDER_MAP *link_multi_properties(OBJECT *obj, char *property_list)
 {
-	char *itemptr, *item;
-	char objstr[128];
-	char itemstr[128];
+	char *item, *lastitem;
 	RECORDER_MAP *first=NULL, *last=NULL, *rmap;
-	OBJECT *target_obj = NULL;
-	UNIT *unit = NULL;
 	char1024 list;
 	complex oblig;
-	int partres = 0;
-	char name[128];
-	char256 pstr, ustr;
-	char *cpart = 0;
-	int64 cid = -1;
-	PROPERTY *prop = NULL;
-	PROPERTY *target = NULL;
-	double scale = 1.0;
+	char objname[128];
+	gl_name_object(obj, objname, 128);
 
 	strcpy(list,property_list); /* avoid destroying orginal list */
-	for (itemptr = strtok(list,","); itemptr != NULL; itemptr = strtok(NULL,","))
+	for ( item = strtok_r(list,", \n", &lastitem); item != NULL; item = strtok_r(NULL,", \n",&lastitem))
 	{
-		cpart = 0;
-		cid = -1;
-		prop = NULL;
-		target = NULL;
-		scale = 1.0;
-		ustr[0] = 0;
-		pstr[0] = 0;
-		unit = NULL;
+		char objstr[128] = "";
+		char propstr[128] = "";
+		char *cpart = 0;
+		int partres = 0;
+		int64 cid = -1;
+		PROPERTY *target_prop = NULL;
+		OBJECT *target_obj = NULL;
+		UNIT *unit = NULL;
+		char256 pstr="", ustr="";
+		double scale = 1.0;
 
-		//if(2 == sscanf(itemptr, "%[^:]:%[^\n\r\0]", objstr, itemstr)){
-		if(2 == sscanf(itemptr, " %[^:]:%s", objstr, itemstr)){	//changed this line because of conflicts in rh5
-			item = itemstr;
-			target_obj = gl_get_object(objstr);
-			if(target_obj == 0){
-				gl_error("multirecorder: unable to find object '%s'", objstr);
-				return 0;
-			}
-		} else { // only the one part
-			if(obj == 0){
-				gl_error("multirecorder: no parent object and no specified target object in '%s'", itemstr);
-				return 0;
-			}
-			target_obj = obj;
-			item = objstr;
-		}
-
-		// everything that looks like a property name, then read units up to ]
-		while (isspace(*item)) item++;
-		if(2 == sscanf(item,"%[A-Za-z0-9_.][%[^]\n,\0]", pstr, ustr)){
-			unit = gl_find_unit(ustr);
-			if(unit == NULL){
-				gl_error("multirecorder: unable to find unit '%s' for property '%s' in object '%s %i'", ustr,pstr,target_obj->oclass->name, target_obj->id);
-				return NULL;
-			}
-			item = pstr;
-		}
 		rmap = (RECORDER_MAP *)malloc(sizeof(RECORDER_MAP));
-		memset(rmap, 0, sizeof(RECORDER_MAP));
-		
-		/* branch: test to see if we're trying to split up a complex property */
-		/* must occur w/ *cpart=0 before gl_get_property in order to properly reformat the property name string */
-		cpart = strchr(item, '.');
-		if(cpart != NULL){
-			if(strcmp("imag", cpart+1) == 0){
-				cid = (int)((int64)&(oblig.i) - (int64)&oblig);
-				*cpart = 0;
-			} else if(strcmp("real", cpart+1) == 0){
-				cid = (int)((int64)&(oblig.r) - (int64)&oblig);
-				*cpart = 0;
-			} else {
-				;
-			}
-		}
-
-		target = gl_get_property(target_obj,item,NULL);
-
-		if (rmap != NULL && target != NULL)
+		if ( rmap == NULL )
 		{
-			if(unit != NULL && target->unit == NULL){
-				gl_error("recorder:%d: property '%s' is unitless, ignoring unit conversion", obj->id, item);
-			}
-			else if(unit != NULL && 0 == gl_convert_ex(target->unit, unit, &scale))
-			{
-				gl_error("recorder:%d: unable to convert property '%s' units to '%s'", obj->id, item, ustr);
+			gl_error("%s -- memory allocation failed", objname);
+			return NULL;
+		}	
+		memset(rmap, 0, sizeof(RECORDER_MAP));
+
+		if ( strlen(item)>0 && strstr(item,"::") != NULL )
+		{
+			char *name = strncmp(item,"::",2)==0 ? item+2 : item;
+ 			GLOBALVAR *var = gl_global_find(name);
+ 			if ( var == NULL )
+ 			{
+				gl_error("%s: unable to find global '%s'", objname, objstr);
+				continue;
+ 			}
+ 			target_obj = NULL;
+ 			target_prop = var->prop; 			
+		}
+		else
+		{
+			switch ( sscanf(item, " %127[^:]:%127s", objstr, propstr) ) {
+			case 2:	
+				if ( strcmp(objstr,"") == 0 )
+				{
+					target_obj = obj->parent;
+				}
+				target_obj = gl_get_object(objstr);
+				if ( target_obj == NULL )
+				{
+					gl_error("%s: unable to find object '%s'", objname, strcmp(objstr,"")==0 ? "(parent)" : objstr);
+					continue;
+				}
+				break;
+			case 1: 	// only the one part (implies parent)
+				if ( obj->parent == NULL )
+				{
+					gl_error("%s: object has no parent for property '%s'", objname, objstr);
+					continue;
+				}
+				target_obj = obj->parent;
+				strcpy(propstr,objstr);
+				break;
+			default:
+				gl_error("%s: property '%s' is not valid", objname, item);
 				return NULL;
 			}
-			if(first == NULL){
+			gl_debug("target object = '%s:%d'", target_obj->oclass->name, target_obj->id);
+
+			// everything that looks like a property name, then read units up to ]
+			if ( sscanf(propstr,"%255[A-Za-z0-9_.][%255[^]\n,]]", pstr, ustr) == 2 )
+			{
+				unit = gl_find_unit(ustr);
+				if ( unit == NULL )
+				{
+					gl_error("%s: unable to find unit '%s' for property '%s' in object '%s %i'", objname, ustr,pstr,target_obj->oclass->name, target_obj->id);
+					continue;
+				}
+			}
+			
+			/* branch: test to see if we're trying to split up a complex property */
+			/* must occur w/ *cpart=0 before gl_get_property in order to properly reformat the property name string */
+			cpart = strchr(pstr, '.');
+			if ( cpart != NULL ) 
+			{
+				if ( strcmp("imag", cpart+1) == 0 ) 
+				{
+					cid = (int)((int64)&(oblig.i) - (int64)&oblig);
+					*cpart = 0;
+				} 
+				else if ( strcmp("real", cpart+1) == 0 )
+				{
+					cid = (int)((int64)&(oblig.r) - (int64)&oblig);
+					*cpart = 0;
+				} 
+			}
+
+			target_prop = gl_get_property(target_obj,pstr,NULL);
+		}	
+
+		if ( target_prop != NULL )
+		{
+			if ( unit != NULL && target_prop->unit == NULL )
+			{
+				gl_error("%s: property '%s' is unitless, ignoring unit conversion", objname, item);
+			}
+			else if ( unit != NULL && gl_convert_ex(target_prop->unit, unit, &scale) == 0 )
+			{
+				gl_error("%s: unable to convert property '%s' units to '%s'", objname, item, ustr);
+				continue;
+			}
+			if ( first == NULL )
+			{
 				first = rmap;
-			} else {
+			} 
+			else 
+			{
 				last->next=rmap;
 			}
 			last = rmap;
 			rmap->obj = target_obj;
-			memcpy(&(rmap->prop), target, sizeof(PROPERTY));
+			memcpy(&(rmap->prop), target_prop, sizeof(PROPERTY));
+			rmap->prop.next = NULL; // unlink from main property list
 			rmap->prop.unit = unit;
+			rmap->scale = scale;
 			rmap->next = NULL;
+			if ( cid >= 0 ) 
+			{ 	/* doing the complex part thing */
+				rmap->prop.ptype = PT_double;
+				(rmap->prop.addr) = (PROPERTYADDR)((int64)(rmap->prop.addr) + cid);
+			}
+			gl_debug("%s: linked %s ok", objname, item);
 		}
 		else
 		{
-			gl_name_object(target_obj, name, 128);
-			gl_error("multirecorder: property '%s' not found in object '%s'", item, name);
-			return NULL;
-		}
-		if(cid >= 0){ /* doing the complex part thing */
-			rmap->prop.ptype = PT_double;
-			(rmap->prop.addr) = (PROPERTYADDR)((int64)(rmap->prop.addr) + cid);
+			if ( target_obj )
+			{
+				gl_error("%s: property '%s' not found in object", objname, item);
+				continue;
+			}
+			else
+			{
+				gl_error("%s: global '%s' not found", objname, item);
+				continue;
+			}
 		}
 	}
 	return first;
@@ -676,21 +717,23 @@ int read_multi_properties(struct recorder *my, OBJECT *obj, RECORDER_MAP *rmap, 
 	memset(&fake, 0, sizeof(PROPERTY));
 	fake.ptype = PT_double;
 	fake.unit = 0;
-	for(r = rmap; r != NULL && offset < size - 33; r = r->next){
+	for(r = rmap; r != NULL && offset < size - 33; r = r->next)
+	{
+		void *addr = ( r->obj == NULL || r->prop.oclass == NULL ? r->prop.addr : GETADDR(r->obj,&(r->prop)) );
 		if(offset > 0){
 			strcpy(buffer+offset++,",");
 		}
-//		offset += gl_get_value(r->obj, GETADDR(r->obj, &(r->prop)), buffer + offset, size - offset - 1, &(r->prop)); /* pointer => int64 */
 		if(r->prop.ptype == PT_double){
 			switch(my->line_units){
 				case LU_ALL:
 					// cascade into 'default', as prop->unit should've been set, if there's a unit available.
 				case LU_DEFAULT:
-					offset+=gl_get_value(r->obj,GETADDR(r->obj,&(r->prop)),buffer+offset,size-offset-1,&(r->prop)); /* pointer => int64 */
+					offset+=gl_get_value(r->obj,addr,buffer+offset,size-offset-1,&(r->prop)); /* pointer => int64 */
 					break;
 				case LU_NONE:
 					// copy value into local value, use fake PROP, feed into gl_get_vaule
 					value = *gl_get_double(r->obj, &(r->prop));
+					value *= r->scale;
 					p2 = gl_get_property(r->obj, r->prop.name,NULL);
 					if(p2 == 0){
 						gl_error("unable to locate %s.%s for LU_NONE", r->obj, r->prop.name);
@@ -703,15 +746,14 @@ int read_multi_properties(struct recorder *my, OBJECT *obj, RECORDER_MAP *rmap, 
 							offset+=gl_get_value(r->obj,&value,buffer+offset,size-offset-1,&fake); /* pointer => int64 */;
 						}
 					} else {
-						offset+=gl_get_value(r->obj,GETADDR(r->obj,&(r->prop)),buffer+offset,size-offset-1,&(r->prop)); /* pointer => int64 */;
+						offset+=gl_get_value(r->obj,addr,buffer+offset,size-offset-1,&(r->prop)); /* pointer => int64 */;
 					}
 					break;
 				default:
 					break;
 			}
 		} else {
-		  //offset += gl_get_value(obj,    GETADDR(obj,    p),          buffer+offset, size-offset-1, p); /* pointer => int64 */
-			offset += gl_get_value(r->obj, GETADDR(r->obj, &(r->prop)), buffer+offset, size-offset-1, &(r->prop)); /* pointer => int64 */
+			offset += gl_get_value(r->obj, addr, buffer+offset, size-offset-1, &(r->prop)); /* pointer => int64 */
 		}
 		buffer[offset] = '\0';
 		count++;
@@ -747,7 +789,7 @@ EXPORT TIMESTAMP sync_multi_recorder(OBJECT *obj, TIMESTAMP t0, PASSCONFIG pass)
 
 	/* connect to property */
 	if (my->rmap==NULL){
-		my->rmap = link_multi_properties(obj->parent,my->property); // allowable use of obj->parent
+		my->rmap = link_multi_properties(obj,my->property); // allowable use of obj->parent
 	}
 	/*	invalid target object must be handled individually */
 	/*if (my->target==NULL)

--- a/tape/recorder.c
+++ b/tape/recorder.c
@@ -523,6 +523,11 @@ PROPERTY *link_properties(struct recorder *rec, OBJECT *obj, char *property_list
 			item = pstr;
 		}
 		prop = (PROPERTY*)malloc(sizeof(PROPERTY));
+		if ( prop == NULL )
+		{
+			gl_error("recorder:%d: memory allocation failure", obj->id);
+			return NULL;
+		}
 		
 		/* branch: test to see if we're trying to split up a complex property */
 		/* must occur w/ *cpart=0 before gl_get_property in order to properly reformat the property name string */
@@ -539,32 +544,40 @@ PROPERTY *link_properties(struct recorder *rec, OBJECT *obj, char *property_list
 			}
 		}
 
-		target = gl_get_property(obj,item,NULL);
-
-		if (prop!=NULL && target!=NULL)
+		if ( strstr(item,"::") != NULL )
 		{
-			if(unit != NULL && target->unit == NULL){
-				gl_error("recorder:%d: property '%s' is unitless, ignoring unit conversion", obj->id, item);
-			}
-			else if(unit != NULL && 0 == gl_convert_ex(target->unit, unit, &scale))
-			{
-				gl_error("recorder:%d: unable to convert property '%s' units to '%s'", obj->id, item, ustr);
-				return NULL;
-			}
-			if (first==NULL) first=prop; else last->next=prop;
-			last=prop;
-			memcpy(prop,target,sizeof(PROPERTY));
-			prop->unit = unit;
-			if(unit == NULL && rec->line_units == LU_ALL){
-				prop->unit = target->unit;
-			}
-			prop->next = NULL;
+			char *name = strncmp(item,"::",2)==0 ? item+2 : item;
+			gl_debug("recorder searching for global '%s'",name);
+			GLOBALVAR *var = gl_global_find(name);
+			if ( var ) target = var->prop;
 		}
 		else
 		{
-			gl_error("recorder: property '%s' not found", item);
+			target = gl_get_property(obj,item,NULL);
+		}
+
+		if ( target == NULL )
+		{
+			gl_error("recorder: property or global '%s' not found", item);
 			return NULL;
 		}
+
+		if(unit != NULL && target->unit == NULL){
+			gl_error("recorder:%d: property '%s' is unitless, ignoring unit conversion", obj->id, item);
+		}
+		else if(unit != NULL && 0 == gl_convert_ex(target->unit, unit, &scale))
+		{
+			gl_error("recorder:%d: unable to convert property '%s' units to '%s'", obj->id, item, ustr);
+			return NULL;
+		}
+		if (first==NULL) first=prop; else last->next=prop;
+		last=prop;
+		memcpy(prop,target,sizeof(PROPERTY));
+		prop->unit = unit;
+		if(unit == NULL && rec->line_units == LU_ALL){
+			prop->unit = target->unit;
+		}
+		prop->next = NULL;
 		if(cid >= 0){ /* doing the complex part thing */
 			prop->ptype = PT_double;
 			(prop->addr) = (PROPERTYADDR)((int64)(prop->addr) + cid);
@@ -581,6 +594,7 @@ int read_properties(struct recorder *my, OBJECT *obj, PROPERTY *prop, char *buff
 	int offset=0;
 	int count=0;
 	double value;
+	void *addr = prop->oclass ? GETADDR(obj,p) : prop->addr;
 	memset(&fake, 0, sizeof(PROPERTY));
 	fake.ptype = PT_double;
 	fake.unit = 0;
@@ -592,7 +606,7 @@ int read_properties(struct recorder *my, OBJECT *obj, PROPERTY *prop, char *buff
 				case LU_ALL:
 					// cascade into 'default', as prop->unit should've been set, if there's a unit available.
 				case LU_DEFAULT:
-					offset+=gl_get_value(obj,GETADDR(obj,p),buffer+offset,size-offset-1,p); /* pointer => int64 */
+					offset+=gl_get_value(obj,addr,buffer+offset,size-offset-1,p); /* pointer => int64 */
 					break;
 				case LU_NONE:
 					// copy value into local value, use fake PROP, feed into gl_get_vaule
@@ -609,14 +623,14 @@ int read_properties(struct recorder *my, OBJECT *obj, PROPERTY *prop, char *buff
 							offset+=gl_get_value(obj,&value,buffer+offset,size-offset-1,&fake); /* pointer => int64 */;
 						}
 					} else {
-						offset+=gl_get_value(obj,GETADDR(obj,p),buffer+offset,size-offset-1,p); /* pointer => int64 */;
+						offset+=gl_get_value(obj,addr,buffer+offset,size-offset-1,p); /* pointer => int64 */;
 					}
 					break;
 				default:
 					break;
 			}
 		} else {
-			offset+=gl_get_value(obj,GETADDR(obj,p),buffer+offset,size-offset-1,p); /* pointer => int64 */
+			offset+=gl_get_value(obj,addr,buffer+offset,size-offset-1,p); /* pointer => int64 */
 		}
 		buffer[offset]='\0';
 		count++;

--- a/tape/tape.h
+++ b/tape/tape.h
@@ -56,6 +56,7 @@ typedef struct {
 typedef struct s_recobjmap {
 	OBJECT *obj;
 	PROPERTY prop; // must be an instance
+	double scale;
 	struct s_recobjmap *next;
 } RECORDER_MAP;
 


### PR DESCRIPTION
This PR addresses issue #19.  Globals may now be referred to in recorder properties using the "::<name>" or "<module>::<name>" syntax.  This is only supported for recorders at this time.