### PR TITLE
[CLOSED] Add support for minimal GLM output.

### DIFF
--- a/gldcore/class.h
+++ b/gldcore/class.h
@@ -119,6 +119,7 @@ struct s_class_list {
 	TECHNOLOGYREADINESSLEVEL trl; // technology readiness level (1-9, 0=unknown)
 	bool has_runtime;	///< flag indicating that a runtime dll, so, or dylib is in use
 	char runtime[1024]; ///< name of file containing runtime dll, so, or dylib
+	void *defaults; ///< pointer to template object with default values
 	struct s_class_list *next;
 }; /* CLASS */
 

--- a/gldcore/compare.c
+++ b/gldcore/compare.c
@@ -23,8 +23,10 @@
 #define COMPARE_NEB(T) int compare_tc_##T##_ne(void* x,void* a,void* b) { return *(T*)x!=*(T*)a; }
 
 #define COMPAREOPO(T) COMPARE_EQO(T) COMPARE_NEO(T)
-#define COMPARE_EQO(T) int compare_tc_##T##_eq(void* x,void* a,void* b) { return strcmp((*(OBJECT**)x)->name,(*(OBJECT**)a)->name)==0; }
-#define COMPARE_NEO(T) int compare_tc_##T##_ne(void* x,void* a,void* b) { return strcmp((*(OBJECT**)x)->name,(*(OBJECT**)a)->name)!=0; }
+//#define COMPARE_EQO(T) int compare_tc_##T##_eq(void* x,void* a,void* b) { return strcmp((*(OBJECT**)x)->name,(*(OBJECT**)a)->name)==0; }
+//#define COMPARE_NEO(T) int compare_tc_##T##_ne(void* x,void* a,void* b) { return strcmp((*(OBJECT**)x)->name,(*(OBJECT**)a)->name)!=0; }
+#define COMPARE_EQO(T) int compare_tc_##T##_eq(void* x,void* a,void* b) { return (*(OBJECT**)x)==(*(OBJECT**)a); }
+#define COMPARE_NEO(T) int compare_tc_##T##_ne(void* x,void* a,void* b) { return (*(OBJECT**)x)!=(*(OBJECT**)a); }
 
 #define COMPAREOPF(T) COMPARE_EQF(T) COMPARE_LEF(T) COMPARE_GEF(T) COMPARE_NEF(T) COMPARE_LTF(T) COMPARE_GTF(T) COMPARE_INF(T) COMPARE_NIF(T)
 #define COMPARE_EQF(T) int compare_tc_##T##_eq(void* x,void* a,void* b) { if (b==NULL) return *(T*)x==*(T*)a; else return fabs((*(T*)x)-(*(T*)a))<=(*(T*)b); }

--- a/gldcore/enduse.c
+++ b/gldcore/enduse.c
@@ -409,7 +409,7 @@ int convert_from_enduse(char *string,int size,void *data, PROPERTY *prop)
 	enduse *e = (enduse*)data;
 	int len = 0;
 #define OUTPUT_NZ(X) if (e->X!=0) len+=sprintf(string+len,"%s" #X ": %f", len>0?"; ":"", e->X)
-#define OUTPUT(X) len+=sprintf(string+len,"%s"#X": %f", len>0?"; ":"", e->X);
+#define OUTPUT(X) len+=sprintf(string+len,"%s"#X": %g", len>0?"; ":"", e->X);
 	OUTPUT_NZ(impedance_fraction);
 	OUTPUT_NZ(current_fraction);
 	OUTPUT_NZ(power_fraction);
@@ -613,8 +613,10 @@ int convert_to_enduse(char *string, void *data, PROPERTY *prop)
 
 	/* reinitialize the loadshape */
 	if (enduse_init((enduse*)data))
+	{
+		output_error("convert_to_enduse(string='%-.64s...', ...): enduse_init failed ",string);
 		return 0;
-
+	}	
 	/* everything converted ok */
 	return 1;
 }

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -71,6 +71,7 @@ void global_dump(void);
 size_t global_getcount(void);
 void global_restore(GLOBALVAR *pos);
 void global_push(char *name, char *value);
