### PR TITLE
[MERGE] Added check of install target after make install finishes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -305,3 +305,8 @@ rpm-prep:
 libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool
 
+install-exec-hook:
+	@if [ "`which gridlabd`" != "$(DESTDIR)$(bindir)/gridlabd" ]; then \
+		echo >&2 "WARNING: install target $(DESTDIR)$(bindir)/gridlabd is not in the current path (`which gridlabd` is found instead)"; \
+	fi
+


### PR DESCRIPTION
This PR addresses issue #111.  

## Current issues
None

## Code changes
1. Added `install-exec-hook` target to `Makefile.am`.

## Documentation changes
None

## Test and Validation Notes
1. First try `make install` with install target not in the path.  You should get a warning message when the install is done.
2. Then try `make install` with install target in the path. You should not get a warning message when the install is done.
