### PR TITLE
[MERGE] Changed build number so it is more obvious what date it corresponds to

### DIFF
--- a/utilities/build_number
+++ b/utilities/build_number
@@ -18,8 +18,7 @@ declare -i num
 dir=`git remote -v | grep "(fetch)" | sed -n 's/^.*\t//; $s/ .*$//p'`
 new=`git log -n 1 | sed -n '1s/^commit //p' | cut -c1-8`
 mod=`git status -s | cut -c1-3 | sort -u | sed 's/ //g'`
-num=`git log --max-count=1 --pretty=format:"%ad" --date=raw | sed -ne 's/ [\+\-][0-9]\{4\}$//p'`
-rev=$((${num}/86400))
+rev=`git log --max-count=1 --pretty=format:"%ad" --date=format:'%y%m%d'`
 branchname=`git rev-parse --abbrev-ref HEAD`
 if [ -z "${mod}" ]; then
 	branch="${dir}:${new}"

--- a/utilities/build_number
+++ b/utilities/build_number
@@ -18,7 +18,7 @@ declare -i num
 dir=`git remote -v | grep "(fetch)" | sed -n 's/^.*\t//; $s/ .*$//p'`
 new=`git log -n 1 | sed -n '1s/^commit //p' | cut -c1-8`
 mod=`git status -s | cut -c1-3 | sort -u | sed 's/ //g'`
-rev=`git log --max-count=1 --pretty=format:"%ad" --date=format:'%y%m%d'`
+rev=`git log --max-count=1 --pretty=format:"%ai" | cut -c3,4,6,7,9,10`
 branchname=`git rev-parse --abbrev-ref HEAD`
 if [ -z "${mod}" ]; then
 	branch="${dir}:${new}"


### PR DESCRIPTION
This PR addresses issue #116.

## Current issues
None

## Code changes
Altered the method of calculating the build number.

## Documentation changes
None

## Test and Validation Notes
The command 
~~~
gridlabd --version
~~~
should report a build number in the form YYMMDD.