### PR TITLE
[MERGE] Increased size of object guid to 128 bits

### DIFF
--- a/gldcore/json.c
+++ b/gldcore/json.c
@@ -278,7 +278,7 @@ static int json_objects(FILE *fp)
 		if ( obj->out_svc > TS_ZERO && obj->out_svc < TS_NEVER ) TUPLE("out","%llu",(int64)(obj->out_svc));
 		TUPLE("rng_state","%llu",(int64)(obj->rng_state));
 		TUPLE("heartbeat","%llu",(int64)(obj->heartbeat));
-		TUPLE("guid","0x%llx",(int64)(obj->guid[0]));
+		(len += json_write(",\n\t\t\t\"%s\" : \"0x%llx%llx\"","guid",(int64)(obj->guid[0]),(int64)(obj->guid[1])));
 		TUPLE("flags","0x%llx",(int64)(obj->flags));
 		for ( pclass = obj->oclass ; pclass != NULL ; pclass = pclass->parent )
 		{

--- a/gldcore/object.h
+++ b/gldcore/object.h
@@ -104,7 +104,7 @@ typedef struct s_object_list {
 	unsigned int lock; /**< object lock */
 	unsigned int rng_state; /**< random number generator state */
 	TIMESTAMP heartbeat; /**< heartbeat call interval (in sim-seconds) */
-	uint64 guid[1]; /**< globally unique identifier */
+	uint64 guid[2]; /**< globally unique identifier */
 	EVENTHANDLERS events;
 	/* IMPORTANT: flags must be last */
 	uint64 flags; /**< object flags */

--- a/gldcore/rt/gridlabd.h
+++ b/gldcore/rt/gridlabd.h
@@ -738,7 +738,7 @@ typedef struct s_eventhandlers {
 	unsigned int lock; /**< object lock */
 	unsigned int rng_state; /**< random number generator state */
 	TIMESTAMP heartbeat; /**< heartbeat call interval (in sim-seconds) */
-	unsigned int64 guid; /**< globally unique identifier */
+	unsigned int64 guid[2]; /**< globally unique identifier */
 	EVENTHANDLERS events;
 	/* IMPORTANT: flags must be last */
 	unsigned int64 flags; /**< object flags */


### PR DESCRIPTION
This PR addresses issue #104.

## Current issues
None

## Code changes
1. increased size of guid member of object header to 2 in both core and rt library
2. adjusted JSON output code

## Documentation changes
None

## Test and Validation Notes
1. Looks at the size of guid in JSON output, e.g., `gldcore/autotest/test_json/output.json`