+size_t global_saveall(FILE *fp);
 
 /* MAJOR and MINOR version */
 GLOBAL unsigned global_version_major INIT(REV_MAJOR); /**< The software's major version */
@@ -395,6 +396,15 @@ typedef enum {
 GLOBAL bool global_validto_context INIT(VTC_SYNC); /**< events for which valid_to applies, rather than just sync passes */
 
 GLOBAL char1024 global_timezone_locale INIT("UTC"); /**< timezone specification */
+typedef enum {
+	GSO_LEGACY 		= 0x0000,
+	GSO_NOINTERNALS = 0x0001,
+	GSO_NOMACROS 	= 0x0002,
+	GSO_NOGLOBALS	= 0x0004,
+	GSO_NODEFAULTS	= 0x0008,
+	GSO_MINIMAL 	= 0x000f,
+} GLMSAVEOPTIONS;
+GLOBAL GLMSAVEOPTIONS global_glm_save_options INIT(GSO_LEGACY);	/**< multirun mode connection */
 
 #ifdef __cplusplus
 }

--- a/gldcore/module.c
+++ b/gldcore/module.c
@@ -757,27 +757,34 @@ int module_saveall(FILE *fp)
 	MODULE *mod;
 	int count=0;
 	CLASS *oclass = NULL;
-	char varname[1024];
 	char buffer[1024];
 	count += fprintf(fp,"\n////////////////////////////////////////////////////////\n");
 	count += fprintf(fp,"// modules\n");
 	for (mod=first_module; mod!=NULL; mod=mod->next)
 	{
-		varname[0] = '\0';
+		GLOBALVAR *var=NULL;
 		oclass = NULL;
 
 		count += fprintf(fp,"module %s {\n",mod->name);
-		if (mod->major>0 || mod->minor>0)
-			count += fprintf(fp,"\tmajor %d;\n\tminor %d;\n",mod->major,mod->minor);
-		for (oclass=mod->oclass; oclass!=NULL ; oclass=oclass->next)
+		if ( (global_glm_save_options&GSO_NOINTERNALS)==0 )
 		{
-			if (oclass->module==mod)
-				count += fprintf(fp,"\tclass %s;\n",oclass->name);
-		}
-
-		while (module_getvar(mod,varname,buffer,sizeof(buffer)))
+			if (mod->major>0 || mod->minor>0)
+				count += fprintf(fp,"\tmajor %d;\n\tminor %d;\n",mod->major,mod->minor);
+			for (oclass=mod->oclass; oclass!=NULL ; oclass=oclass->next)
+			{
+				if (oclass->module==mod)
+					count += fprintf(fp,"\tclass %s;\n",oclass->name);
+			}
+		}		
+		while ( (var=global_getnext(var)) != NULL )
 		{
-			count += fprintf(fp,"\t%s %s;\n",varname,buffer);
+			char modname[256]="", varname[256]="";
+			if ( sscanf(var->prop->name,"%[^:]::%[^\n]",modname,varname) == 2
+				&& strcmp(modname,mod->name) == 0 
+				&& global_getvar(var->prop->name,buffer,sizeof(buffer)-1) != NULL )
+			{
+				count += fprintf(fp,"\t%s %s;\n",varname,buffer);
+			}
 		}
 		count += fprintf(fp,"}\n");
 	}

--- a/gldcore/module.c
+++ b/gldcore/module.c
@@ -783,7 +783,10 @@ int module_saveall(FILE *fp)
 				&& strcmp(modname,mod->name) == 0 
 				&& global_getvar(var->prop->name,buffer,sizeof(buffer)-1) != NULL )
 			{
-				count += fprintf(fp,"\t%s %s;\n",varname,buffer);
+				if ( buffer[0] == '"' )
+					count += fprintf(fp,"\t%s %s;\n",varname,buffer);
+				else
+					count += fprintf(fp,"\t%s \"%s\";\n",varname,buffer);
 			}
 		}
 		count += fprintf(fp,"}\n");

