### PR TITLE
[CLOSED] Ability to export a complex multi-GLM model into a single GLM model

### DIFF
--- a/gldcore/object.c
+++ b/gldcore/object.c
@@ -1952,8 +1952,10 @@ int object_saveall(FILE *fp) /**< the stream to write to */
 			PROPERTYACCESS access=PA_PUBLIC;
 			PROPERTY *prop = NULL;
 			char32 oname = "(unidentified)";
-			if ( obj->oclass->name )
+			if ( obj->oclass->name && (global_glm_save_options&GSO_NOINTERNALS)==0 )
 				count += fprintf(fp, "object %s:%d {\n", obj->oclass->name, obj->id);
+			else
+				count += fprintf(fp, "object %s {\n", obj->oclass->name);
 
 			/* dump internal properties */
 			if ( obj->parent != NULL )
@@ -1973,6 +1975,8 @@ int object_saveall(FILE *fp) /**< the stream to write to */
 			}
 			if ( obj->name != NULL )
 				count += fprintf(fp, "\tname \"%s\";\n", obj->name);
+			else if ( (global_glm_save_options&GSO_NOINTERNALS)==GSO_NOINTERNALS )
+				count += fprintf(fp, "\tname \"%s:%d\";\n", obj->oclass->name, obj->id);
 			if ( (global_glm_save_options&GSO_NOINTERNALS)==0 && convert_from_timestamp(obj->clock, buffer, sizeof(buffer)) )
 				count += fprintf(fp,"\tclock '%s';\n",  buffer);
 			if ( !isnan(obj->latitude) )


### PR DESCRIPTION
This PR addresses Issue #74. It is a continuation of PR #81.

Current status:

1. The output of values that are default is not always suppressed. This is most often due to values for which the defaults are not set in the class template.
1. None of the transforms are output (so filters won't come through).
1. Schedules are suppressed even when they are defined by the user because there's no way to tell the difference between an internal schedule and a user schedule.
1. A round robin of models/ieee123 does not give the same result.

Documentation:
- [glm_save_options](https://github.com/dchassin/gridlabd/wiki/glm_save_options)