### PR TITLE
[MERGE] Fix install hook error

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -307,7 +307,8 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool
 
 install-exec-hook:
+	@( export SRCDIR=$(top_srcdir); python3 $(top_srcdir)/gldcore/link/python/setup.py install)
 	@if [ "`which gridlabd`" != "$(DESTDIR)$(bindir)/gridlabd" ]; then \
-		echo >&2 "WARNING: install target $(DESTDIR)$(bindir)/gridlabd is not in the current path (`which gridlabd` is found instead)"; \
+		echo >&2 "***WARNING***: install target $(DESTDIR)$(bindir)/gridlabd is not in the current path (`which gridlabd` is found instead)"; \
 	fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -600,6 +600,9 @@ AC_SUBST([MYSQL_CPPFLAGS])
 AC_SUBST([MYSQL_LDFLAGS])
 AC_SUBST([MYSQL_LIBS])
 
+# Verify python version
+AM_PATH_PYTHON(3.6)
+
 ###############################################################################
 # The End
 ###############################################################################

--- a/gldcore/link/python/Makefile.mk
+++ b/gldcore/link/python/Makefile.mk
@@ -1,2 +1,0 @@
-install-exec-hook:
-	( export SRCDIR=$(top_srcdir); python3 $(top_srcdir)/gldcore/link/python/setup.py install)

--- a/gldcore/link/python/setup.py
+++ b/gldcore/link/python/setup.py
@@ -26,6 +26,8 @@ except:
 		compile_options = None
 	if not compile_options :
 		compile_options=['-w','-O3']
+if not srcdir :
+	raise Exception("SRCDIR environment variable was not set -- try the command 'export SRCDIR=$PWD' before running setup.py")
 compile_options.extend(['-I'+srcdir+'/gldcore',"-DHAVE_CONFIG_H","-DHAVE_PYTHON"])
 
 from distutils.core import setup, Extension

--- a/utilities/docker/centos/system.sh
+++ b/utilities/docker/centos/system.sh
@@ -12,6 +12,7 @@ yum groupinstall "Development Tools" -y
 yum install cmake -y 
 yum install ncurses-devel -y
 yum install epel-release -y
+yum install which -y
 yum --disablerepo="*" --enablerepo="epel" install python36 -y
-ln -s /usr/bin/python3.6 /usr/bin/python3
 yum install python36-devel -y
+ln -s /usr/bin/python3.6 /usr/bin/python3


### PR DESCRIPTION
This PR addresses issue(s) #156.

## Current issues
None

## Code changes
1. Changed how python makefile works so only one `install-exec-hook` is used. Not ideal, but it works ok.

## Documentation changes
None

## Test and Validation Notes
Running `make install` should result in python module for gridlabd build.