--- a/gldcore/object.c
+++ b/gldcore/object.c
@@ -327,7 +327,8 @@ OBJECT *object_create_single(CLASS *oclass){ /**< the class of the object */
 		 */
 	}
 
-	memset(obj, 0, sz + oclass->size);
+	memset(obj, 0, sz);
+	memcpy(obj+1, oclass->defaults, oclass->size);
 
 	tp_next %= tp_count;
 
@@ -1958,34 +1959,45 @@ int object_saveall(FILE *fp) /**< the stream to write to */
 			if ( obj->parent != NULL )
 			{
 				if ( obj->parent->name != NULL )
-					count += fprintf(fp, "\tparent %s;\n", obj->parent->name);
+					count += fprintf(fp, "\tparent \"%s\";\n", obj->parent->name);
 				else
-					count += fprintf(fp, "\tparent %s:%d;\n", obj->parent->oclass->name, obj->parent->id);
+					count += fprintf(fp, "\tparent \"%s:%d\";\n", obj->parent->oclass->name, obj->parent->id);
 			}
-			else
+			else if ( (global_glm_save_options&GSO_NOMACROS)==0 )
 			{
 				count += fprintf(fp,"#ifdef INCLUDE_ROOT\n\troot;\n#endif\n");
 			}
-			count += fprintf(fp, "\trank %d;\n", obj->rank);
+			if ( (global_glm_save_options&GSO_NOINTERNALS)==0 )
+			{
+				count += fprintf(fp, "\trank \"%d\";\n", obj->rank);
+			}
 			if ( obj->name != NULL )
-				count += fprintf(fp, "\tname %s;\n", obj->name);
-			if ( convert_from_timestamp(obj->clock, buffer, sizeof(buffer)) )
-				count += fprintf(fp,"\tclock %s;\n",  buffer);
+				count += fprintf(fp, "\tname \"%s\";\n", obj->name);
+			if ( (global_glm_save_options&GSO_NOINTERNALS)==0 && convert_from_timestamp(obj->clock, buffer, sizeof(buffer)) )
+				count += fprintf(fp,"\tclock '%s';\n",  buffer);
 			if ( !isnan(obj->latitude) )
-				count += fprintf(fp, "\tlatitude %s;\n", convert_from_latitude(obj->latitude, buffer, sizeof(buffer)) ? buffer : "(invalid)");
+				count += fprintf(fp, "\tlatitude \"%s\";\n", convert_from_latitude(obj->latitude, buffer, sizeof(buffer)) ? buffer : "(invalid)");
 			if ( !isnan(obj->longitude) )
-				count += fprintf(fp, "\tlongitude %s;\n", convert_from_longitude(obj->longitude, buffer, sizeof(buffer)) ? buffer : "(invalid)");
-			if ( convert_from_set(buffer, sizeof(buffer), &(obj->flags), object_flag_property()) > 0 )
-				count += fprintf(fp, "\tflags %s;\n",  buffer);
-			else
-				count += fprintf(fp, "\tflags %lld;\n", obj->flags);
+				count += fprintf(fp, "\tlongitude \"%s\";\n", convert_from_longitude(obj->longitude, buffer, sizeof(buffer)) ? buffer : "(invalid)");
+			if ( (global_glm_save_options&GSO_NOINTERNALS)==0 )
+			{
+				if ( convert_from_set(buffer, sizeof(buffer), &(obj->flags), object_flag_property()) > 0 )
+					count += fprintf(fp, "\tflags \"%s\";\n",  buffer);
+				else
+					count += fprintf(fp, "\tflags \"%lld\";\n", obj->flags);
+			}
 
 			/* dump properties */
 			for ( prop=obj->oclass->pmap; prop!=NULL; prop=(prop->next?prop->next:(prop->oclass->parent?prop->oclass->parent->pmap:NULL)) )
 			{
+				if ( (global_glm_save_options&GSO_NODEFAULTS)==GSO_NODEFAULTS && property_is_default(obj,prop) )
+					continue;
+				if ( (global_glm_save_options&GSO_NOINTERNALS)==GSO_NOINTERNALS && prop->access!=PA_PUBLIC )
+					continue;
+				buffer[0]='\0';
 				if ( object_property_to_string(obj, prop->name, buffer, sizeof(buffer)) != NULL )
 				{
-					if ( prop->access != access )
+					if ( prop->access != access && (global_glm_save_options&GSO_NOMACROS)==0 )
 					{
 						if ( access != PA_PUBLIC )
 							count += fprintf(fp, "#endif\n");
@@ -1999,10 +2011,12 @@ int object_saveall(FILE *fp) /**< the stream to write to */
 							count += fprintf(fp, "#ifdef INCLUDE_HIDDEN\n");
 						access = prop->access;
 					}
-					count += fprintf(fp, "\t%s %s;\n", prop->name, buffer);
+					if ( prop->ptype==PT_object && strcmp(buffer,"")==0 )
+						continue; // never output empty object names -- they have special meaning to the loader
+					count += fprintf(fp, "\t%s \"%s\";\n", prop->name, buffer);
 				}
 			}
