### PR TITLE
Removed verbose output for introducing extra randomness.

### DIFF
--- a/gldcore/random.c
+++ b/gldcore/random.c
@@ -245,7 +245,6 @@ TryAgain:
 	if ( u<=0 || u>=1 ){
 		if( state!=0 && *state == 0){
 			*state = randwarn(0);
-		//	output_verbose("randunit() introducing extra randomness to prevent state stagnation and infinite loops");
 		}
 		goto TryAgain;
 	}

--- a/gldcore/random.c
+++ b/gldcore/random.c
@@ -245,7 +245,7 @@ TryAgain:
 	if ( u<=0 || u>=1 ){
 		if( state!=0 && *state == 0){
 			*state = randwarn(0);
-			output_verbose("randunit() introducing extra randomness to prevent state stagnation and infinite loops");
+		//	output_verbose("randunit() introducing extra randomness to prevent state stagnation and infinite loops");
 		}
 		goto TryAgain;
 	}


### PR DESCRIPTION
This PR addresses issue(s) #110 

## Current issues
None

## Code changes
1. Removed verbose warning in random.c "randunit() introducing extra randomness to prevent state stagnation and infinite loops"


## Test and Validation Notes
Enable verbose when using randunit()