### PR TITLE
[MERGE] Added support for calling valgrind from the command line

### DIFF
--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -317,11 +317,20 @@ fi
 if test "x$1" = "x--gdb" ; then :
   shift
   gdb -ex "run $@" $bindir/gridlabd.bin
+  exit 0
 elif test "x$1" = "x--lldb" ; then :
   shift
   echo "run $@" > /tmp/gridlabd-$$
   lldb -s /tmp/gridlabd-$$ $bindir/gridlabd.bin
   rm /tmp/gridlabd-$$
+  exit 0
+elif test "x$1" = "x--valgrind" ; then :
+  shift
+  if test -z "${VALGRIND_OPTIONS}" ; then :
+    echo "warning: VALGRIND_OPTIONS is not set, using default valgrind options"
+  fi
+  valgrind ${VALGRIND_OPTIONS} $bindir/gridlabd.bin $@
+  exit 0
 fi
 
 if test "x$GLPATH" = x; then :

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -62,11 +62,20 @@ fi
 if test "x$1" = "x--gdb" ; then :
   shift
   gdb -ex "run $@" $bindir/gridlabd.bin
+  exit 0
 elif test "x$1" = "x--lldb" ; then :
   shift
   echo "run $@" > /tmp/gridlabd-$$
   lldb -s /tmp/gridlabd-$$ $bindir/gridlabd.bin
   rm /tmp/gridlabd-$$
+  exit 0
+elif test "x$1" = "x--valgrind" ; then :
+  shift
+  if test -z "${VALGRIND_OPTIONS}" ; then :
+    echo "warning: VALGRIND_OPTIONS is not set, using default valgrind options"
+  fi
+  valgrind ${VALGRIND_OPTIONS} $bindir/gridlabd.bin $@
+  exit 0
 fi
 
 AS_IF([test "x$GLPATH" = x],


### PR DESCRIPTION
This PR addresses issue #87

## Current issues
None

## Code changes
1. Changed gldcore/gridlabd.{m4sh,in} to handle `--valgrind` command line option.

## Documentation changes
- https://github.com/dchassin/gridlabd/wiki/valgrind

## Test and Validation Notes
1. Just try a gridlabd simulation with valgrind enabled.