-			if ( access != PA_PUBLIC )
+			if ( access != PA_PUBLIC && (global_glm_save_options&GSO_NOMACROS)==0 )
 				count += fprintf(fp, "#endif\n");
 			count += fprintf(fp,"}\n");
 		}

--- a/gldcore/object.c
+++ b/gldcore/object.c
@@ -2013,7 +2013,10 @@ int object_saveall(FILE *fp) /**< the stream to write to */
 					}
 					if ( prop->ptype==PT_object && strcmp(buffer,"")==0 )
 						continue; // never output empty object names -- they have special meaning to the loader
-					count += fprintf(fp, "\t%s \"%s\";\n", prop->name, buffer);
+					if ( buffer[0]=='"' )
+						count += fprintf(fp, "\t%s %s;\n", prop->name, buffer);
+					else
+						count += fprintf(fp, "\t%s \"%s\";\n", prop->name, buffer);
 				}
 			}
 			if ( access != PA_PUBLIC && (global_glm_save_options&GSO_NOMACROS)==0 )

--- a/gldcore/property.c
+++ b/gldcore/property.c
@@ -276,11 +276,22 @@ double property_get_part(OBJECT *obj, PROPERTY *prop, char *part)
 
 bool property_is_default(OBJECT *obj, PROPERTY *prop)
 {
-	if ( obj->oclass->defaults != NULL )
+	if ( prop->ptype > PT_void && prop->ptype < PT_object && obj->oclass->defaults != NULL )
 	{
 		void *a = (char*)obj + (int)prop->addr;
 		void *b = (char*)(obj->oclass->defaults) + (int)prop->addr;
-		return property_compare_basic(prop->ptype,TCOP_EQ,a,b,NULL,NULL);
+		bool result = property_compare_basic(prop->ptype,TCOP_EQ,a,b,NULL,NULL);
+		if ( !result && global_debug_output )
+		{
+			char buf1[1024] = "<???>", buf2[1024] = "<???>";
+			class_property_to_string(prop,a,buf1,sizeof(buf1));
+			class_property_to_string(prop,b,buf2,sizeof(buf2));
+			output_debug("comparing %s:%d.%s [%s] == %s:default.%s [%s] --> %s",
+				obj->name?obj->name:obj->oclass->name, obj->id, prop->name, buf1,
+				obj->oclass->name, prop->name, buf2,
+				result ? "true" : "false");
+		}	
+		return result;
 	}
 	else
 		return false;

--- a/gldcore/property.c
+++ b/gldcore/property.c
@@ -233,7 +233,7 @@ bool property_compare_basic(PROPERTYTYPE ptype, PROPERTYCOMPAREOP op, void *x, v
 {
 	if ( part==NULL && property_type[ptype].compare[op].fn!=NULL )
 		return property_type[ptype].compare[op].fn(x,a,b);
-	else if ( property_type[ptype].get_part!=NULL )
+	else if ( property_type[ptype].get_part!=NULL && part != NULL )
 	{
 		double d = property_type[ptype].get_part ? property_type[ptype].get_part(x,part) : QNAN ;
 		if ( isfinite(d) )
@@ -247,7 +247,7 @@ bool property_compare_basic(PROPERTYTYPE ptype, PROPERTYCOMPAREOP op, void *x, v
 	}
 	else // no comparison possible
 	{
-		output_error("property type '%s' does not support comparison operations or parts", property_type[ptype].name);
+		output_debug("property type '%s' does not support comparison operations or parts", property_type[ptype].name);
 		return 0;
 	}
 }
@@ -272,6 +272,18 @@ double property_get_part(OBJECT *obj, PROPERTY *prop, char *part)
 	}
 	else
 		return QNAN;
+}
+
+bool property_is_default(OBJECT *obj, PROPERTY *prop)
+{
+	if ( obj->oclass->defaults != NULL )
+	{
+		void *a = (char*)obj + (int)prop->addr;
+		void *b = (char*)(obj->oclass->defaults) + (int)prop->addr;
+		return property_compare_basic(prop->ptype,TCOP_EQ,a,b,NULL,NULL);
+	}
+	else
+		return false;
 }
 
 /*********************************************************

--- a/gldcore/property.h
+++ b/gldcore/property.h
@@ -972,6 +972,7 @@ bool property_compare_basic(PROPERTYTYPE ptype, PROPERTYCOMPAREOP op, void *x, v
 PROPERTYCOMPAREOP property_compare_op(PROPERTYTYPE ptype, char *opstr);
 PROPERTYTYPE property_get_type(char *name);
 double property_get_part(struct s_object_list *obj, PROPERTY *prop, char *part);
+bool property_is_default(struct s_object_list *obj, PROPERTY *prop);
 
 /* double array */
 int double_array_create(double_array*a);

--- a/gldcore/save.c
+++ b/gldcore/save.c
@@ -127,16 +127,23 @@ int saveglm(char *filename,FILE *fp)
 	count += fprintf(fp,"// modules.... %d\n", module_getcount());
 	count += fprintf(fp,"// classes.... %d\n", class_get_count());
 	count += fprintf(fp,"// objects.... %d\n", object_get_count());
+	if ( global_getvar("glm_save_options",buffer,sizeof(buffer)-1) )
+	{
+		count += fprintf(fp,"// options.... %s\n", buffer);
+	}
 
 	// loader flags
-	count += fprintf(fp,"\n// flags to enable GLM definitions not supported by standard GLM loader");
-	count += fprintf(fp,"//#define INCLUDE_PARENT_CLASS=TRUE // class inheritance definitions\n");
-	count += fprintf(fp,"//#define INCLUDE_FUNCTIONS=TRUE // class function definitions\n");
-	count += fprintf(fp,"//#define INCLUDE_ROOT=TRUE // object root definitions\n");
-	count += fprintf(fp,"//#define INCLUDE_REFERENCE=TRUE // reference property definitions\n");
-	count += fprintf(fp,"//#define INCLUDE_PROTECTED=TRUE // protected property definitions\n");
-	count += fprintf(fp,"//#define INCLUDE_PRIVATE=TRUE // private property definitions\n");
-	count += fprintf(fp,"//#define INCLUDE_HIDDEN=TRUE // hidden property definitions\n");
+	if ( (global_glm_save_options&GSO_NOMACROS)==0 )
+	{
+		count += fprintf(fp,"\n// flags to enable GLM definitions not supported by standard GLM loader");
+		count += fprintf(fp,"//#define INCLUDE_PARENT_CLASS=TRUE // class inheritance definitions\n");
+		count += fprintf(fp,"//#define INCLUDE_FUNCTIONS=TRUE // class function definitions\n");
+		count += fprintf(fp,"//#define INCLUDE_ROOT=TRUE // object root definitions\n");
+		count += fprintf(fp,"//#define INCLUDE_REFERENCE=TRUE // reference property definitions\n");
+		count += fprintf(fp,"//#define INCLUDE_PROTECTED=TRUE // protected property definitions\n");
+		count += fprintf(fp,"//#define INCLUDE_PRIVATE=TRUE // private property definitions\n");
+		count += fprintf(fp,"//#define INCLUDE_HIDDEN=TRUE // hidden property definitions\n");
+	}
 
 	/* save gui, if any */
 	if (gui_get_root()!=NULL)
@@ -162,9 +169,16 @@ int saveglm(char *filename,FILE *fp)
 	count += fprintf(fp,"}\n");
 
 	/* save parts */
+	if ( (global_glm_save_options&GSO_NOGLOBALS)==0 )
+	{
+		count += global_saveall(fp);
+	}
 	count += module_saveall(fp);
-	count += class_saveall(fp);
-	count += schedule_saveall(fp);
+	if ( (global_glm_save_options&GSO_NOINTERNALS)==0 )
+	{
+		count += class_saveall(fp);
+		count += schedule_saveall(fp);
+	}
 	count += transform_saveall(fp);
 	count += object_saveall(fp);
 

--- a/gldcore/save.c
+++ b/gldcore/save.c
@@ -159,11 +159,11 @@ int saveglm(char *filename,FILE *fp)
 		count += fprintf(fp,"\n// CLOCK\n");
 	count += fprintf(fp,"clock {\n");
 //	count += fprintf(fp,"\ttick 1e%+d;\n",TS_SCALE);
-	count += fprintf(fp,"\ttimezone %s;\n", timestamp_current_timezone());
+	count += fprintf(fp,"\ttimezone \"%s\";\n", timestamp_current_timezone());
 	if ( convert_from_timestamp(global_starttime,buffer,sizeof(buffer))>0 )
-		count += fprintf(fp,"\tstarttime '%s';\n", buffer);
+		count += fprintf(fp,"\tstarttime \"%s\";\n", buffer);
 	if ( convert_from_timestamp(global_stoptime,buffer,sizeof(buffer))>0 )
-		count += fprintf(fp,"\tstoptime '%s';\n", buffer);
+		count += fprintf(fp,"\tstoptime \"%s\";\n", buffer);
 //	if (getenv("TZ"))
 //		count += fprintf(fp,"\ttimezone %s;\n", getenv("TZ"));
 	count += fprintf(fp,"}\n");

--- a/gldcore/schedule.c
+++ b/gldcore/schedule.c
@@ -1425,6 +1425,28 @@ int schedule_saveall(FILE *fp)
 	int count = fprintf(fp,"%s\n","// schedules");
 	SCHEDULE *sch;
 	for (sch=schedule_list; sch!=NULL; sch=sch->next)
-		count += fprintf(fp,"schedule %s {\n%s\n}\n", sch->name, sch->definition);
+	{
+		char *c;
+		count += fprintf(fp,"schedule %s {\n\t",sch->name);
+		for ( c = sch->definition ; *c != '\0' ; c++ )
+		{
+			switch (*c) {
+			case ';':
+			case '{':
+			case '}':
+				count += fprintf(fp,"%c\n\t",*c);
+				while ( *c != '\0' && isspace(c[1]) )
+				{
+					c++;
+				}
+				break;
+			default:
+				count++;
+				fputc(*c,fp);
+				break;
+			}
+		}
+		count += fprintf(fp,"%s","\n}\n");
+	}
 	return count;
 }


### PR DESCRIPTION
This PR addresses issue #74.

Current status:

1. The output of values that are default is not always suppressed. This is most often due to values for which the defaults are not set in the class template.
1. None of the transforms are output (so filters won't come through).
1. Schedules are suppressed even when they are defined by the user because there's no way to tell the difference between an internal schedule and a user schedule.
1. A round robin of `models/ieee123` does not give the same result.
1. A sample of the output for `model/ieee123` is attached for reviewer consideration. See [output.glm.zip](https://github.com/dchassin/gridlabd/files/2678049/output.glm.zip)

