### PR TITLE
[MERGE] Power and volt dump post-processing tools.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ third_party/xerces*/*
 .*.swp
 .DS_Store
 *.json
+output/

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ third_party/xerces*/*
 .DS_Store
 *.json
 output/
+models/ieee123/config/local.glm

--- a/gldcore/property.c
+++ b/gldcore/property.c
@@ -235,11 +235,11 @@ int property_write(PROPERTY *prop, void *addr, char *string, size_t size)
 	{
 		OBJECT *obj = (OBJECT*)addr;
 		/* TODO: implement iterator */
-		output_error("gldcore/property.c:property_write(prop='%s', addr=<%s:%d>(name='%s'), string=%p, size=%u): no iterator available",
+		output_warning("gldcore/property.c:property_write(prop='%s', addr=<%s:%d>(name='%s'), string=%p, size=%u): no iterator available",
 			prop->name, obj->oclass->name, obj->id, obj->name?obj->name:"(none)", string, size);
 		/*	TROUBLESHOOT
 			Method properties require iterators to extract data. The request to extract data cannot
-			be fulfilled because using this function call. This is most likely an internal error due
+			be fulfilled using this function call. This is most likely an internal error due
 			to improper or legacy implementation.
 		 */
 		return 0;

--- a/models/ieee123/config/default.glm
+++ b/models/ieee123/config/default.glm
@@ -1,0 +1,28 @@
+// this file is used if local.glm is not found
+#define DOCROOT=${DOCROOT:-/ieee123}
+#define NAME=${NAME:-ieee123.glm}
+#define PORT=${PORT:-3306}
+#define TIMEZONE=${TIMEZONE:-US/CA/Los Angeles}
+#define LOADS=${LOADS:-off}
+#define SOLAR=${SOLAR:-off}
+#define DR_HVAC=${DR_HVAC:-off}
+#define DR_WATERHEATER=${DR_WATERHEATER:-off}
+#define DR_DISHWASHER=${DR_DISHWASHER:-off}
+#define DR_WASHER=${DR_WASHER:-off}
+#define DR_DRYER=${DR_DRYER:-off}
+
+#define WEATHER=${WEATHER:-CA-Bakersfield_Meadows_Field_high_wind.tmy3}
+
+#define MYSQL_ENABLE=${MYSQL_ENABLE:-off}
+#define HOSTNAME=${HOSTNAME:-localhost}
+#define MYSQLHOST=${MYSQLHOST:-localhost}
+#define MYSQL_NAME=${MYSQL_NAME:-ieee123}
+#define MYSQL_SCADA=${MYSQL_SCADA:-off}
+#define MYSQL_AMI=${MYSQL_AMI:-off}
+#define MYSQL_MODEL=${MYSQL_MODEL:-off}
+#define MYSQL_GRAPH=${MYSQL_GRAPH:-off}
+
+#define POLE_TYPE=${POLE_TYPE:-node}
+#define VOLTDUMP=${VOLTDUMP:-off}
+#define CURRDUMP=${CURRDUMP:-off}
+

--- a/models/ieee123/config/local.glm
+++ b/models/ieee123/config/local.glm
@@ -10,6 +10,9 @@
 #define DR_DISHWASHER=none
 #define DR_WASHER=none
 #define DR_DRYER=none
+#define VOLT_POWERDUMP
+
+#define POLE_TYPE=node
 
 #ifndef POLE_TYPE
 #define POLE_TYPE=node
@@ -35,5 +38,5 @@
 #endif //MYSQL_ENABLE
 
 
-#define STARTTIME=2003-02-01 00:00:00 PST
-#define STOPTIME=2003-02-01 00:05:00 PST
+#define STARTTIME=2018-03-01 00:00:00 PST
+#define STOPTIME=2018-03-03 00:00:00 PST

--- a/models/ieee123/config/local.glm
+++ b/models/ieee123/config/local.glm
@@ -10,7 +10,7 @@
 #define DR_DISHWASHER=none
 #define DR_WASHER=none
 #define DR_DRYER=none
-#define VOLT_POWERDUMP
+#define VOLT_POWERDUMP = on
 
 #define POLE_TYPE=node
 

--- a/models/ieee123/config/local.glm
+++ b/models/ieee123/config/local.glm
@@ -1,42 +1,5 @@
-// do not edit -- updated automatically by 'save' action to setup.php at Tue, 09 Jan 2018 20:05:18 +0000 
-#define DOCROOT=/ieee123
-#define NAME=ieee123.glm
-#define PORT=3306
-#define TIMEZONE=US/CA/Los Angeles
+#define POLE_TYPE=node
+#define VOLTDUMP=all
 #define LOADS=on
-#define SOLAR=on
-#define DR_HVAC=none
-#define DR_WATERHEATER=none
-#define DR_DISHWASHER=none
-#define DR_WASHER=none
-#define DR_DRYER=none
-#define VOLT_POWERDUMP = on
-
-#define POLE_TYPE=node
-
-#ifndef POLE_TYPE
-#define POLE_TYPE=node
-#else // POLE_TYPE is defined
-#if POLE_TYPE!=node
-#if POLE_TYPE!=pole
-#warning changing invalid POLE_TYPE to node
-#set POLE_TYPE=node
-#endif // POLE_TYPE!=pole
-#endif // POLE_TYPE!=node
-#endif // POLE_TYPE defined
-
-#define WEATHER=CA-Bakersfield_Meadows_Field_high_wind.tmy3
-
-
-//#define MYSQL_ENABLE='on'
-#ifdef MYSQL_ENABLE
-#define HOSTNAME=localhost
-#define MYSQLHOST=${HOSTNAME}
-#define MYSQL_NAME=ieee123
-#define MYSQL_SCADA=on
-#define MYSQL_AMI=on
-#endif //MYSQL_ENABLE
-
-
 #define STARTTIME=2018-03-01 00:00:00 PST
 #define STOPTIME=2018-03-03 00:00:00 PST

--- a/models/ieee123/model/ieee123.glm
+++ b/models/ieee123/model/ieee123.glm
@@ -232,3 +232,187 @@ export mysql --graph ${MYSQL_NAME}_graph;
 #print starting historical simulation from ${STARTTIME} to ${STOPTIME}
 #set show_progress=1
 #endif
+
+
+//module voltdump;
+#ifdef VOLT_POWERDUMP
+object voltdump {
+	filemode "a";
+	runtime TS_NEVER;
+	maxcount 3000;
+	filename "model/output/volt_dump.csv";
+//	on_commit "python:voltdump.commit_voltdump";
+}
+module tape;
+
+object multi_recorder {
+	property substation_meter:measured_real_power, meter_1:measured_real_power, meter_2:measured_real_power, meter_3:measured_real_power, meter_4:measured_real_power, meter_5:measured_real_power, meter_6:measured_real_power, meter_7:measured_real_power, meter_8:measured_real_power, meter_9:measured_real_power, meter_10:measured_real_power, meter_11:measured_real_power, meter_12:measured_real_power, meter_13:measured_real_power, meter_14:measured_real_power, meter_15:measured_real_power, meter_16:measured_real_power, meter_17:measured_real_power, meter_18:measured_real_power, meter_19:measured_real_power, meter_20:measured_real_power, meter_21:measured_real_power, meter_22:measured_real_power, meter_23:measured_real_power, meter_24:measured_real_power, meter_25:measured_real_power, meter_26:measured_real_power, meter_27:measured_real_power, meter_28:measured_real_power, meter_29:measured_real_power, meter_30:measured_real_power;
+	file "model/output/power_dump_1.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_31:measured_real_power, meter_32:measured_real_power, meter_33:measured_real_power, meter_34:measured_real_power, meter_35:measured_real_power, meter_36:measured_real_power, meter_37:measured_real_power, meter_38:measured_real_power, meter_39:measured_real_power, meter_40:measured_real_power, meter_41:measured_real_power, meter_42:measured_real_power, meter_43:measured_real_power, meter_44:measured_real_power, meter_45:measured_real_power, meter_46:measured_real_power, meter_47:measured_real_power, meter_48:measured_real_power, meter_49:measured_real_power, meter_50:measured_real_power, meter_51:measured_real_power, meter_52:measured_real_power, meter_53:measured_real_power, meter_54:measured_real_power, meter_55:measured_real_power, meter_56:measured_real_power, meter_57:measured_real_power, meter_58:measured_real_power, meter_59:measured_real_power, meter_60:measured_real_power;
+	file "model/output/power_dump_2.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_61:measured_real_power, meter_62:measured_real_power, meter_63:measured_real_power, meter_64:measured_real_power, meter_65:measured_real_power, meter_66:measured_real_power, meter_67:measured_real_power, meter_68:measured_real_power, meter_69:measured_real_power, meter_70:measured_real_power, meter_71:measured_real_power, meter_72:measured_real_power, meter_73:measured_real_power, meter_74:measured_real_power, meter_75:measured_real_power, meter_76:measured_real_power, meter_77:measured_real_power, meter_78:measured_real_power, meter_79:measured_real_power, meter_80:measured_real_power, meter_81:measured_real_power, meter_82:measured_real_power, meter_83:measured_real_power, meter_84:measured_real_power, meter_85:measured_real_power, meter_86:measured_real_power, meter_87:measured_real_power, meter_88:measured_real_power, meter_89:measured_real_power, meter_90:measured_real_power;
+	file "model/output/power_dump_3.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_91:measured_real_power, meter_92:measured_real_power, meter_93:measured_real_power, meter_94:measured_real_power, meter_95:measured_real_power, meter_96:measured_real_power, meter_97:measured_real_power, meter_98:measured_real_power, meter_99:measured_real_power, meter_100:measured_real_power, meter_101:measured_real_power, meter_102:measured_real_power, meter_103:measured_real_power, meter_104:measured_real_power, meter_105:measured_real_power, meter_106:measured_real_power, meter_107:measured_real_power, meter_108:measured_real_power, meter_109:measured_real_power, meter_110:measured_real_power, meter_111:measured_real_power, meter_112:measured_real_power, meter_113:measured_real_power, meter_114:measured_real_power, meter_115:measured_real_power, meter_116:measured_real_power, meter_117:measured_real_power, meter_118:measured_real_power, meter_119:measured_real_power, meter_120:measured_real_power;
+	file "model/output/power_dump_4.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_121:measured_real_power, meter_122:measured_real_power, meter_123:measured_real_power, meter_124:measured_real_power, meter_125:measured_real_power, meter_126:measured_real_power, meter_127:measured_real_power, meter_128:measured_real_power, meter_129:measured_real_power, meter_130:measured_real_power, meter_131:measured_real_power, meter_132:measured_real_power, meter_133:measured_real_power, meter_134:measured_real_power, meter_135:measured_real_power, meter_136:measured_real_power, meter_137:measured_real_power, meter_138:measured_real_power, meter_139:measured_real_power, meter_140:measured_real_power, meter_141:measured_real_power, meter_142:measured_real_power, meter_143:measured_real_power, meter_144:measured_real_power, meter_145:measured_real_power, meter_146:measured_real_power, meter_147:measured_real_power, meter_148:measured_real_power, meter_149:measured_real_power, meter_150:measured_real_power;
+	file "model/output/power_dump_5.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_151:measured_real_power, meter_152:measured_real_power, meter_153:measured_real_power, meter_154:measured_real_power, meter_155:measured_real_power, meter_156:measured_real_power, meter_157:measured_real_power, meter_158:measured_real_power, meter_159:measured_real_power, meter_160:measured_real_power, meter_161:measured_real_power, meter_162:measured_real_power, meter_163:measured_real_power, meter_164:measured_real_power, meter_165:measured_real_power, meter_166:measured_real_power, meter_167:measured_real_power, meter_168:measured_real_power, meter_169:measured_real_power, meter_170:measured_real_power, meter_171:measured_real_power, meter_172:measured_real_power, meter_173:measured_real_power, meter_174:measured_real_power, meter_175:measured_real_power, meter_176:measured_real_power, meter_177:measured_real_power, meter_178:measured_real_power, meter_179:measured_real_power, meter_180:measured_real_power;
+	file "model/output/power_dump_6.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_181:measured_real_power, meter_182:measured_real_power, meter_183:measured_real_power, meter_184:measured_real_power, meter_185:measured_real_power, meter_186:measured_real_power, meter_187:measured_real_power, meter_188:measured_real_power, meter_189:measured_real_power, meter_190:measured_real_power, meter_191:measured_real_power, meter_192:measured_real_power, meter_193:measured_real_power, meter_194:measured_real_power, meter_195:measured_real_power, meter_196:measured_real_power, meter_197:measured_real_power, meter_198:measured_real_power, meter_199:measured_real_power, meter_200:measured_real_power, meter_201:measured_real_power, meter_202:measured_real_power, meter_203:measured_real_power, meter_204:measured_real_power, meter_205:measured_real_power, meter_206:measured_real_power, meter_207:measured_real_power, meter_208:measured_real_power, meter_209:measured_real_power, meter_210:measured_real_power;
+	file "model/output/power_dump_7.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_211:measured_real_power, meter_212:measured_real_power, meter_213:measured_real_power, meter_214:measured_real_power, meter_215:measured_real_power, meter_216:measured_real_power, meter_217:measured_real_power, meter_218:measured_real_power, meter_219:measured_real_power, meter_220:measured_real_power, meter_221:measured_real_power, meter_222:measured_real_power, meter_223:measured_real_power, meter_224:measured_real_power, meter_225:measured_real_power, meter_226:measured_real_power, meter_227:measured_real_power, meter_228:measured_real_power, meter_229:measured_real_power, meter_230:measured_real_power, meter_231:measured_real_power, meter_232:measured_real_power, meter_233:measured_real_power, meter_234:measured_real_power, meter_235:measured_real_power, meter_236:measured_real_power, meter_237:measured_real_power, meter_238:measured_real_power, meter_239:measured_real_power, meter_240:measured_real_power;
+	file "model/output/power_dump_8.csv";
+	interval -1;
+}
+object multi_recorder {
+	file "model/output/power_dump_9.csv";
+	property meter_241:measured_real_power, meter_242:measured_real_power, meter_243:measured_real_power, meter_244:measured_real_power, meter_245:measured_real_power, meter_246:measured_real_power, meter_247:measured_real_power, meter_248:measured_real_power, meter_249:measured_real_power, meter_250:measured_real_power, meter_251:measured_real_power, meter_252:measured_real_power, meter_253:measured_real_power, meter_254:measured_real_power, meter_255:measured_real_power, meter_256:measured_real_power, meter_257:measured_real_power, meter_258:measured_real_power, meter_259:measured_real_power, meter_260:measured_real_power, meter_261:measured_real_power, meter_262:measured_real_power, meter_263:measured_real_power, meter_264:measured_real_power, meter_265:measured_real_power, meter_266:measured_real_power, meter_267:measured_real_power, meter_268:measured_real_power, meter_269:measured_real_power, meter_270:measured_real_power;
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_271:measured_real_power, meter_272:measured_real_power, meter_273:measured_real_power, meter_274:measured_real_power, meter_275:measured_real_power, meter_276:measured_real_power, meter_277:measured_real_power, meter_278:measured_real_power, meter_279:measured_real_power, meter_280:measured_real_power, meter_281:measured_real_power, meter_282:measured_real_power, meter_283:measured_real_power, meter_284:measured_real_power, meter_285:measured_real_power, meter_286:measured_real_power, meter_287:measured_real_power, meter_288:measured_real_power, meter_289:measured_real_power, meter_290:measured_real_power, meter_291:measured_real_power, meter_292:measured_real_power, meter_293:measured_real_power, meter_294:measured_real_power, meter_295:measured_real_power, meter_296:measured_real_power, meter_297:measured_real_power, meter_298:measured_real_power, meter_299:measured_real_power, meter_300:measured_real_power;
+	file "model/output/power_dump_10.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_301:measured_real_power, meter_302:measured_real_power, meter_303:measured_real_power, meter_304:measured_real_power, meter_305:measured_real_power, meter_306:measured_real_power, meter_307:measured_real_power, meter_308:measured_real_power, meter_309:measured_real_power, meter_310:measured_real_power, meter_311:measured_real_power, meter_312:measured_real_power, meter_313:measured_real_power, meter_314:measured_real_power, meter_315:measured_real_power, meter_316:measured_real_power, meter_317:measured_real_power, meter_318:measured_real_power, meter_319:measured_real_power, meter_320:measured_real_power, meter_321:measured_real_power, meter_322:measured_real_power, meter_323:measured_real_power, meter_324:measured_real_power, meter_325:measured_real_power, meter_326:measured_real_power, meter_327:measured_real_power, meter_328:measured_real_power, meter_329:measured_real_power, meter_330:measured_real_power;
+	file "model/output/power_dump_11.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_331:measured_real_power, meter_332:measured_real_power, meter_333:measured_real_power, meter_334:measured_real_power, meter_335:measured_real_power, meter_336:measured_real_power, meter_337:measured_real_power, meter_338:measured_real_power, meter_339:measured_real_power, meter_340:measured_real_power, meter_341:measured_real_power, meter_342:measured_real_power, meter_343:measured_real_power, meter_344:measured_real_power;
+	file "model/output/power_dump_12.csv";
+	interval -1;
+}
+
+//reactive power recordings 
+
+object multi_recorder {
+	property substation_meter:measured_reactive_power, meter_1:measured_reactive_power, meter_2:measured_reactive_power, meter_3:measured_reactive_power, meter_4:measured_reactive_power, meter_5:measured_reactive_power, meter_6:measured_reactive_power, meter_7:measured_reactive_power, meter_8:measured_reactive_power, meter_9:measured_reactive_power, meter_10:measured_reactive_power, meter_11:measured_reactive_power, meter_12:measured_reactive_power, meter_13:measured_reactive_power, meter_14:measured_reactive_power, meter_15:measured_reactive_power, meter_16:measured_reactive_power, meter_17:measured_reactive_power, meter_18:measured_reactive_power, meter_19:measured_reactive_power, meter_20:measured_reactive_power, meter_21:measured_reactive_power, meter_22:measured_reactive_power, meter_23:measured_reactive_power, meter_24:measured_reactive_power;
+	file "model/output/power_dump_13.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_25:measured_reactive_power, meter_26:measured_reactive_power, meter_27:measured_reactive_power, meter_28:measured_reactive_power, meter_29:measured_reactive_power, meter_30:measured_reactive_power;
+	file "model/output/power_dump_14.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_31:measured_reactive_power, meter_32:measured_reactive_power, meter_33:measured_reactive_power, meter_34:measured_reactive_power, meter_35:measured_reactive_power, meter_36:measured_reactive_power, meter_37:measured_reactive_power, meter_38:measured_reactive_power, meter_39:measured_reactive_power, meter_40:measured_reactive_power, meter_41:measured_reactive_power, meter_42:measured_reactive_power, meter_43:measured_reactive_power, meter_44:measured_reactive_power, meter_45:measured_reactive_power, meter_46:measured_reactive_power, meter_47:measured_reactive_power, meter_48:measured_reactive_power, meter_49:measured_reactive_power, meter_50:measured_reactive_power, meter_51:measured_reactive_power, meter_52:measured_reactive_power, meter_53:measured_reactive_power, meter_54:measured_reactive_power, meter_55:measured_reactive_power, meter_56:measured_reactive_power, meter_57:measured_reactive_power, meter_58:measured_reactive_power, meter_59:measured_reactive_power, meter_60:measured_reactive_power;
+	file "model/output/power_dump_15.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_61:measured_reactive_power, meter_62:measured_reactive_power, meter_63:measured_reactive_power, meter_64:measured_reactive_power, meter_65:measured_reactive_power, meter_66:measured_reactive_power, meter_67:measured_reactive_power, meter_68:measured_reactive_power, meter_69:measured_reactive_power, meter_70:measured_reactive_power, meter_71:measured_reactive_power, meter_72:measured_reactive_power, meter_73:measured_reactive_power, meter_74:measured_reactive_power, meter_75:measured_reactive_power, meter_76:measured_reactive_power, meter_77:measured_reactive_power, meter_78:measured_reactive_power, meter_79:measured_reactive_power, meter_80:measured_reactive_power, meter_81:measured_reactive_power, meter_82:measured_reactive_power, meter_83:measured_reactive_power, meter_84:measured_reactive_power, meter_85:measured_reactive_power, meter_86:measured_reactive_power, meter_87:measured_reactive_power, meter_88:measured_reactive_power, meter_89:measured_reactive_power, meter_90:measured_reactive_power;
+	file "model/output/power_dump_16.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_91:measured_reactive_power, meter_92:measured_reactive_power, meter_93:measured_reactive_power, meter_94:measured_reactive_power, meter_95:measured_reactive_power, meter_96:measured_reactive_power, meter_97:measured_reactive_power, meter_98:measured_reactive_power, meter_99:measured_reactive_power, meter_100:measured_reactive_power, meter_101:measured_reactive_power, meter_102:measured_reactive_power, meter_103:measured_reactive_power, meter_104:measured_reactive_power, meter_105:measured_reactive_power, meter_106:measured_reactive_power, meter_107:measured_reactive_power, meter_108:measured_reactive_power, meter_109:measured_reactive_power, meter_110:measured_reactive_power, meter_111:measured_reactive_power, meter_112:measured_reactive_power, meter_113:measured_reactive_power, meter_114:measured_reactive_power;
+	file "model/output/power_dump_17.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_115:measured_reactive_power, meter_116:measured_reactive_power, meter_117:measured_reactive_power, meter_118:measured_reactive_power, meter_119:measured_reactive_power, meter_120:measured_reactive_power, meter_121:measured_reactive_power, meter_122:measured_reactive_power, meter_123:measured_reactive_power, meter_124:measured_reactive_power, meter_125:measured_reactive_power;
+	file "model/output/power_dump_18.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_126:measured_reactive_power, meter_127:measured_reactive_power, meter_128:measured_reactive_power, meter_129:measured_reactive_power, meter_130:measured_reactive_power, meter_131:measured_reactive_power, meter_132:measured_reactive_power, meter_133:measured_reactive_power, meter_134:measured_reactive_power, meter_135:measured_reactive_power, meter_136:measured_reactive_power, meter_137:measured_reactive_power, meter_138:measured_reactive_power, meter_139:measured_reactive_power, meter_140:measured_reactive_power, meter_141:measured_reactive_power, meter_142:measured_reactive_power, meter_143:measured_reactive_power, meter_144:measured_reactive_power, meter_145:measured_reactive_power, meter_146:measured_reactive_power, meter_147:measured_reactive_power, meter_148:measured_reactive_power, meter_149:measured_reactive_power, meter_150:measured_reactive_power;
+	file "model/output/power_dump_19.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_151:measured_reactive_power, meter_152:measured_reactive_power, meter_153:measured_reactive_power, meter_154:measured_reactive_power, meter_155:measured_reactive_power, meter_156:measured_reactive_power, meter_157:measured_reactive_power, meter_158:measured_reactive_power, meter_159:measured_reactive_power, meter_160:measured_reactive_power, meter_161:measured_reactive_power, meter_162:measured_reactive_power, meter_163:measured_reactive_power, meter_164:measured_reactive_power, meter_165:measured_reactive_power, meter_166:measured_reactive_power, meter_167:measured_reactive_power, meter_168:measured_reactive_power, meter_169:measured_reactive_power, meter_170:measured_reactive_power, meter_171:measured_reactive_power, meter_172:measured_reactive_power, meter_173:measured_reactive_power, meter_174:measured_reactive_power, meter_175:measured_reactive_power;
+	file "model/output/power_dump_20.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_176:measured_reactive_power, meter_177:measured_reactive_power, meter_178:measured_reactive_power, meter_179:measured_reactive_power, meter_180:measured_reactive_power, meter_181:measured_reactive_power, meter_182:measured_reactive_power, meter_183:measured_reactive_power, meter_184:measured_reactive_power;
+	file "model/output/power_dump_21.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_185:measured_reactive_power, meter_186:measured_reactive_power, meter_187:measured_reactive_power, meter_188:measured_reactive_power, meter_189:measured_reactive_power, meter_190:measured_reactive_power, meter_191:measured_reactive_power, meter_192:measured_reactive_power, meter_193:measured_reactive_power, meter_194:measured_reactive_power, meter_195:measured_reactive_power, meter_196:measured_reactive_power, meter_197:measured_reactive_power, meter_198:measured_reactive_power, meter_199:measured_reactive_power, meter_200:measured_reactive_power, meter_201:measured_reactive_power, meter_202:measured_reactive_power, meter_203:measured_reactive_power, meter_204:measured_reactive_power, meter_205:measured_reactive_power, meter_206:measured_reactive_power, meter_207:measured_reactive_power, meter_208:measured_reactive_power, meter_209:measured_reactive_power, meter_210:measured_reactive_power;
+	file "model/output/power_dump_22.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_211:measured_reactive_power, meter_212:measured_reactive_power, meter_213:measured_reactive_power, meter_214:measured_reactive_power, meter_215:measured_reactive_power, meter_216:measured_reactive_power, meter_217:measured_reactive_power, meter_218:measured_reactive_power, meter_219:measured_reactive_power, meter_220:measured_reactive_power, meter_221:measured_reactive_power, meter_222:measured_reactive_power, meter_223:measured_reactive_power, meter_224:measured_reactive_power, meter_225:measured_reactive_power, meter_226:measured_reactive_power, meter_227:measured_reactive_power, meter_228:measured_reactive_power, meter_229:measured_reactive_power, meter_230:measured_reactive_power, meter_231:measured_reactive_power, meter_232:measured_reactive_power, meter_233:measured_reactive_power, meter_234:measured_reactive_power, meter_235:measured_reactive_power;
+	file "model/output/power_dump_23.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_236:measured_reactive_power, meter_237:measured_reactive_power, meter_238:measured_reactive_power, meter_239:measured_reactive_power, meter_240:measured_reactive_power, meter_241:measured_reactive_power, meter_242:measured_reactive_power, meter_243:measured_reactive_power, meter_244:measured_reactive_power;
+	file "model/output/power_dump_24.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	file "model/output/power_dump_25.csv";
+	property meter_245:measured_reactive_power, meter_246:measured_reactive_power, meter_247:measured_reactive_power, meter_248:measured_reactive_power, meter_249:measured_reactive_power, meter_250:measured_reactive_power, meter_251:measured_reactive_power, meter_252:measured_reactive_power, meter_253:measured_reactive_power, meter_254:measured_reactive_power, meter_255:measured_reactive_power, meter_256:measured_reactive_power, meter_257:measured_reactive_power, meter_258:measured_reactive_power, meter_259:measured_reactive_power, meter_260:measured_reactive_power, meter_261:measured_reactive_power, meter_262:measured_reactive_power, meter_263:measured_reactive_power, meter_264:measured_reactive_power, meter_265:measured_reactive_power, meter_266:measured_reactive_power, meter_267:measured_reactive_power, meter_268:measured_reactive_power, meter_269:measured_reactive_power, meter_270:measured_reactive_power;
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_271:measured_reactive_power, meter_272:measured_reactive_power, meter_273:measured_reactive_power, meter_274:measured_reactive_power, meter_275:measured_reactive_power, meter_276:measured_reactive_power, meter_277:measured_reactive_power, meter_278:measured_reactive_power, meter_279:measured_reactive_power, meter_280:measured_reactive_power, meter_281:measured_reactive_power, meter_282:measured_reactive_power, meter_283:measured_reactive_power, meter_284:measured_reactive_power, meter_285:measured_reactive_power, meter_286:measured_reactive_power, meter_287:measured_reactive_power, meter_288:measured_reactive_power, meter_289:measured_reactive_power, meter_290:measured_reactive_power, meter_291:measured_reactive_power, meter_292:measured_reactive_power, meter_293:measured_reactive_power, meter_294:measured_reactive_power, meter_295:measured_reactive_power, meter_296:measured_reactive_power, meter_297:measured_reactive_power, meter_298:measured_reactive_power, meter_299:measured_reactive_power;
+	file "model/output/power_dump_26.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_300:measured_reactive_power, meter_301:measured_reactive_power, meter_302:measured_reactive_power, meter_303:measured_reactive_power, meter_304:measured_reactive_power, meter_305:measured_reactive_power, meter_306:measured_reactive_power, meter_307:measured_reactive_power, meter_308:measured_reactive_power, meter_309:measured_reactive_power, meter_310:measured_reactive_power, meter_311:measured_reactive_power, meter_312:measured_reactive_power, meter_313:measured_reactive_power, meter_314:measured_reactive_power, meter_315:measured_reactive_power, meter_316:measured_reactive_power, meter_317:measured_reactive_power, meter_318:measured_reactive_power, meter_319:measured_reactive_power, meter_320:measured_reactive_power, meter_321:measured_reactive_power, meter_322:measured_reactive_power, meter_323:measured_reactive_power, meter_324:measured_reactive_power, meter_325:measured_reactive_power, meter_326:measured_reactive_power, meter_327:measured_reactive_power, meter_328:measured_reactive_power;
+	file "model/output/power_dump_27.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_329:measured_reactive_power, meter_330:measured_reactive_power, meter_331:measured_reactive_power, meter_332:measured_reactive_power, meter_333:measured_reactive_power, meter_334:measured_reactive_power, meter_335:measured_reactive_power, meter_336:measured_reactive_power, meter_337:measured_reactive_power, meter_338:measured_reactive_power, meter_339:measured_reactive_power, meter_340:measured_reactive_power, meter_341:measured_reactive_power, meter_342:measured_reactive_power, meter_343:measured_reactive_power, meter_344:measured_reactive_power;
+	file "model/output/power_dump_28.csv";
+	interval -1;
+}
+
+#endif //VOLT_POWERDUMP
+//script on_commit "python volt_dump.py"

--- a/models/ieee123/model/ieee123.glm
+++ b/models/ieee123/model/ieee123.glm
@@ -10,9 +10,12 @@
 // Read the configuration file for this system
 // Assumes the model is run from parent of model folder
 //
+#include "config/default.glm"
+#define CONFIGFILE=config/default.glm
 #ifexist config/local.glm
 #include "config/local.glm"
-#endif // exist local.glm
+#set CONFIGFILE=config/local.glm
+#endif
 
 //
 // Check the configuration
@@ -27,6 +30,9 @@
 //
 ///////////////////////////////////////////////////////
 
+#ifndef POLE_TYPE
+#error POLE_TYPE is not specified in ${CONFIGFILE}
+#endif
 
 #ifdef RANDOMSEED
 #set randomseed=${RANDOMSEED} // select deterministic simulation
@@ -66,7 +72,7 @@ clock {
 #endif
 }
 #else
-#error No timezone specified
+#error TIMEZONE is not specified in ${CONFIGFILE}
 #endif // TIMEZONE
 
 ///////////////////////////////////////////////////////
@@ -82,7 +88,7 @@ object climate {
         interpolate QUADRATIC;
 }
 #else
-#error No weather specified.
+#error WEATHER is not specified in ${CONFIGFILE}
 #endif // exist WEATHER
 
 ///////////////////////////////////////////////////////
@@ -100,7 +106,10 @@ module powerflow {
 module generators;
 #endif // SOLAR
 
-#ifdef VOLTDUMP
+#ifndef VOLTDUMP
+#error VOLTDUMP is not specified in ${CONFIGFILE}
+#endif
+#if VOLTDUMP==on
 object voltdump {
 	filename ${VOLTDUMP};
 	group "nodevolts";
@@ -108,7 +117,10 @@ object voltdump {
 }
 #endif // VOLTDUMP
 
-#ifdef CURRDUMP
+#ifndef CURRDUMP
+#error CURRDUMP is not specified in ${CONFIGFILE}
+#endif
+#if CURRDUMP==on
 object currdump {
 	filename ${CURRDUMP};
 	mode rect;
@@ -136,8 +148,11 @@ object currdump {
 // MYSQL DATABASE SUPPORT
 //
 ///////////////////////////////////////////////////////
-#ifdef MYSQL_ENABLE
+#ifndef MYSQL_ENABLE
+#error MYSQL_ENABLE is not specified in ${CONFIGFILE}
+#endif
 
+#if MYSQL_ENABLE==on
 #ifndef MYSQLHOST
 #define MYSQLHOST=localhost
 #endif // MYSQLHOST
@@ -153,14 +168,20 @@ module mysql {
 #endif // SOCKETNAME
 }
 
-#ifdef MYSQL_SCADA
+#ifndef MYSQL_SCADA
+#error MYSQL_SCADA is not specified in ${CONFIGFILE}
+#endif
+#if MYSQL_SCADA==on
 object database {
 	name scada;
 	schema "${MYSQL_NAME}_scada";
 }
 #endif // MYSQL_SCADA
 
-#ifdef MYSQL_AMI
+#ifndef MYSQL_AMI
+#error MYSQL_AMI is not specified in ${CONFIGFILE}
+#endif
+#if MYSQL_AMI==on
 object database {
 	name ami;
 	schema "${MYSQL_NAME}_ami";
@@ -181,11 +202,11 @@ object database {
 //
 ///////////////////////////////////////////////////////
 
-#ifdef MYSQL_ENABLE
+#if MYSQL_ENABLE==on
 //
 // SCADA recorders
 //
-#ifdef MYSQL_SCADA
+#if MYSQL_SCADA==on
 #include "model/library/scada.glm"
 #endif // MYSQL_SCADA
 #endif // MYSQL_ENABLE
@@ -203,16 +224,16 @@ object database {
 //
 ///////////////////////////////////////////////////////
 
-#ifdef MYSQL_ENABLE
+#if MYSQL_ENABLE==on
 
-#ifdef MYSQL_MODEL
+#if MYSQL_MODEL==on
 
 #ifndef STOPTIME
 #print dumping model to '${MYSQL_MODEL}_model'
 export mysql ${MYSQL_NAME}_model;
 #endif // MYSQL_MODEL
 
-#ifdef MYSQL_GRAPH
+#if MYSQL_GRAPH==on
 #print dumping graph to '${MYSQL_NAME}_graph'
 export mysql --graph ${MYSQL_NAME}_graph;
 #endif // MYSQL_GRAPH
@@ -220,6 +241,14 @@ export mysql --graph ${MYSQL_NAME}_graph;
 #endif // STOPTIME
 
 #endif // MYSQL_ENABLE
+
+#if VOLTDUMP==all
+#if LOADS==on
+#include "model/library/voltdump.glm"
+#else
+#error VOLTDUMP=all not possible unless LOADS=on in ${CONFIGFILE}
+#endif
+#endif
 
 ///////////////////////////////////////////////////////
 //
@@ -232,187 +261,3 @@ export mysql --graph ${MYSQL_NAME}_graph;
 #print starting historical simulation from ${STARTTIME} to ${STOPTIME}
 #set show_progress=1
 #endif
-
-
-//module voltdump;
-#ifdef VOLT_POWERDUMP
-object voltdump {
-	filemode "a";
-	runtime TS_NEVER;
-	maxcount 3000;
-	filename "model/output/volt_dump.csv";
-//	on_commit "python:voltdump.commit_voltdump";
-}
-module tape;
-
-object multi_recorder {
-	property substation_meter:measured_real_power, meter_1:measured_real_power, meter_2:measured_real_power, meter_3:measured_real_power, meter_4:measured_real_power, meter_5:measured_real_power, meter_6:measured_real_power, meter_7:measured_real_power, meter_8:measured_real_power, meter_9:measured_real_power, meter_10:measured_real_power, meter_11:measured_real_power, meter_12:measured_real_power, meter_13:measured_real_power, meter_14:measured_real_power, meter_15:measured_real_power, meter_16:measured_real_power, meter_17:measured_real_power, meter_18:measured_real_power, meter_19:measured_real_power, meter_20:measured_real_power, meter_21:measured_real_power, meter_22:measured_real_power, meter_23:measured_real_power, meter_24:measured_real_power, meter_25:measured_real_power, meter_26:measured_real_power, meter_27:measured_real_power, meter_28:measured_real_power, meter_29:measured_real_power, meter_30:measured_real_power;
-	file "model/output/power_dump_1.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_31:measured_real_power, meter_32:measured_real_power, meter_33:measured_real_power, meter_34:measured_real_power, meter_35:measured_real_power, meter_36:measured_real_power, meter_37:measured_real_power, meter_38:measured_real_power, meter_39:measured_real_power, meter_40:measured_real_power, meter_41:measured_real_power, meter_42:measured_real_power, meter_43:measured_real_power, meter_44:measured_real_power, meter_45:measured_real_power, meter_46:measured_real_power, meter_47:measured_real_power, meter_48:measured_real_power, meter_49:measured_real_power, meter_50:measured_real_power, meter_51:measured_real_power, meter_52:measured_real_power, meter_53:measured_real_power, meter_54:measured_real_power, meter_55:measured_real_power, meter_56:measured_real_power, meter_57:measured_real_power, meter_58:measured_real_power, meter_59:measured_real_power, meter_60:measured_real_power;
-	file "model/output/power_dump_2.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_61:measured_real_power, meter_62:measured_real_power, meter_63:measured_real_power, meter_64:measured_real_power, meter_65:measured_real_power, meter_66:measured_real_power, meter_67:measured_real_power, meter_68:measured_real_power, meter_69:measured_real_power, meter_70:measured_real_power, meter_71:measured_real_power, meter_72:measured_real_power, meter_73:measured_real_power, meter_74:measured_real_power, meter_75:measured_real_power, meter_76:measured_real_power, meter_77:measured_real_power, meter_78:measured_real_power, meter_79:measured_real_power, meter_80:measured_real_power, meter_81:measured_real_power, meter_82:measured_real_power, meter_83:measured_real_power, meter_84:measured_real_power, meter_85:measured_real_power, meter_86:measured_real_power, meter_87:measured_real_power, meter_88:measured_real_power, meter_89:measured_real_power, meter_90:measured_real_power;
-	file "model/output/power_dump_3.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_91:measured_real_power, meter_92:measured_real_power, meter_93:measured_real_power, meter_94:measured_real_power, meter_95:measured_real_power, meter_96:measured_real_power, meter_97:measured_real_power, meter_98:measured_real_power, meter_99:measured_real_power, meter_100:measured_real_power, meter_101:measured_real_power, meter_102:measured_real_power, meter_103:measured_real_power, meter_104:measured_real_power, meter_105:measured_real_power, meter_106:measured_real_power, meter_107:measured_real_power, meter_108:measured_real_power, meter_109:measured_real_power, meter_110:measured_real_power, meter_111:measured_real_power, meter_112:measured_real_power, meter_113:measured_real_power, meter_114:measured_real_power, meter_115:measured_real_power, meter_116:measured_real_power, meter_117:measured_real_power, meter_118:measured_real_power, meter_119:measured_real_power, meter_120:measured_real_power;
-	file "model/output/power_dump_4.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_121:measured_real_power, meter_122:measured_real_power, meter_123:measured_real_power, meter_124:measured_real_power, meter_125:measured_real_power, meter_126:measured_real_power, meter_127:measured_real_power, meter_128:measured_real_power, meter_129:measured_real_power, meter_130:measured_real_power, meter_131:measured_real_power, meter_132:measured_real_power, meter_133:measured_real_power, meter_134:measured_real_power, meter_135:measured_real_power, meter_136:measured_real_power, meter_137:measured_real_power, meter_138:measured_real_power, meter_139:measured_real_power, meter_140:measured_real_power, meter_141:measured_real_power, meter_142:measured_real_power, meter_143:measured_real_power, meter_144:measured_real_power, meter_145:measured_real_power, meter_146:measured_real_power, meter_147:measured_real_power, meter_148:measured_real_power, meter_149:measured_real_power, meter_150:measured_real_power;
-	file "model/output/power_dump_5.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_151:measured_real_power, meter_152:measured_real_power, meter_153:measured_real_power, meter_154:measured_real_power, meter_155:measured_real_power, meter_156:measured_real_power, meter_157:measured_real_power, meter_158:measured_real_power, meter_159:measured_real_power, meter_160:measured_real_power, meter_161:measured_real_power, meter_162:measured_real_power, meter_163:measured_real_power, meter_164:measured_real_power, meter_165:measured_real_power, meter_166:measured_real_power, meter_167:measured_real_power, meter_168:measured_real_power, meter_169:measured_real_power, meter_170:measured_real_power, meter_171:measured_real_power, meter_172:measured_real_power, meter_173:measured_real_power, meter_174:measured_real_power, meter_175:measured_real_power, meter_176:measured_real_power, meter_177:measured_real_power, meter_178:measured_real_power, meter_179:measured_real_power, meter_180:measured_real_power;
-	file "model/output/power_dump_6.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_181:measured_real_power, meter_182:measured_real_power, meter_183:measured_real_power, meter_184:measured_real_power, meter_185:measured_real_power, meter_186:measured_real_power, meter_187:measured_real_power, meter_188:measured_real_power, meter_189:measured_real_power, meter_190:measured_real_power, meter_191:measured_real_power, meter_192:measured_real_power, meter_193:measured_real_power, meter_194:measured_real_power, meter_195:measured_real_power, meter_196:measured_real_power, meter_197:measured_real_power, meter_198:measured_real_power, meter_199:measured_real_power, meter_200:measured_real_power, meter_201:measured_real_power, meter_202:measured_real_power, meter_203:measured_real_power, meter_204:measured_real_power, meter_205:measured_real_power, meter_206:measured_real_power, meter_207:measured_real_power, meter_208:measured_real_power, meter_209:measured_real_power, meter_210:measured_real_power;
-	file "model/output/power_dump_7.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_211:measured_real_power, meter_212:measured_real_power, meter_213:measured_real_power, meter_214:measured_real_power, meter_215:measured_real_power, meter_216:measured_real_power, meter_217:measured_real_power, meter_218:measured_real_power, meter_219:measured_real_power, meter_220:measured_real_power, meter_221:measured_real_power, meter_222:measured_real_power, meter_223:measured_real_power, meter_224:measured_real_power, meter_225:measured_real_power, meter_226:measured_real_power, meter_227:measured_real_power, meter_228:measured_real_power, meter_229:measured_real_power, meter_230:measured_real_power, meter_231:measured_real_power, meter_232:measured_real_power, meter_233:measured_real_power, meter_234:measured_real_power, meter_235:measured_real_power, meter_236:measured_real_power, meter_237:measured_real_power, meter_238:measured_real_power, meter_239:measured_real_power, meter_240:measured_real_power;
-	file "model/output/power_dump_8.csv";
-	interval -1;
-}
-object multi_recorder {
-	file "model/output/power_dump_9.csv";
-	property meter_241:measured_real_power, meter_242:measured_real_power, meter_243:measured_real_power, meter_244:measured_real_power, meter_245:measured_real_power, meter_246:measured_real_power, meter_247:measured_real_power, meter_248:measured_real_power, meter_249:measured_real_power, meter_250:measured_real_power, meter_251:measured_real_power, meter_252:measured_real_power, meter_253:measured_real_power, meter_254:measured_real_power, meter_255:measured_real_power, meter_256:measured_real_power, meter_257:measured_real_power, meter_258:measured_real_power, meter_259:measured_real_power, meter_260:measured_real_power, meter_261:measured_real_power, meter_262:measured_real_power, meter_263:measured_real_power, meter_264:measured_real_power, meter_265:measured_real_power, meter_266:measured_real_power, meter_267:measured_real_power, meter_268:measured_real_power, meter_269:measured_real_power, meter_270:measured_real_power;
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_271:measured_real_power, meter_272:measured_real_power, meter_273:measured_real_power, meter_274:measured_real_power, meter_275:measured_real_power, meter_276:measured_real_power, meter_277:measured_real_power, meter_278:measured_real_power, meter_279:measured_real_power, meter_280:measured_real_power, meter_281:measured_real_power, meter_282:measured_real_power, meter_283:measured_real_power, meter_284:measured_real_power, meter_285:measured_real_power, meter_286:measured_real_power, meter_287:measured_real_power, meter_288:measured_real_power, meter_289:measured_real_power, meter_290:measured_real_power, meter_291:measured_real_power, meter_292:measured_real_power, meter_293:measured_real_power, meter_294:measured_real_power, meter_295:measured_real_power, meter_296:measured_real_power, meter_297:measured_real_power, meter_298:measured_real_power, meter_299:measured_real_power, meter_300:measured_real_power;
-	file "model/output/power_dump_10.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_301:measured_real_power, meter_302:measured_real_power, meter_303:measured_real_power, meter_304:measured_real_power, meter_305:measured_real_power, meter_306:measured_real_power, meter_307:measured_real_power, meter_308:measured_real_power, meter_309:measured_real_power, meter_310:measured_real_power, meter_311:measured_real_power, meter_312:measured_real_power, meter_313:measured_real_power, meter_314:measured_real_power, meter_315:measured_real_power, meter_316:measured_real_power, meter_317:measured_real_power, meter_318:measured_real_power, meter_319:measured_real_power, meter_320:measured_real_power, meter_321:measured_real_power, meter_322:measured_real_power, meter_323:measured_real_power, meter_324:measured_real_power, meter_325:measured_real_power, meter_326:measured_real_power, meter_327:measured_real_power, meter_328:measured_real_power, meter_329:measured_real_power, meter_330:measured_real_power;
-	file "model/output/power_dump_11.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_331:measured_real_power, meter_332:measured_real_power, meter_333:measured_real_power, meter_334:measured_real_power, meter_335:measured_real_power, meter_336:measured_real_power, meter_337:measured_real_power, meter_338:measured_real_power, meter_339:measured_real_power, meter_340:measured_real_power, meter_341:measured_real_power, meter_342:measured_real_power, meter_343:measured_real_power, meter_344:measured_real_power;
-	file "model/output/power_dump_12.csv";
-	interval -1;
-}
-
-//reactive power recordings 
-
-object multi_recorder {
-	property substation_meter:measured_reactive_power, meter_1:measured_reactive_power, meter_2:measured_reactive_power, meter_3:measured_reactive_power, meter_4:measured_reactive_power, meter_5:measured_reactive_power, meter_6:measured_reactive_power, meter_7:measured_reactive_power, meter_8:measured_reactive_power, meter_9:measured_reactive_power, meter_10:measured_reactive_power, meter_11:measured_reactive_power, meter_12:measured_reactive_power, meter_13:measured_reactive_power, meter_14:measured_reactive_power, meter_15:measured_reactive_power, meter_16:measured_reactive_power, meter_17:measured_reactive_power, meter_18:measured_reactive_power, meter_19:measured_reactive_power, meter_20:measured_reactive_power, meter_21:measured_reactive_power, meter_22:measured_reactive_power, meter_23:measured_reactive_power, meter_24:measured_reactive_power;
-	file "model/output/power_dump_13.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_25:measured_reactive_power, meter_26:measured_reactive_power, meter_27:measured_reactive_power, meter_28:measured_reactive_power, meter_29:measured_reactive_power, meter_30:measured_reactive_power;
-	file "model/output/power_dump_14.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_31:measured_reactive_power, meter_32:measured_reactive_power, meter_33:measured_reactive_power, meter_34:measured_reactive_power, meter_35:measured_reactive_power, meter_36:measured_reactive_power, meter_37:measured_reactive_power, meter_38:measured_reactive_power, meter_39:measured_reactive_power, meter_40:measured_reactive_power, meter_41:measured_reactive_power, meter_42:measured_reactive_power, meter_43:measured_reactive_power, meter_44:measured_reactive_power, meter_45:measured_reactive_power, meter_46:measured_reactive_power, meter_47:measured_reactive_power, meter_48:measured_reactive_power, meter_49:measured_reactive_power, meter_50:measured_reactive_power, meter_51:measured_reactive_power, meter_52:measured_reactive_power, meter_53:measured_reactive_power, meter_54:measured_reactive_power, meter_55:measured_reactive_power, meter_56:measured_reactive_power, meter_57:measured_reactive_power, meter_58:measured_reactive_power, meter_59:measured_reactive_power, meter_60:measured_reactive_power;
-	file "model/output/power_dump_15.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_61:measured_reactive_power, meter_62:measured_reactive_power, meter_63:measured_reactive_power, meter_64:measured_reactive_power, meter_65:measured_reactive_power, meter_66:measured_reactive_power, meter_67:measured_reactive_power, meter_68:measured_reactive_power, meter_69:measured_reactive_power, meter_70:measured_reactive_power, meter_71:measured_reactive_power, meter_72:measured_reactive_power, meter_73:measured_reactive_power, meter_74:measured_reactive_power, meter_75:measured_reactive_power, meter_76:measured_reactive_power, meter_77:measured_reactive_power, meter_78:measured_reactive_power, meter_79:measured_reactive_power, meter_80:measured_reactive_power, meter_81:measured_reactive_power, meter_82:measured_reactive_power, meter_83:measured_reactive_power, meter_84:measured_reactive_power, meter_85:measured_reactive_power, meter_86:measured_reactive_power, meter_87:measured_reactive_power, meter_88:measured_reactive_power, meter_89:measured_reactive_power, meter_90:measured_reactive_power;
-	file "model/output/power_dump_16.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_91:measured_reactive_power, meter_92:measured_reactive_power, meter_93:measured_reactive_power, meter_94:measured_reactive_power, meter_95:measured_reactive_power, meter_96:measured_reactive_power, meter_97:measured_reactive_power, meter_98:measured_reactive_power, meter_99:measured_reactive_power, meter_100:measured_reactive_power, meter_101:measured_reactive_power, meter_102:measured_reactive_power, meter_103:measured_reactive_power, meter_104:measured_reactive_power, meter_105:measured_reactive_power, meter_106:measured_reactive_power, meter_107:measured_reactive_power, meter_108:measured_reactive_power, meter_109:measured_reactive_power, meter_110:measured_reactive_power, meter_111:measured_reactive_power, meter_112:measured_reactive_power, meter_113:measured_reactive_power, meter_114:measured_reactive_power;
-	file "model/output/power_dump_17.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_115:measured_reactive_power, meter_116:measured_reactive_power, meter_117:measured_reactive_power, meter_118:measured_reactive_power, meter_119:measured_reactive_power, meter_120:measured_reactive_power, meter_121:measured_reactive_power, meter_122:measured_reactive_power, meter_123:measured_reactive_power, meter_124:measured_reactive_power, meter_125:measured_reactive_power;
-	file "model/output/power_dump_18.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_126:measured_reactive_power, meter_127:measured_reactive_power, meter_128:measured_reactive_power, meter_129:measured_reactive_power, meter_130:measured_reactive_power, meter_131:measured_reactive_power, meter_132:measured_reactive_power, meter_133:measured_reactive_power, meter_134:measured_reactive_power, meter_135:measured_reactive_power, meter_136:measured_reactive_power, meter_137:measured_reactive_power, meter_138:measured_reactive_power, meter_139:measured_reactive_power, meter_140:measured_reactive_power, meter_141:measured_reactive_power, meter_142:measured_reactive_power, meter_143:measured_reactive_power, meter_144:measured_reactive_power, meter_145:measured_reactive_power, meter_146:measured_reactive_power, meter_147:measured_reactive_power, meter_148:measured_reactive_power, meter_149:measured_reactive_power, meter_150:measured_reactive_power;
-	file "model/output/power_dump_19.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_151:measured_reactive_power, meter_152:measured_reactive_power, meter_153:measured_reactive_power, meter_154:measured_reactive_power, meter_155:measured_reactive_power, meter_156:measured_reactive_power, meter_157:measured_reactive_power, meter_158:measured_reactive_power, meter_159:measured_reactive_power, meter_160:measured_reactive_power, meter_161:measured_reactive_power, meter_162:measured_reactive_power, meter_163:measured_reactive_power, meter_164:measured_reactive_power, meter_165:measured_reactive_power, meter_166:measured_reactive_power, meter_167:measured_reactive_power, meter_168:measured_reactive_power, meter_169:measured_reactive_power, meter_170:measured_reactive_power, meter_171:measured_reactive_power, meter_172:measured_reactive_power, meter_173:measured_reactive_power, meter_174:measured_reactive_power, meter_175:measured_reactive_power;
-	file "model/output/power_dump_20.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_176:measured_reactive_power, meter_177:measured_reactive_power, meter_178:measured_reactive_power, meter_179:measured_reactive_power, meter_180:measured_reactive_power, meter_181:measured_reactive_power, meter_182:measured_reactive_power, meter_183:measured_reactive_power, meter_184:measured_reactive_power;
-	file "model/output/power_dump_21.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_185:measured_reactive_power, meter_186:measured_reactive_power, meter_187:measured_reactive_power, meter_188:measured_reactive_power, meter_189:measured_reactive_power, meter_190:measured_reactive_power, meter_191:measured_reactive_power, meter_192:measured_reactive_power, meter_193:measured_reactive_power, meter_194:measured_reactive_power, meter_195:measured_reactive_power, meter_196:measured_reactive_power, meter_197:measured_reactive_power, meter_198:measured_reactive_power, meter_199:measured_reactive_power, meter_200:measured_reactive_power, meter_201:measured_reactive_power, meter_202:measured_reactive_power, meter_203:measured_reactive_power, meter_204:measured_reactive_power, meter_205:measured_reactive_power, meter_206:measured_reactive_power, meter_207:measured_reactive_power, meter_208:measured_reactive_power, meter_209:measured_reactive_power, meter_210:measured_reactive_power;
-	file "model/output/power_dump_22.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_211:measured_reactive_power, meter_212:measured_reactive_power, meter_213:measured_reactive_power, meter_214:measured_reactive_power, meter_215:measured_reactive_power, meter_216:measured_reactive_power, meter_217:measured_reactive_power, meter_218:measured_reactive_power, meter_219:measured_reactive_power, meter_220:measured_reactive_power, meter_221:measured_reactive_power, meter_222:measured_reactive_power, meter_223:measured_reactive_power, meter_224:measured_reactive_power, meter_225:measured_reactive_power, meter_226:measured_reactive_power, meter_227:measured_reactive_power, meter_228:measured_reactive_power, meter_229:measured_reactive_power, meter_230:measured_reactive_power, meter_231:measured_reactive_power, meter_232:measured_reactive_power, meter_233:measured_reactive_power, meter_234:measured_reactive_power, meter_235:measured_reactive_power;
-	file "model/output/power_dump_23.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_236:measured_reactive_power, meter_237:measured_reactive_power, meter_238:measured_reactive_power, meter_239:measured_reactive_power, meter_240:measured_reactive_power, meter_241:measured_reactive_power, meter_242:measured_reactive_power, meter_243:measured_reactive_power, meter_244:measured_reactive_power;
-	file "model/output/power_dump_24.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	file "model/output/power_dump_25.csv";
-	property meter_245:measured_reactive_power, meter_246:measured_reactive_power, meter_247:measured_reactive_power, meter_248:measured_reactive_power, meter_249:measured_reactive_power, meter_250:measured_reactive_power, meter_251:measured_reactive_power, meter_252:measured_reactive_power, meter_253:measured_reactive_power, meter_254:measured_reactive_power, meter_255:measured_reactive_power, meter_256:measured_reactive_power, meter_257:measured_reactive_power, meter_258:measured_reactive_power, meter_259:measured_reactive_power, meter_260:measured_reactive_power, meter_261:measured_reactive_power, meter_262:measured_reactive_power, meter_263:measured_reactive_power, meter_264:measured_reactive_power, meter_265:measured_reactive_power, meter_266:measured_reactive_power, meter_267:measured_reactive_power, meter_268:measured_reactive_power, meter_269:measured_reactive_power, meter_270:measured_reactive_power;
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_271:measured_reactive_power, meter_272:measured_reactive_power, meter_273:measured_reactive_power, meter_274:measured_reactive_power, meter_275:measured_reactive_power, meter_276:measured_reactive_power, meter_277:measured_reactive_power, meter_278:measured_reactive_power, meter_279:measured_reactive_power, meter_280:measured_reactive_power, meter_281:measured_reactive_power, meter_282:measured_reactive_power, meter_283:measured_reactive_power, meter_284:measured_reactive_power, meter_285:measured_reactive_power, meter_286:measured_reactive_power, meter_287:measured_reactive_power, meter_288:measured_reactive_power, meter_289:measured_reactive_power, meter_290:measured_reactive_power, meter_291:measured_reactive_power, meter_292:measured_reactive_power, meter_293:measured_reactive_power, meter_294:measured_reactive_power, meter_295:measured_reactive_power, meter_296:measured_reactive_power, meter_297:measured_reactive_power, meter_298:measured_reactive_power, meter_299:measured_reactive_power;
-	file "model/output/power_dump_26.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_300:measured_reactive_power, meter_301:measured_reactive_power, meter_302:measured_reactive_power, meter_303:measured_reactive_power, meter_304:measured_reactive_power, meter_305:measured_reactive_power, meter_306:measured_reactive_power, meter_307:measured_reactive_power, meter_308:measured_reactive_power, meter_309:measured_reactive_power, meter_310:measured_reactive_power, meter_311:measured_reactive_power, meter_312:measured_reactive_power, meter_313:measured_reactive_power, meter_314:measured_reactive_power, meter_315:measured_reactive_power, meter_316:measured_reactive_power, meter_317:measured_reactive_power, meter_318:measured_reactive_power, meter_319:measured_reactive_power, meter_320:measured_reactive_power, meter_321:measured_reactive_power, meter_322:measured_reactive_power, meter_323:measured_reactive_power, meter_324:measured_reactive_power, meter_325:measured_reactive_power, meter_326:measured_reactive_power, meter_327:measured_reactive_power, meter_328:measured_reactive_power;
-	file "model/output/power_dump_27.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_329:measured_reactive_power, meter_330:measured_reactive_power, meter_331:measured_reactive_power, meter_332:measured_reactive_power, meter_333:measured_reactive_power, meter_334:measured_reactive_power, meter_335:measured_reactive_power, meter_336:measured_reactive_power, meter_337:measured_reactive_power, meter_338:measured_reactive_power, meter_339:measured_reactive_power, meter_340:measured_reactive_power, meter_341:measured_reactive_power, meter_342:measured_reactive_power, meter_343:measured_reactive_power, meter_344:measured_reactive_power;
-	file "model/output/power_dump_28.csv";
-	interval -1;
-}
-
-#endif //VOLT_POWERDUMP
-//script on_commit "python volt_dump.py"

--- a/models/ieee123/model/library/control.glm
+++ b/models/ieee123/model/library/control.glm
@@ -27,8 +27,7 @@ object switch_coordinator {
 	connect sw300to350;
 	connect sw450to451;
 	connect sw95to195;
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_SCADA
+#if MYSQL_SCADA==on
 	object recorder {
 		connection scada;
 		table control;
@@ -36,7 +35,6 @@ object switch_coordinator {
 		interval -1;
 		header_fieldnames "name";
 	};
-#endif
 #endif
 }
 

--- a/models/ieee123/model/library/house.glm
+++ b/models/ieee123/model/library/house.glm
@@ -23,7 +23,7 @@
 //
  
 // connect dynamics load
-#ifdef LOADS
+#if LOADS==on
 #debug Converting area ${AREA} static load ${LOADID} phase ${PHASE} to ${COUNT} houses
 modify load_${LOADID}.groupid area_${AREA};
 modify load_${LOADID}.constant_power_${PHASE} 0+0j;	
@@ -31,8 +31,7 @@ modify load_${LOADID}.constant_current_${PHASE} 0+0j;
 modify load_${LOADID}.constant_impedance_${PHASE} 0+0j;	
 #define XLOAD=yes
 #else
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_AMI
+#if MYSQL_AMI==on
 object recorder {
 	parent load_${LOADID};
 	connection ami;
@@ -42,11 +41,10 @@ object recorder {
 	header_fieldnames "name";
 };
 #endif // MYSQL_AMI
-#endif // MYSQL_ENABLE
 #endif // LOADS
 
 // add solar panel installation rank
-#ifdef SOLAR
+#if SOLAR==on
 #ifndef XLOAD
 #define XLOAD=yes
 #endif // XLOAD
@@ -85,8 +83,7 @@ object triplex_meter:..${COUNT} {
 		name `house_{SEQ_CUSTID}`;
 	}; 
 #endif // LOADS
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_AMI
+#if MYSQL_AMI==on
 	object recorder {
 		connection ami;
 		table meter;
@@ -95,8 +92,7 @@ object triplex_meter:..${COUNT} {
 		header_fieldnames "name,groupid";
 	};
 #endif // MYSQL_AMI
-#endif // MYSQL_ENABLE
-#ifdef SOLAR
+#if SOLAR==on
 	object inverter {
 		name `inverter_{SEQ_CUSTID}`;
 		phases ${PHASE}S;
@@ -121,7 +117,6 @@ object triplex_meter:..${COUNT} {
 #endif // PVPROB
 			generator_mode SUPPLY_DRIVEN;
 			panel_type SINGLE_CRYSTAL_SILICON;
-#ifdef MYSQL_ENABLE
 #ifdef MYSQL_AMI
 			object recorder {
 				connection ami;
@@ -131,10 +126,8 @@ object triplex_meter:..${COUNT} {
 				header_fieldnames "name";
 			};
 #endif // MYSQL_AMI
-#endif // MYSQL_ENABLE
 		};
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_AMI
+#if MYSQL_AMI==on
 		object recorder {
 			connection ami;
 			table inverter;
@@ -143,7 +136,6 @@ object triplex_meter:..${COUNT} {
 			header_fieldnames "name";
 		};
 #endif // MYSQL_AMI
-#endif // MYSQL_ENABLE
 	};
 #endif // SOLAR
 }

--- a/models/ieee123/model/library/sensors.glm
+++ b/models/ieee123/model/library/sensors.glm
@@ -12,8 +12,7 @@ object line_sensor {
 	parent line13to18;
 	measured_phase ${PHASE};
 	location 200 ft;
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_SCADA
+#if MYSQL_SCADA==on
 	object recorder {
 	        connection scada;
 	        table sensor;
@@ -21,7 +20,6 @@ object line_sensor {
 	        interval 4;
 	        header_fieldnames "name";
 	};
-#endif
 #endif
 }
 object line_sensor {
@@ -29,8 +27,7 @@ object line_sensor {
 	parent line51to151;
 	measured_phase ${PHASE};
 	location 250 ft;
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_SCADA
+#if MYSQL_SCADA==on
 	object recorder {
 	        connection scada;
 	        table sensor;
@@ -38,7 +35,6 @@ object line_sensor {
 	        interval 4;
 	        header_fieldnames "name";
 	};
-#endif
 #endif
 }
 object line_sensor {
@@ -46,8 +42,7 @@ object line_sensor {
 	parent line57to60;
 	measured_phase ${PHASE};
 	location 700 ft;
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_SCADA;
+#if MYSQL_SCADA==on
 	object recorder {
 	        connection scada;
 	        table sensor;
@@ -55,7 +50,6 @@ object line_sensor {
 	        interval 4;
 	        header_fieldnames "name";
 	};
-#endif
 #endif
 }
 object line_sensor {
@@ -63,8 +57,7 @@ object line_sensor {
 	parent line67to97;
 	measured_phase ${PHASE};
 	location 50 ft;
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_SCADA
+#if MYSQL_SCADA==on
 	object recorder {
 	        connection scada;
 	        table sensor;
@@ -72,7 +65,6 @@ object line_sensor {
 	        interval 4;
 	        header_fieldnames "name";
 	};
-#endif
 #endif
 }
 object line_sensor {
@@ -80,8 +72,7 @@ object line_sensor {
 	parent line76to86;
 	measured_phase ${PHASE};
 	location 350 ft;
-#ifdef MYSQL_ENABLE
-#ifdef MYSQL_SCADA
+#if MYSQL_SCADA==on
 	object recorder {
 	        connection scada;
 	        table sensor;
@@ -89,7 +80,6 @@ object line_sensor {
 	        interval 4;
 	        header_fieldnames "name";
 	};
-#endif
 #endif
 }
 

--- a/models/ieee123/model/library/voltdump.glm
+++ b/models/ieee123/model/library/voltdump.glm
@@ -1,4 +1,4 @@
-script on_term "python3 voltdump.py";
+script on_term "python voltdump.py";
 
 object voltdump {
 	filemode "a";
@@ -7,7 +7,9 @@ object voltdump {
 	filename "output/volt_dump.csv";
 	on_init "mkdir -p output; rm -rf output/power_dump_*.csv output/volt_dump.csv";
 }
-module tape;
+module tape {
+	flush_interval 0;
+}
 
 object multi_recorder {
 	property substation_meter:measured_power, meter_1:measured_power, meter_2:measured_power, meter_3:measured_power, meter_4:measured_power, meter_5:measured_power, meter_6:measured_power, meter_7:measured_power, meter_8:measured_power, meter_9:measured_power, meter_10:measured_power, meter_11:measured_power, meter_12:measured_power, meter_13:measured_power, meter_14:measured_power, meter_15:measured_power, meter_16:measured_power, meter_17:measured_power, meter_18:measured_power, meter_19:measured_power, meter_20:measured_power, meter_21:measured_power, meter_22:measured_power, meter_23:measured_power, meter_24:measured_power, meter_25:measured_power, meter_26:measured_power, meter_27:measured_power, meter_28:measured_power, meter_29:measured_power, meter_30:measured_power;

--- a/models/ieee123/model/library/voltdump.glm
+++ b/models/ieee123/model/library/voltdump.glm
@@ -1,0 +1,179 @@
+script on_term "python3 voltdump.py";
+
+object voltdump {
+	filemode "a";
+	runtime TS_NEVER;
+	maxcount 3000;
+	filename "output/volt_dump.csv";
+	on_init "mkdir -p output; rm -rf output/power_dump_*.csv output/volt_dump.csv";
+}
+module tape;
+
+object multi_recorder {
+	property substation_meter:measured_real_power, meter_1:measured_real_power, meter_2:measured_real_power, meter_3:measured_real_power, meter_4:measured_real_power, meter_5:measured_real_power, meter_6:measured_real_power, meter_7:measured_real_power, meter_8:measured_real_power, meter_9:measured_real_power, meter_10:measured_real_power, meter_11:measured_real_power, meter_12:measured_real_power, meter_13:measured_real_power, meter_14:measured_real_power, meter_15:measured_real_power, meter_16:measured_real_power, meter_17:measured_real_power, meter_18:measured_real_power, meter_19:measured_real_power, meter_20:measured_real_power, meter_21:measured_real_power, meter_22:measured_real_power, meter_23:measured_real_power, meter_24:measured_real_power, meter_25:measured_real_power, meter_26:measured_real_power, meter_27:measured_real_power, meter_28:measured_real_power, meter_29:measured_real_power, meter_30:measured_real_power;
+	file "output/power_dump_1.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_31:measured_real_power, meter_32:measured_real_power, meter_33:measured_real_power, meter_34:measured_real_power, meter_35:measured_real_power, meter_36:measured_real_power, meter_37:measured_real_power, meter_38:measured_real_power, meter_39:measured_real_power, meter_40:measured_real_power, meter_41:measured_real_power, meter_42:measured_real_power, meter_43:measured_real_power, meter_44:measured_real_power, meter_45:measured_real_power, meter_46:measured_real_power, meter_47:measured_real_power, meter_48:measured_real_power, meter_49:measured_real_power, meter_50:measured_real_power, meter_51:measured_real_power, meter_52:measured_real_power, meter_53:measured_real_power, meter_54:measured_real_power, meter_55:measured_real_power, meter_56:measured_real_power, meter_57:measured_real_power, meter_58:measured_real_power, meter_59:measured_real_power, meter_60:measured_real_power;
+	file "output/power_dump_2.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_61:measured_real_power, meter_62:measured_real_power, meter_63:measured_real_power, meter_64:measured_real_power, meter_65:measured_real_power, meter_66:measured_real_power, meter_67:measured_real_power, meter_68:measured_real_power, meter_69:measured_real_power, meter_70:measured_real_power, meter_71:measured_real_power, meter_72:measured_real_power, meter_73:measured_real_power, meter_74:measured_real_power, meter_75:measured_real_power, meter_76:measured_real_power, meter_77:measured_real_power, meter_78:measured_real_power, meter_79:measured_real_power, meter_80:measured_real_power, meter_81:measured_real_power, meter_82:measured_real_power, meter_83:measured_real_power, meter_84:measured_real_power, meter_85:measured_real_power, meter_86:measured_real_power, meter_87:measured_real_power, meter_88:measured_real_power, meter_89:measured_real_power, meter_90:measured_real_power;
+	file "output/power_dump_3.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_91:measured_real_power, meter_92:measured_real_power, meter_93:measured_real_power, meter_94:measured_real_power, meter_95:measured_real_power, meter_96:measured_real_power, meter_97:measured_real_power, meter_98:measured_real_power, meter_99:measured_real_power, meter_100:measured_real_power, meter_101:measured_real_power, meter_102:measured_real_power, meter_103:measured_real_power, meter_104:measured_real_power, meter_105:measured_real_power, meter_106:measured_real_power, meter_107:measured_real_power, meter_108:measured_real_power, meter_109:measured_real_power, meter_110:measured_real_power, meter_111:measured_real_power, meter_112:measured_real_power, meter_113:measured_real_power, meter_114:measured_real_power, meter_115:measured_real_power, meter_116:measured_real_power, meter_117:measured_real_power, meter_118:measured_real_power, meter_119:measured_real_power, meter_120:measured_real_power;
+	file "output/power_dump_4.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_121:measured_real_power, meter_122:measured_real_power, meter_123:measured_real_power, meter_124:measured_real_power, meter_125:measured_real_power, meter_126:measured_real_power, meter_127:measured_real_power, meter_128:measured_real_power, meter_129:measured_real_power, meter_130:measured_real_power, meter_131:measured_real_power, meter_132:measured_real_power, meter_133:measured_real_power, meter_134:measured_real_power, meter_135:measured_real_power, meter_136:measured_real_power, meter_137:measured_real_power, meter_138:measured_real_power, meter_139:measured_real_power, meter_140:measured_real_power, meter_141:measured_real_power, meter_142:measured_real_power, meter_143:measured_real_power, meter_144:measured_real_power, meter_145:measured_real_power, meter_146:measured_real_power, meter_147:measured_real_power, meter_148:measured_real_power, meter_149:measured_real_power, meter_150:measured_real_power;
+	file "output/power_dump_5.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_151:measured_real_power, meter_152:measured_real_power, meter_153:measured_real_power, meter_154:measured_real_power, meter_155:measured_real_power, meter_156:measured_real_power, meter_157:measured_real_power, meter_158:measured_real_power, meter_159:measured_real_power, meter_160:measured_real_power, meter_161:measured_real_power, meter_162:measured_real_power, meter_163:measured_real_power, meter_164:measured_real_power, meter_165:measured_real_power, meter_166:measured_real_power, meter_167:measured_real_power, meter_168:measured_real_power, meter_169:measured_real_power, meter_170:measured_real_power, meter_171:measured_real_power, meter_172:measured_real_power, meter_173:measured_real_power, meter_174:measured_real_power, meter_175:measured_real_power, meter_176:measured_real_power, meter_177:measured_real_power, meter_178:measured_real_power, meter_179:measured_real_power, meter_180:measured_real_power;
+	file "output/power_dump_6.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_181:measured_real_power, meter_182:measured_real_power, meter_183:measured_real_power, meter_184:measured_real_power, meter_185:measured_real_power, meter_186:measured_real_power, meter_187:measured_real_power, meter_188:measured_real_power, meter_189:measured_real_power, meter_190:measured_real_power, meter_191:measured_real_power, meter_192:measured_real_power, meter_193:measured_real_power, meter_194:measured_real_power, meter_195:measured_real_power, meter_196:measured_real_power, meter_197:measured_real_power, meter_198:measured_real_power, meter_199:measured_real_power, meter_200:measured_real_power, meter_201:measured_real_power, meter_202:measured_real_power, meter_203:measured_real_power, meter_204:measured_real_power, meter_205:measured_real_power, meter_206:measured_real_power, meter_207:measured_real_power, meter_208:measured_real_power, meter_209:measured_real_power, meter_210:measured_real_power;
+	file "output/power_dump_7.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_211:measured_real_power, meter_212:measured_real_power, meter_213:measured_real_power, meter_214:measured_real_power, meter_215:measured_real_power, meter_216:measured_real_power, meter_217:measured_real_power, meter_218:measured_real_power, meter_219:measured_real_power, meter_220:measured_real_power, meter_221:measured_real_power, meter_222:measured_real_power, meter_223:measured_real_power, meter_224:measured_real_power, meter_225:measured_real_power, meter_226:measured_real_power, meter_227:measured_real_power, meter_228:measured_real_power, meter_229:measured_real_power, meter_230:measured_real_power, meter_231:measured_real_power, meter_232:measured_real_power, meter_233:measured_real_power, meter_234:measured_real_power, meter_235:measured_real_power, meter_236:measured_real_power, meter_237:measured_real_power, meter_238:measured_real_power, meter_239:measured_real_power, meter_240:measured_real_power;
+	file "output/power_dump_8.csv";
+	interval -1;
+}
+object multi_recorder {
+	file "output/power_dump_9.csv";
+	property meter_241:measured_real_power, meter_242:measured_real_power, meter_243:measured_real_power, meter_244:measured_real_power, meter_245:measured_real_power, meter_246:measured_real_power, meter_247:measured_real_power, meter_248:measured_real_power, meter_249:measured_real_power, meter_250:measured_real_power, meter_251:measured_real_power, meter_252:measured_real_power, meter_253:measured_real_power, meter_254:measured_real_power, meter_255:measured_real_power, meter_256:measured_real_power, meter_257:measured_real_power, meter_258:measured_real_power, meter_259:measured_real_power, meter_260:measured_real_power, meter_261:measured_real_power, meter_262:measured_real_power, meter_263:measured_real_power, meter_264:measured_real_power, meter_265:measured_real_power, meter_266:measured_real_power, meter_267:measured_real_power, meter_268:measured_real_power, meter_269:measured_real_power, meter_270:measured_real_power;
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_271:measured_real_power, meter_272:measured_real_power, meter_273:measured_real_power, meter_274:measured_real_power, meter_275:measured_real_power, meter_276:measured_real_power, meter_277:measured_real_power, meter_278:measured_real_power, meter_279:measured_real_power, meter_280:measured_real_power, meter_281:measured_real_power, meter_282:measured_real_power, meter_283:measured_real_power, meter_284:measured_real_power, meter_285:measured_real_power, meter_286:measured_real_power, meter_287:measured_real_power, meter_288:measured_real_power, meter_289:measured_real_power, meter_290:measured_real_power, meter_291:measured_real_power, meter_292:measured_real_power, meter_293:measured_real_power, meter_294:measured_real_power, meter_295:measured_real_power, meter_296:measured_real_power, meter_297:measured_real_power, meter_298:measured_real_power, meter_299:measured_real_power, meter_300:measured_real_power;
+	file "output/power_dump_10.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_301:measured_real_power, meter_302:measured_real_power, meter_303:measured_real_power, meter_304:measured_real_power, meter_305:measured_real_power, meter_306:measured_real_power, meter_307:measured_real_power, meter_308:measured_real_power, meter_309:measured_real_power, meter_310:measured_real_power, meter_311:measured_real_power, meter_312:measured_real_power, meter_313:measured_real_power, meter_314:measured_real_power, meter_315:measured_real_power, meter_316:measured_real_power, meter_317:measured_real_power, meter_318:measured_real_power, meter_319:measured_real_power, meter_320:measured_real_power, meter_321:measured_real_power, meter_322:measured_real_power, meter_323:measured_real_power, meter_324:measured_real_power, meter_325:measured_real_power, meter_326:measured_real_power, meter_327:measured_real_power, meter_328:measured_real_power, meter_329:measured_real_power, meter_330:measured_real_power;
+	file "output/power_dump_11.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_331:measured_real_power, meter_332:measured_real_power, meter_333:measured_real_power, meter_334:measured_real_power, meter_335:measured_real_power, meter_336:measured_real_power, meter_337:measured_real_power, meter_338:measured_real_power, meter_339:measured_real_power, meter_340:measured_real_power, meter_341:measured_real_power, meter_342:measured_real_power, meter_343:measured_real_power, meter_344:measured_real_power;
+	file "output/power_dump_12.csv";
+	interval -1;
+}
+
+//reactive power recordings 
+
+object multi_recorder {
+	property substation_meter:measured_reactive_power, meter_1:measured_reactive_power, meter_2:measured_reactive_power, meter_3:measured_reactive_power, meter_4:measured_reactive_power, meter_5:measured_reactive_power, meter_6:measured_reactive_power, meter_7:measured_reactive_power, meter_8:measured_reactive_power, meter_9:measured_reactive_power, meter_10:measured_reactive_power, meter_11:measured_reactive_power, meter_12:measured_reactive_power, meter_13:measured_reactive_power, meter_14:measured_reactive_power, meter_15:measured_reactive_power, meter_16:measured_reactive_power, meter_17:measured_reactive_power, meter_18:measured_reactive_power, meter_19:measured_reactive_power, meter_20:measured_reactive_power, meter_21:measured_reactive_power, meter_22:measured_reactive_power, meter_23:measured_reactive_power, meter_24:measured_reactive_power;
+	file "output/power_dump_13.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_25:measured_reactive_power, meter_26:measured_reactive_power, meter_27:measured_reactive_power, meter_28:measured_reactive_power, meter_29:measured_reactive_power, meter_30:measured_reactive_power;
+	file "output/power_dump_14.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_31:measured_reactive_power, meter_32:measured_reactive_power, meter_33:measured_reactive_power, meter_34:measured_reactive_power, meter_35:measured_reactive_power, meter_36:measured_reactive_power, meter_37:measured_reactive_power, meter_38:measured_reactive_power, meter_39:measured_reactive_power, meter_40:measured_reactive_power, meter_41:measured_reactive_power, meter_42:measured_reactive_power, meter_43:measured_reactive_power, meter_44:measured_reactive_power, meter_45:measured_reactive_power, meter_46:measured_reactive_power, meter_47:measured_reactive_power, meter_48:measured_reactive_power, meter_49:measured_reactive_power, meter_50:measured_reactive_power, meter_51:measured_reactive_power, meter_52:measured_reactive_power, meter_53:measured_reactive_power, meter_54:measured_reactive_power, meter_55:measured_reactive_power, meter_56:measured_reactive_power, meter_57:measured_reactive_power, meter_58:measured_reactive_power, meter_59:measured_reactive_power, meter_60:measured_reactive_power;
+	file "output/power_dump_15.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_61:measured_reactive_power, meter_62:measured_reactive_power, meter_63:measured_reactive_power, meter_64:measured_reactive_power, meter_65:measured_reactive_power, meter_66:measured_reactive_power, meter_67:measured_reactive_power, meter_68:measured_reactive_power, meter_69:measured_reactive_power, meter_70:measured_reactive_power, meter_71:measured_reactive_power, meter_72:measured_reactive_power, meter_73:measured_reactive_power, meter_74:measured_reactive_power, meter_75:measured_reactive_power, meter_76:measured_reactive_power, meter_77:measured_reactive_power, meter_78:measured_reactive_power, meter_79:measured_reactive_power, meter_80:measured_reactive_power, meter_81:measured_reactive_power, meter_82:measured_reactive_power, meter_83:measured_reactive_power, meter_84:measured_reactive_power, meter_85:measured_reactive_power, meter_86:measured_reactive_power, meter_87:measured_reactive_power, meter_88:measured_reactive_power, meter_89:measured_reactive_power, meter_90:measured_reactive_power;
+	file "output/power_dump_16.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_91:measured_reactive_power, meter_92:measured_reactive_power, meter_93:measured_reactive_power, meter_94:measured_reactive_power, meter_95:measured_reactive_power, meter_96:measured_reactive_power, meter_97:measured_reactive_power, meter_98:measured_reactive_power, meter_99:measured_reactive_power, meter_100:measured_reactive_power, meter_101:measured_reactive_power, meter_102:measured_reactive_power, meter_103:measured_reactive_power, meter_104:measured_reactive_power, meter_105:measured_reactive_power, meter_106:measured_reactive_power, meter_107:measured_reactive_power, meter_108:measured_reactive_power, meter_109:measured_reactive_power, meter_110:measured_reactive_power, meter_111:measured_reactive_power, meter_112:measured_reactive_power, meter_113:measured_reactive_power, meter_114:measured_reactive_power;
+	file "output/power_dump_17.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_115:measured_reactive_power, meter_116:measured_reactive_power, meter_117:measured_reactive_power, meter_118:measured_reactive_power, meter_119:measured_reactive_power, meter_120:measured_reactive_power, meter_121:measured_reactive_power, meter_122:measured_reactive_power, meter_123:measured_reactive_power, meter_124:measured_reactive_power, meter_125:measured_reactive_power;
+	file "output/power_dump_18.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_126:measured_reactive_power, meter_127:measured_reactive_power, meter_128:measured_reactive_power, meter_129:measured_reactive_power, meter_130:measured_reactive_power, meter_131:measured_reactive_power, meter_132:measured_reactive_power, meter_133:measured_reactive_power, meter_134:measured_reactive_power, meter_135:measured_reactive_power, meter_136:measured_reactive_power, meter_137:measured_reactive_power, meter_138:measured_reactive_power, meter_139:measured_reactive_power, meter_140:measured_reactive_power, meter_141:measured_reactive_power, meter_142:measured_reactive_power, meter_143:measured_reactive_power, meter_144:measured_reactive_power, meter_145:measured_reactive_power, meter_146:measured_reactive_power, meter_147:measured_reactive_power, meter_148:measured_reactive_power, meter_149:measured_reactive_power, meter_150:measured_reactive_power;
+	file "output/power_dump_19.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_151:measured_reactive_power, meter_152:measured_reactive_power, meter_153:measured_reactive_power, meter_154:measured_reactive_power, meter_155:measured_reactive_power, meter_156:measured_reactive_power, meter_157:measured_reactive_power, meter_158:measured_reactive_power, meter_159:measured_reactive_power, meter_160:measured_reactive_power, meter_161:measured_reactive_power, meter_162:measured_reactive_power, meter_163:measured_reactive_power, meter_164:measured_reactive_power, meter_165:measured_reactive_power, meter_166:measured_reactive_power, meter_167:measured_reactive_power, meter_168:measured_reactive_power, meter_169:measured_reactive_power, meter_170:measured_reactive_power, meter_171:measured_reactive_power, meter_172:measured_reactive_power, meter_173:measured_reactive_power, meter_174:measured_reactive_power, meter_175:measured_reactive_power;
+	file "output/power_dump_20.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_176:measured_reactive_power, meter_177:measured_reactive_power, meter_178:measured_reactive_power, meter_179:measured_reactive_power, meter_180:measured_reactive_power, meter_181:measured_reactive_power, meter_182:measured_reactive_power, meter_183:measured_reactive_power, meter_184:measured_reactive_power;
+	file "output/power_dump_21.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_185:measured_reactive_power, meter_186:measured_reactive_power, meter_187:measured_reactive_power, meter_188:measured_reactive_power, meter_189:measured_reactive_power, meter_190:measured_reactive_power, meter_191:measured_reactive_power, meter_192:measured_reactive_power, meter_193:measured_reactive_power, meter_194:measured_reactive_power, meter_195:measured_reactive_power, meter_196:measured_reactive_power, meter_197:measured_reactive_power, meter_198:measured_reactive_power, meter_199:measured_reactive_power, meter_200:measured_reactive_power, meter_201:measured_reactive_power, meter_202:measured_reactive_power, meter_203:measured_reactive_power, meter_204:measured_reactive_power, meter_205:measured_reactive_power, meter_206:measured_reactive_power, meter_207:measured_reactive_power, meter_208:measured_reactive_power, meter_209:measured_reactive_power, meter_210:measured_reactive_power;
+	file "output/power_dump_22.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_211:measured_reactive_power, meter_212:measured_reactive_power, meter_213:measured_reactive_power, meter_214:measured_reactive_power, meter_215:measured_reactive_power, meter_216:measured_reactive_power, meter_217:measured_reactive_power, meter_218:measured_reactive_power, meter_219:measured_reactive_power, meter_220:measured_reactive_power, meter_221:measured_reactive_power, meter_222:measured_reactive_power, meter_223:measured_reactive_power, meter_224:measured_reactive_power, meter_225:measured_reactive_power, meter_226:measured_reactive_power, meter_227:measured_reactive_power, meter_228:measured_reactive_power, meter_229:measured_reactive_power, meter_230:measured_reactive_power, meter_231:measured_reactive_power, meter_232:measured_reactive_power, meter_233:measured_reactive_power, meter_234:measured_reactive_power, meter_235:measured_reactive_power;
+	file "output/power_dump_23.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_236:measured_reactive_power, meter_237:measured_reactive_power, meter_238:measured_reactive_power, meter_239:measured_reactive_power, meter_240:measured_reactive_power, meter_241:measured_reactive_power, meter_242:measured_reactive_power, meter_243:measured_reactive_power, meter_244:measured_reactive_power;
+	file "output/power_dump_24.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	file "output/power_dump_25.csv";
+	property meter_245:measured_reactive_power, meter_246:measured_reactive_power, meter_247:measured_reactive_power, meter_248:measured_reactive_power, meter_249:measured_reactive_power, meter_250:measured_reactive_power, meter_251:measured_reactive_power, meter_252:measured_reactive_power, meter_253:measured_reactive_power, meter_254:measured_reactive_power, meter_255:measured_reactive_power, meter_256:measured_reactive_power, meter_257:measured_reactive_power, meter_258:measured_reactive_power, meter_259:measured_reactive_power, meter_260:measured_reactive_power, meter_261:measured_reactive_power, meter_262:measured_reactive_power, meter_263:measured_reactive_power, meter_264:measured_reactive_power, meter_265:measured_reactive_power, meter_266:measured_reactive_power, meter_267:measured_reactive_power, meter_268:measured_reactive_power, meter_269:measured_reactive_power, meter_270:measured_reactive_power;
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_271:measured_reactive_power, meter_272:measured_reactive_power, meter_273:measured_reactive_power, meter_274:measured_reactive_power, meter_275:measured_reactive_power, meter_276:measured_reactive_power, meter_277:measured_reactive_power, meter_278:measured_reactive_power, meter_279:measured_reactive_power, meter_280:measured_reactive_power, meter_281:measured_reactive_power, meter_282:measured_reactive_power, meter_283:measured_reactive_power, meter_284:measured_reactive_power, meter_285:measured_reactive_power, meter_286:measured_reactive_power, meter_287:measured_reactive_power, meter_288:measured_reactive_power, meter_289:measured_reactive_power, meter_290:measured_reactive_power, meter_291:measured_reactive_power, meter_292:measured_reactive_power, meter_293:measured_reactive_power, meter_294:measured_reactive_power, meter_295:measured_reactive_power, meter_296:measured_reactive_power, meter_297:measured_reactive_power, meter_298:measured_reactive_power, meter_299:measured_reactive_power;
+	file "output/power_dump_26.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_300:measured_reactive_power, meter_301:measured_reactive_power, meter_302:measured_reactive_power, meter_303:measured_reactive_power, meter_304:measured_reactive_power, meter_305:measured_reactive_power, meter_306:measured_reactive_power, meter_307:measured_reactive_power, meter_308:measured_reactive_power, meter_309:measured_reactive_power, meter_310:measured_reactive_power, meter_311:measured_reactive_power, meter_312:measured_reactive_power, meter_313:measured_reactive_power, meter_314:measured_reactive_power, meter_315:measured_reactive_power, meter_316:measured_reactive_power, meter_317:measured_reactive_power, meter_318:measured_reactive_power, meter_319:measured_reactive_power, meter_320:measured_reactive_power, meter_321:measured_reactive_power, meter_322:measured_reactive_power, meter_323:measured_reactive_power, meter_324:measured_reactive_power, meter_325:measured_reactive_power, meter_326:measured_reactive_power, meter_327:measured_reactive_power, meter_328:measured_reactive_power;
+	file "output/power_dump_27.csv";
+	interval -1;
+}
+
+object multi_recorder {
+	property meter_329:measured_reactive_power, meter_330:measured_reactive_power, meter_331:measured_reactive_power, meter_332:measured_reactive_power, meter_333:measured_reactive_power, meter_334:measured_reactive_power, meter_335:measured_reactive_power, meter_336:measured_reactive_power, meter_337:measured_reactive_power, meter_338:measured_reactive_power, meter_339:measured_reactive_power, meter_340:measured_reactive_power, meter_341:measured_reactive_power, meter_342:measured_reactive_power, meter_343:measured_reactive_power, meter_344:measured_reactive_power;
+	file "output/power_dump_28.csv";
+	interval -1;
+}

--- a/models/ieee123/model/library/voltdump.glm
+++ b/models/ieee123/model/library/voltdump.glm
@@ -10,170 +10,72 @@ object voltdump {
 module tape;
 
 object multi_recorder {
-	property substation_meter:measured_real_power, meter_1:measured_real_power, meter_2:measured_real_power, meter_3:measured_real_power, meter_4:measured_real_power, meter_5:measured_real_power, meter_6:measured_real_power, meter_7:measured_real_power, meter_8:measured_real_power, meter_9:measured_real_power, meter_10:measured_real_power, meter_11:measured_real_power, meter_12:measured_real_power, meter_13:measured_real_power, meter_14:measured_real_power, meter_15:measured_real_power, meter_16:measured_real_power, meter_17:measured_real_power, meter_18:measured_real_power, meter_19:measured_real_power, meter_20:measured_real_power, meter_21:measured_real_power, meter_22:measured_real_power, meter_23:measured_real_power, meter_24:measured_real_power, meter_25:measured_real_power, meter_26:measured_real_power, meter_27:measured_real_power, meter_28:measured_real_power, meter_29:measured_real_power, meter_30:measured_real_power;
+	property substation_meter:measured_power, meter_1:measured_power, meter_2:measured_power, meter_3:measured_power, meter_4:measured_power, meter_5:measured_power, meter_6:measured_power, meter_7:measured_power, meter_8:measured_power, meter_9:measured_power, meter_10:measured_power, meter_11:measured_power, meter_12:measured_power, meter_13:measured_power, meter_14:measured_power, meter_15:measured_power, meter_16:measured_power, meter_17:measured_power, meter_18:measured_power, meter_19:measured_power, meter_20:measured_power, meter_21:measured_power, meter_22:measured_power, meter_23:measured_power, meter_24:measured_power, meter_25:measured_power, meter_26:measured_power, meter_27:measured_power, meter_28:measured_power, meter_29:measured_power, meter_30:measured_power;
 	file "output/power_dump_1.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_31:measured_real_power, meter_32:measured_real_power, meter_33:measured_real_power, meter_34:measured_real_power, meter_35:measured_real_power, meter_36:measured_real_power, meter_37:measured_real_power, meter_38:measured_real_power, meter_39:measured_real_power, meter_40:measured_real_power, meter_41:measured_real_power, meter_42:measured_real_power, meter_43:measured_real_power, meter_44:measured_real_power, meter_45:measured_real_power, meter_46:measured_real_power, meter_47:measured_real_power, meter_48:measured_real_power, meter_49:measured_real_power, meter_50:measured_real_power, meter_51:measured_real_power, meter_52:measured_real_power, meter_53:measured_real_power, meter_54:measured_real_power, meter_55:measured_real_power, meter_56:measured_real_power, meter_57:measured_real_power, meter_58:measured_real_power, meter_59:measured_real_power, meter_60:measured_real_power;
+	property meter_31:measured_power, meter_32:measured_power, meter_33:measured_power, meter_34:measured_power, meter_35:measured_power, meter_36:measured_power, meter_37:measured_power, meter_38:measured_power, meter_39:measured_power, meter_40:measured_power, meter_41:measured_power, meter_42:measured_power, meter_43:measured_power, meter_44:measured_power, meter_45:measured_power, meter_46:measured_power, meter_47:measured_power, meter_48:measured_power, meter_49:measured_power, meter_50:measured_power, meter_51:measured_power, meter_52:measured_power, meter_53:measured_power, meter_54:measured_power, meter_55:measured_power, meter_56:measured_power, meter_57:measured_power, meter_58:measured_power, meter_59:measured_power, meter_60:measured_power;
 	file "output/power_dump_2.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_61:measured_real_power, meter_62:measured_real_power, meter_63:measured_real_power, meter_64:measured_real_power, meter_65:measured_real_power, meter_66:measured_real_power, meter_67:measured_real_power, meter_68:measured_real_power, meter_69:measured_real_power, meter_70:measured_real_power, meter_71:measured_real_power, meter_72:measured_real_power, meter_73:measured_real_power, meter_74:measured_real_power, meter_75:measured_real_power, meter_76:measured_real_power, meter_77:measured_real_power, meter_78:measured_real_power, meter_79:measured_real_power, meter_80:measured_real_power, meter_81:measured_real_power, meter_82:measured_real_power, meter_83:measured_real_power, meter_84:measured_real_power, meter_85:measured_real_power, meter_86:measured_real_power, meter_87:measured_real_power, meter_88:measured_real_power, meter_89:measured_real_power, meter_90:measured_real_power;
+	property meter_61:measured_power, meter_62:measured_power, meter_63:measured_power, meter_64:measured_power, meter_65:measured_power, meter_66:measured_power, meter_67:measured_power, meter_68:measured_power, meter_69:measured_power, meter_70:measured_power, meter_71:measured_power, meter_72:measured_power, meter_73:measured_power, meter_74:measured_power, meter_75:measured_power, meter_76:measured_power, meter_77:measured_power, meter_78:measured_power, meter_79:measured_power, meter_80:measured_power, meter_81:measured_power, meter_82:measured_power, meter_83:measured_power, meter_84:measured_power, meter_85:measured_power, meter_86:measured_power, meter_87:measured_power, meter_88:measured_power, meter_89:measured_power, meter_90:measured_power;
 	file "output/power_dump_3.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_91:measured_real_power, meter_92:measured_real_power, meter_93:measured_real_power, meter_94:measured_real_power, meter_95:measured_real_power, meter_96:measured_real_power, meter_97:measured_real_power, meter_98:measured_real_power, meter_99:measured_real_power, meter_100:measured_real_power, meter_101:measured_real_power, meter_102:measured_real_power, meter_103:measured_real_power, meter_104:measured_real_power, meter_105:measured_real_power, meter_106:measured_real_power, meter_107:measured_real_power, meter_108:measured_real_power, meter_109:measured_real_power, meter_110:measured_real_power, meter_111:measured_real_power, meter_112:measured_real_power, meter_113:measured_real_power, meter_114:measured_real_power, meter_115:measured_real_power, meter_116:measured_real_power, meter_117:measured_real_power, meter_118:measured_real_power, meter_119:measured_real_power, meter_120:measured_real_power;
+	property meter_91:measured_power, meter_92:measured_power, meter_93:measured_power, meter_94:measured_power, meter_95:measured_power, meter_96:measured_power, meter_97:measured_power, meter_98:measured_power, meter_99:measured_power, meter_100:measured_power, meter_101:measured_power, meter_102:measured_power, meter_103:measured_power, meter_104:measured_power, meter_105:measured_power, meter_106:measured_power, meter_107:measured_power, meter_108:measured_power, meter_109:measured_power, meter_110:measured_power, meter_111:measured_power, meter_112:measured_power, meter_113:measured_power, meter_114:measured_power, meter_115:measured_power, meter_116:measured_power, meter_117:measured_power, meter_118:measured_power, meter_119:measured_power, meter_120:measured_power;
 	file "output/power_dump_4.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_121:measured_real_power, meter_122:measured_real_power, meter_123:measured_real_power, meter_124:measured_real_power, meter_125:measured_real_power, meter_126:measured_real_power, meter_127:measured_real_power, meter_128:measured_real_power, meter_129:measured_real_power, meter_130:measured_real_power, meter_131:measured_real_power, meter_132:measured_real_power, meter_133:measured_real_power, meter_134:measured_real_power, meter_135:measured_real_power, meter_136:measured_real_power, meter_137:measured_real_power, meter_138:measured_real_power, meter_139:measured_real_power, meter_140:measured_real_power, meter_141:measured_real_power, meter_142:measured_real_power, meter_143:measured_real_power, meter_144:measured_real_power, meter_145:measured_real_power, meter_146:measured_real_power, meter_147:measured_real_power, meter_148:measured_real_power, meter_149:measured_real_power, meter_150:measured_real_power;
+	property meter_121:measured_power, meter_122:measured_power, meter_123:measured_power, meter_124:measured_power, meter_125:measured_power, meter_126:measured_power, meter_127:measured_power, meter_128:measured_power, meter_129:measured_power, meter_130:measured_power, meter_131:measured_power, meter_132:measured_power, meter_133:measured_power, meter_134:measured_power, meter_135:measured_power, meter_136:measured_power, meter_137:measured_power, meter_138:measured_power, meter_139:measured_power, meter_140:measured_power, meter_141:measured_power, meter_142:measured_power, meter_143:measured_power, meter_144:measured_power, meter_145:measured_power, meter_146:measured_power, meter_147:measured_power, meter_148:measured_power, meter_149:measured_power, meter_150:measured_power;
 	file "output/power_dump_5.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_151:measured_real_power, meter_152:measured_real_power, meter_153:measured_real_power, meter_154:measured_real_power, meter_155:measured_real_power, meter_156:measured_real_power, meter_157:measured_real_power, meter_158:measured_real_power, meter_159:measured_real_power, meter_160:measured_real_power, meter_161:measured_real_power, meter_162:measured_real_power, meter_163:measured_real_power, meter_164:measured_real_power, meter_165:measured_real_power, meter_166:measured_real_power, meter_167:measured_real_power, meter_168:measured_real_power, meter_169:measured_real_power, meter_170:measured_real_power, meter_171:measured_real_power, meter_172:measured_real_power, meter_173:measured_real_power, meter_174:measured_real_power, meter_175:measured_real_power, meter_176:measured_real_power, meter_177:measured_real_power, meter_178:measured_real_power, meter_179:measured_real_power, meter_180:measured_real_power;
+	property meter_151:measured_power, meter_152:measured_power, meter_153:measured_power, meter_154:measured_power, meter_155:measured_power, meter_156:measured_power, meter_157:measured_power, meter_158:measured_power, meter_159:measured_power, meter_160:measured_power, meter_161:measured_power, meter_162:measured_power, meter_163:measured_power, meter_164:measured_power, meter_165:measured_power, meter_166:measured_power, meter_167:measured_power, meter_168:measured_power, meter_169:measured_power, meter_170:measured_power, meter_171:measured_power, meter_172:measured_power, meter_173:measured_power, meter_174:measured_power, meter_175:measured_power, meter_176:measured_power, meter_177:measured_power, meter_178:measured_power, meter_179:measured_power, meter_180:measured_power;
 	file "output/power_dump_6.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_181:measured_real_power, meter_182:measured_real_power, meter_183:measured_real_power, meter_184:measured_real_power, meter_185:measured_real_power, meter_186:measured_real_power, meter_187:measured_real_power, meter_188:measured_real_power, meter_189:measured_real_power, meter_190:measured_real_power, meter_191:measured_real_power, meter_192:measured_real_power, meter_193:measured_real_power, meter_194:measured_real_power, meter_195:measured_real_power, meter_196:measured_real_power, meter_197:measured_real_power, meter_198:measured_real_power, meter_199:measured_real_power, meter_200:measured_real_power, meter_201:measured_real_power, meter_202:measured_real_power, meter_203:measured_real_power, meter_204:measured_real_power, meter_205:measured_real_power, meter_206:measured_real_power, meter_207:measured_real_power, meter_208:measured_real_power, meter_209:measured_real_power, meter_210:measured_real_power;
+	property meter_181:measured_power, meter_182:measured_power, meter_183:measured_power, meter_184:measured_power, meter_185:measured_power, meter_186:measured_power, meter_187:measured_power, meter_188:measured_power, meter_189:measured_power, meter_190:measured_power, meter_191:measured_power, meter_192:measured_power, meter_193:measured_power, meter_194:measured_power, meter_195:measured_power, meter_196:measured_power, meter_197:measured_power, meter_198:measured_power, meter_199:measured_power, meter_200:measured_power, meter_201:measured_power, meter_202:measured_power, meter_203:measured_power, meter_204:measured_power, meter_205:measured_power, meter_206:measured_power, meter_207:measured_power, meter_208:measured_power, meter_209:measured_power, meter_210:measured_power;
 	file "output/power_dump_7.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_211:measured_real_power, meter_212:measured_real_power, meter_213:measured_real_power, meter_214:measured_real_power, meter_215:measured_real_power, meter_216:measured_real_power, meter_217:measured_real_power, meter_218:measured_real_power, meter_219:measured_real_power, meter_220:measured_real_power, meter_221:measured_real_power, meter_222:measured_real_power, meter_223:measured_real_power, meter_224:measured_real_power, meter_225:measured_real_power, meter_226:measured_real_power, meter_227:measured_real_power, meter_228:measured_real_power, meter_229:measured_real_power, meter_230:measured_real_power, meter_231:measured_real_power, meter_232:measured_real_power, meter_233:measured_real_power, meter_234:measured_real_power, meter_235:measured_real_power, meter_236:measured_real_power, meter_237:measured_real_power, meter_238:measured_real_power, meter_239:measured_real_power, meter_240:measured_real_power;
+	property meter_211:measured_power, meter_212:measured_power, meter_213:measured_power, meter_214:measured_power, meter_215:measured_power, meter_216:measured_power, meter_217:measured_power, meter_218:measured_power, meter_219:measured_power, meter_220:measured_power, meter_221:measured_power, meter_222:measured_power, meter_223:measured_power, meter_224:measured_power, meter_225:measured_power, meter_226:measured_power, meter_227:measured_power, meter_228:measured_power, meter_229:measured_power, meter_230:measured_power, meter_231:measured_power, meter_232:measured_power, meter_233:measured_power, meter_234:measured_power, meter_235:measured_power, meter_236:measured_power, meter_237:measured_power, meter_238:measured_power, meter_239:measured_power, meter_240:measured_power;
 	file "output/power_dump_8.csv";
 	interval -1;
 }
 object multi_recorder {
 	file "output/power_dump_9.csv";
-	property meter_241:measured_real_power, meter_242:measured_real_power, meter_243:measured_real_power, meter_244:measured_real_power, meter_245:measured_real_power, meter_246:measured_real_power, meter_247:measured_real_power, meter_248:measured_real_power, meter_249:measured_real_power, meter_250:measured_real_power, meter_251:measured_real_power, meter_252:measured_real_power, meter_253:measured_real_power, meter_254:measured_real_power, meter_255:measured_real_power, meter_256:measured_real_power, meter_257:measured_real_power, meter_258:measured_real_power, meter_259:measured_real_power, meter_260:measured_real_power, meter_261:measured_real_power, meter_262:measured_real_power, meter_263:measured_real_power, meter_264:measured_real_power, meter_265:measured_real_power, meter_266:measured_real_power, meter_267:measured_real_power, meter_268:measured_real_power, meter_269:measured_real_power, meter_270:measured_real_power;
+	property meter_241:measured_power, meter_242:measured_power, meter_243:measured_power, meter_244:measured_power, meter_245:measured_power, meter_246:measured_power, meter_247:measured_power, meter_248:measured_power, meter_249:measured_power, meter_250:measured_power, meter_251:measured_power, meter_252:measured_power, meter_253:measured_power, meter_254:measured_power, meter_255:measured_power, meter_256:measured_power, meter_257:measured_power, meter_258:measured_power, meter_259:measured_power, meter_260:measured_power, meter_261:measured_power, meter_262:measured_power, meter_263:measured_power, meter_264:measured_power, meter_265:measured_power, meter_266:measured_power, meter_267:measured_power, meter_268:measured_power, meter_269:measured_power, meter_270:measured_power;
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_271:measured_real_power, meter_272:measured_real_power, meter_273:measured_real_power, meter_274:measured_real_power, meter_275:measured_real_power, meter_276:measured_real_power, meter_277:measured_real_power, meter_278:measured_real_power, meter_279:measured_real_power, meter_280:measured_real_power, meter_281:measured_real_power, meter_282:measured_real_power, meter_283:measured_real_power, meter_284:measured_real_power, meter_285:measured_real_power, meter_286:measured_real_power, meter_287:measured_real_power, meter_288:measured_real_power, meter_289:measured_real_power, meter_290:measured_real_power, meter_291:measured_real_power, meter_292:measured_real_power, meter_293:measured_real_power, meter_294:measured_real_power, meter_295:measured_real_power, meter_296:measured_real_power, meter_297:measured_real_power, meter_298:measured_real_power, meter_299:measured_real_power, meter_300:measured_real_power;
+	property meter_271:measured_power, meter_272:measured_power, meter_273:measured_power, meter_274:measured_power, meter_275:measured_power, meter_276:measured_power, meter_277:measured_power, meter_278:measured_power, meter_279:measured_power, meter_280:measured_power, meter_281:measured_power, meter_282:measured_power, meter_283:measured_power, meter_284:measured_power, meter_285:measured_power, meter_286:measured_power, meter_287:measured_power, meter_288:measured_power, meter_289:measured_power, meter_290:measured_power, meter_291:measured_power, meter_292:measured_power, meter_293:measured_power, meter_294:measured_power, meter_295:measured_power, meter_296:measured_power, meter_297:measured_power, meter_298:measured_power, meter_299:measured_power, meter_300:measured_power;
 	file "output/power_dump_10.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_301:measured_real_power, meter_302:measured_real_power, meter_303:measured_real_power, meter_304:measured_real_power, meter_305:measured_real_power, meter_306:measured_real_power, meter_307:measured_real_power, meter_308:measured_real_power, meter_309:measured_real_power, meter_310:measured_real_power, meter_311:measured_real_power, meter_312:measured_real_power, meter_313:measured_real_power, meter_314:measured_real_power, meter_315:measured_real_power, meter_316:measured_real_power, meter_317:measured_real_power, meter_318:measured_real_power, meter_319:measured_real_power, meter_320:measured_real_power, meter_321:measured_real_power, meter_322:measured_real_power, meter_323:measured_real_power, meter_324:measured_real_power, meter_325:measured_real_power, meter_326:measured_real_power, meter_327:measured_real_power, meter_328:measured_real_power, meter_329:measured_real_power, meter_330:measured_real_power;
+	property meter_301:measured_power, meter_302:measured_power, meter_303:measured_power, meter_304:measured_power, meter_305:measured_power, meter_306:measured_power, meter_307:measured_power, meter_308:measured_power, meter_309:measured_power, meter_310:measured_power, meter_311:measured_power, meter_312:measured_power, meter_313:measured_power, meter_314:measured_power, meter_315:measured_power, meter_316:measured_power, meter_317:measured_power, meter_318:measured_power, meter_319:measured_power, meter_320:measured_power, meter_321:measured_power, meter_322:measured_power, meter_323:measured_power, meter_324:measured_power, meter_325:measured_power, meter_326:measured_power, meter_327:measured_power, meter_328:measured_power, meter_329:measured_power, meter_330:measured_power;
 	file "output/power_dump_11.csv";
 	interval -1;
 }
 
 object multi_recorder {
-	property meter_331:measured_real_power, meter_332:measured_real_power, meter_333:measured_real_power, meter_334:measured_real_power, meter_335:measured_real_power, meter_336:measured_real_power, meter_337:measured_real_power, meter_338:measured_real_power, meter_339:measured_real_power, meter_340:measured_real_power, meter_341:measured_real_power, meter_342:measured_real_power, meter_343:measured_real_power, meter_344:measured_real_power;
+	property meter_331:measured_power, meter_332:measured_power, meter_333:measured_power, meter_334:measured_power, meter_335:measured_power, meter_336:measured_power, meter_337:measured_power, meter_338:measured_power, meter_339:measured_power, meter_340:measured_power, meter_341:measured_power, meter_342:measured_power, meter_343:measured_power, meter_344:measured_power;
 	file "output/power_dump_12.csv";
-	interval -1;
-}
-
-//reactive power recordings 
-
-object multi_recorder {
-	property substation_meter:measured_reactive_power, meter_1:measured_reactive_power, meter_2:measured_reactive_power, meter_3:measured_reactive_power, meter_4:measured_reactive_power, meter_5:measured_reactive_power, meter_6:measured_reactive_power, meter_7:measured_reactive_power, meter_8:measured_reactive_power, meter_9:measured_reactive_power, meter_10:measured_reactive_power, meter_11:measured_reactive_power, meter_12:measured_reactive_power, meter_13:measured_reactive_power, meter_14:measured_reactive_power, meter_15:measured_reactive_power, meter_16:measured_reactive_power, meter_17:measured_reactive_power, meter_18:measured_reactive_power, meter_19:measured_reactive_power, meter_20:measured_reactive_power, meter_21:measured_reactive_power, meter_22:measured_reactive_power, meter_23:measured_reactive_power, meter_24:measured_reactive_power;
-	file "output/power_dump_13.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_25:measured_reactive_power, meter_26:measured_reactive_power, meter_27:measured_reactive_power, meter_28:measured_reactive_power, meter_29:measured_reactive_power, meter_30:measured_reactive_power;
-	file "output/power_dump_14.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_31:measured_reactive_power, meter_32:measured_reactive_power, meter_33:measured_reactive_power, meter_34:measured_reactive_power, meter_35:measured_reactive_power, meter_36:measured_reactive_power, meter_37:measured_reactive_power, meter_38:measured_reactive_power, meter_39:measured_reactive_power, meter_40:measured_reactive_power, meter_41:measured_reactive_power, meter_42:measured_reactive_power, meter_43:measured_reactive_power, meter_44:measured_reactive_power, meter_45:measured_reactive_power, meter_46:measured_reactive_power, meter_47:measured_reactive_power, meter_48:measured_reactive_power, meter_49:measured_reactive_power, meter_50:measured_reactive_power, meter_51:measured_reactive_power, meter_52:measured_reactive_power, meter_53:measured_reactive_power, meter_54:measured_reactive_power, meter_55:measured_reactive_power, meter_56:measured_reactive_power, meter_57:measured_reactive_power, meter_58:measured_reactive_power, meter_59:measured_reactive_power, meter_60:measured_reactive_power;
-	file "output/power_dump_15.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_61:measured_reactive_power, meter_62:measured_reactive_power, meter_63:measured_reactive_power, meter_64:measured_reactive_power, meter_65:measured_reactive_power, meter_66:measured_reactive_power, meter_67:measured_reactive_power, meter_68:measured_reactive_power, meter_69:measured_reactive_power, meter_70:measured_reactive_power, meter_71:measured_reactive_power, meter_72:measured_reactive_power, meter_73:measured_reactive_power, meter_74:measured_reactive_power, meter_75:measured_reactive_power, meter_76:measured_reactive_power, meter_77:measured_reactive_power, meter_78:measured_reactive_power, meter_79:measured_reactive_power, meter_80:measured_reactive_power, meter_81:measured_reactive_power, meter_82:measured_reactive_power, meter_83:measured_reactive_power, meter_84:measured_reactive_power, meter_85:measured_reactive_power, meter_86:measured_reactive_power, meter_87:measured_reactive_power, meter_88:measured_reactive_power, meter_89:measured_reactive_power, meter_90:measured_reactive_power;
-	file "output/power_dump_16.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_91:measured_reactive_power, meter_92:measured_reactive_power, meter_93:measured_reactive_power, meter_94:measured_reactive_power, meter_95:measured_reactive_power, meter_96:measured_reactive_power, meter_97:measured_reactive_power, meter_98:measured_reactive_power, meter_99:measured_reactive_power, meter_100:measured_reactive_power, meter_101:measured_reactive_power, meter_102:measured_reactive_power, meter_103:measured_reactive_power, meter_104:measured_reactive_power, meter_105:measured_reactive_power, meter_106:measured_reactive_power, meter_107:measured_reactive_power, meter_108:measured_reactive_power, meter_109:measured_reactive_power, meter_110:measured_reactive_power, meter_111:measured_reactive_power, meter_112:measured_reactive_power, meter_113:measured_reactive_power, meter_114:measured_reactive_power;
-	file "output/power_dump_17.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_115:measured_reactive_power, meter_116:measured_reactive_power, meter_117:measured_reactive_power, meter_118:measured_reactive_power, meter_119:measured_reactive_power, meter_120:measured_reactive_power, meter_121:measured_reactive_power, meter_122:measured_reactive_power, meter_123:measured_reactive_power, meter_124:measured_reactive_power, meter_125:measured_reactive_power;
-	file "output/power_dump_18.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_126:measured_reactive_power, meter_127:measured_reactive_power, meter_128:measured_reactive_power, meter_129:measured_reactive_power, meter_130:measured_reactive_power, meter_131:measured_reactive_power, meter_132:measured_reactive_power, meter_133:measured_reactive_power, meter_134:measured_reactive_power, meter_135:measured_reactive_power, meter_136:measured_reactive_power, meter_137:measured_reactive_power, meter_138:measured_reactive_power, meter_139:measured_reactive_power, meter_140:measured_reactive_power, meter_141:measured_reactive_power, meter_142:measured_reactive_power, meter_143:measured_reactive_power, meter_144:measured_reactive_power, meter_145:measured_reactive_power, meter_146:measured_reactive_power, meter_147:measured_reactive_power, meter_148:measured_reactive_power, meter_149:measured_reactive_power, meter_150:measured_reactive_power;
-	file "output/power_dump_19.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_151:measured_reactive_power, meter_152:measured_reactive_power, meter_153:measured_reactive_power, meter_154:measured_reactive_power, meter_155:measured_reactive_power, meter_156:measured_reactive_power, meter_157:measured_reactive_power, meter_158:measured_reactive_power, meter_159:measured_reactive_power, meter_160:measured_reactive_power, meter_161:measured_reactive_power, meter_162:measured_reactive_power, meter_163:measured_reactive_power, meter_164:measured_reactive_power, meter_165:measured_reactive_power, meter_166:measured_reactive_power, meter_167:measured_reactive_power, meter_168:measured_reactive_power, meter_169:measured_reactive_power, meter_170:measured_reactive_power, meter_171:measured_reactive_power, meter_172:measured_reactive_power, meter_173:measured_reactive_power, meter_174:measured_reactive_power, meter_175:measured_reactive_power;
-	file "output/power_dump_20.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_176:measured_reactive_power, meter_177:measured_reactive_power, meter_178:measured_reactive_power, meter_179:measured_reactive_power, meter_180:measured_reactive_power, meter_181:measured_reactive_power, meter_182:measured_reactive_power, meter_183:measured_reactive_power, meter_184:measured_reactive_power;
-	file "output/power_dump_21.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_185:measured_reactive_power, meter_186:measured_reactive_power, meter_187:measured_reactive_power, meter_188:measured_reactive_power, meter_189:measured_reactive_power, meter_190:measured_reactive_power, meter_191:measured_reactive_power, meter_192:measured_reactive_power, meter_193:measured_reactive_power, meter_194:measured_reactive_power, meter_195:measured_reactive_power, meter_196:measured_reactive_power, meter_197:measured_reactive_power, meter_198:measured_reactive_power, meter_199:measured_reactive_power, meter_200:measured_reactive_power, meter_201:measured_reactive_power, meter_202:measured_reactive_power, meter_203:measured_reactive_power, meter_204:measured_reactive_power, meter_205:measured_reactive_power, meter_206:measured_reactive_power, meter_207:measured_reactive_power, meter_208:measured_reactive_power, meter_209:measured_reactive_power, meter_210:measured_reactive_power;
-	file "output/power_dump_22.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_211:measured_reactive_power, meter_212:measured_reactive_power, meter_213:measured_reactive_power, meter_214:measured_reactive_power, meter_215:measured_reactive_power, meter_216:measured_reactive_power, meter_217:measured_reactive_power, meter_218:measured_reactive_power, meter_219:measured_reactive_power, meter_220:measured_reactive_power, meter_221:measured_reactive_power, meter_222:measured_reactive_power, meter_223:measured_reactive_power, meter_224:measured_reactive_power, meter_225:measured_reactive_power, meter_226:measured_reactive_power, meter_227:measured_reactive_power, meter_228:measured_reactive_power, meter_229:measured_reactive_power, meter_230:measured_reactive_power, meter_231:measured_reactive_power, meter_232:measured_reactive_power, meter_233:measured_reactive_power, meter_234:measured_reactive_power, meter_235:measured_reactive_power;
-	file "output/power_dump_23.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_236:measured_reactive_power, meter_237:measured_reactive_power, meter_238:measured_reactive_power, meter_239:measured_reactive_power, meter_240:measured_reactive_power, meter_241:measured_reactive_power, meter_242:measured_reactive_power, meter_243:measured_reactive_power, meter_244:measured_reactive_power;
-	file "output/power_dump_24.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	file "output/power_dump_25.csv";
-	property meter_245:measured_reactive_power, meter_246:measured_reactive_power, meter_247:measured_reactive_power, meter_248:measured_reactive_power, meter_249:measured_reactive_power, meter_250:measured_reactive_power, meter_251:measured_reactive_power, meter_252:measured_reactive_power, meter_253:measured_reactive_power, meter_254:measured_reactive_power, meter_255:measured_reactive_power, meter_256:measured_reactive_power, meter_257:measured_reactive_power, meter_258:measured_reactive_power, meter_259:measured_reactive_power, meter_260:measured_reactive_power, meter_261:measured_reactive_power, meter_262:measured_reactive_power, meter_263:measured_reactive_power, meter_264:measured_reactive_power, meter_265:measured_reactive_power, meter_266:measured_reactive_power, meter_267:measured_reactive_power, meter_268:measured_reactive_power, meter_269:measured_reactive_power, meter_270:measured_reactive_power;
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_271:measured_reactive_power, meter_272:measured_reactive_power, meter_273:measured_reactive_power, meter_274:measured_reactive_power, meter_275:measured_reactive_power, meter_276:measured_reactive_power, meter_277:measured_reactive_power, meter_278:measured_reactive_power, meter_279:measured_reactive_power, meter_280:measured_reactive_power, meter_281:measured_reactive_power, meter_282:measured_reactive_power, meter_283:measured_reactive_power, meter_284:measured_reactive_power, meter_285:measured_reactive_power, meter_286:measured_reactive_power, meter_287:measured_reactive_power, meter_288:measured_reactive_power, meter_289:measured_reactive_power, meter_290:measured_reactive_power, meter_291:measured_reactive_power, meter_292:measured_reactive_power, meter_293:measured_reactive_power, meter_294:measured_reactive_power, meter_295:measured_reactive_power, meter_296:measured_reactive_power, meter_297:measured_reactive_power, meter_298:measured_reactive_power, meter_299:measured_reactive_power;
-	file "output/power_dump_26.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_300:measured_reactive_power, meter_301:measured_reactive_power, meter_302:measured_reactive_power, meter_303:measured_reactive_power, meter_304:measured_reactive_power, meter_305:measured_reactive_power, meter_306:measured_reactive_power, meter_307:measured_reactive_power, meter_308:measured_reactive_power, meter_309:measured_reactive_power, meter_310:measured_reactive_power, meter_311:measured_reactive_power, meter_312:measured_reactive_power, meter_313:measured_reactive_power, meter_314:measured_reactive_power, meter_315:measured_reactive_power, meter_316:measured_reactive_power, meter_317:measured_reactive_power, meter_318:measured_reactive_power, meter_319:measured_reactive_power, meter_320:measured_reactive_power, meter_321:measured_reactive_power, meter_322:measured_reactive_power, meter_323:measured_reactive_power, meter_324:measured_reactive_power, meter_325:measured_reactive_power, meter_326:measured_reactive_power, meter_327:measured_reactive_power, meter_328:measured_reactive_power;
-	file "output/power_dump_27.csv";
-	interval -1;
-}
-
-object multi_recorder {
-	property meter_329:measured_reactive_power, meter_330:measured_reactive_power, meter_331:measured_reactive_power, meter_332:measured_reactive_power, meter_333:measured_reactive_power, meter_334:measured_reactive_power, meter_335:measured_reactive_power, meter_336:measured_reactive_power, meter_337:measured_reactive_power, meter_338:measured_reactive_power, meter_339:measured_reactive_power, meter_340:measured_reactive_power, meter_341:measured_reactive_power, meter_342:measured_reactive_power, meter_343:measured_reactive_power, meter_344:measured_reactive_power;
-	file "output/power_dump_28.csv";
 	interval -1;
 }

--- a/models/ieee123/voltdump.py
+++ b/models/ieee123/voltdump.py
@@ -1,26 +1,42 @@
-import csv
-import pandas as pd
 import os 
+import csv
+import datetime
 
-#def commit_voltdump(obj,t):
-time_stamp = []
-column_names = []
-value_voltA_real = []
-value_voltB_real = []
-value_voltC_real = []
-value_voltA_imag = []
-value_voltB_imag = []
-value_voltC_imag = []
-column_names.append("Time")
+data = {}
+nodes = []
+timestamp = None
+timezone = "UTC"
+with open('output/volt_dump.csv', 'r') as dumpfile:
+	reader = csv.reader(dumpfile)
+	for row in reader:
+		if row[0].startswith("#") :
+			tpos = row[0].find(" at ")
+			if tpos > 0 :
+				timestamp = row[0][tpos+4:tpos+27]
+				timestamp = datetime.datetime.strptime(timestamp,"%Y-%m-%d %H:%M:%S %Z")
+				data[timestamp] = []
+				timezone = row[0][tpos+24:tpos+27]
+			header = []
+		elif not header :
+			header = row
+			assert(header==['node_name', 'voltA_real', 'voltA_imag', 'voltB_real', 'voltB_imag', 'voltC_real', 'voltC_imag'])
+		else :
+			try :
+				node = row[0]
+				A = complex(float(row[1]),float(row[2]))
+				B = complex(float(row[3]),float(row[4]))
+				C = complex(float(row[5]),float(row[6]))
+				if not node+"_A" in nodes :
+					nodes.extend([node+"_A",node+"_B",node+"_C"])
+				data[timestamp].extend([A,B,C])
+			except :
+				print("ERROR: ignored row '%s'" % row)
 
-#voltdump is a file with appended timstamps to the end of the file
-with open('output/volt_dump.csv', 'r') as textfile:
-	for row, val in enumerate(list(csv.reader(textfile))): 
-		if (str(val)).startswith("['#") :
-			time_stamp.append((str(val))[32:55])
-		elif row == 1 : 
-			continue 
-		else : 
-			column_names.append(val[0])
-print(time_stamp)
-
+with open('output/voltages.csv','w') as voltages:
+	writer = csv.writer(voltages)
+	writer.writerow(nodes)
+	for key,values in data.items() :
+		data = [key.strftime("%Y-%m-%dT%H:%M:%S%z")]
+		for value in values:
+			data.append("%g%+gj" % (value.real,value.imag))
+		writer.writerow(data)

--- a/models/ieee123/voltdump.py
+++ b/models/ieee123/voltdump.py
@@ -14,90 +14,13 @@ value_voltC_imag = []
 column_names.append("Time")
 
 #voltdump is a file with appended timstamps to the end of the file
-with open('volt_dump.csv', 'r') as textfile:
+with open('output/volt_dump.csv', 'r') as textfile:
 	for row, val in enumerate(list(csv.reader(textfile))): 
 		if (str(val)).startswith("['#") :
-			time_stamp.append((str(val))[31:54])
-			# value_voltA_real.append(time_stamp)
-			# value_voltB_real.append(time_stamp)
-			# value_voltC_real.append(time_stamp)
-			# value_voltA_imag.append(time_stamp)
-			# value_voltB_imag.append(time_stamp)
-			# value_voltC_imag.append(time_stamp)
+			time_stamp.append((str(val))[32:55])
 		elif row == 1 : 
 			continue 
 		else : 
 			column_names.append(val[0])
-			# value_voltA_real.append(val[1])
-			# value_voltB_real.append(val[3])
-			# value_voltC_real.append(val[5])
-			# value_voltA_imag.append(val[2])
-			# value_voltB_imag.append(val[4])
-			# value_voltC_imag.append(val[6])
 print(time_stamp)
 
-# try : # if file exists 
-# 	df = pd.read_csv('voltA_real.csv')
-# 	with open('voltA_real.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(value_voltA_real)
-# except : # if file doesn't exist add column names 
-# 	with open('voltA_real.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(column_names)
-# 		filewriter.writerow(value_voltA_real)
-
-# try : # if file exists 
-# 	df = pd.read_csv('voltB_real.csv')
-# 	with open('voltB_real.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(value_voltB_real)
-# except : # if file doesn't exist add column names 
-# 	with open('voltB_real.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(column_names)
-# 		filewriter.writerow(value_voltB_real)
-
-# try : # if file exists 
-# 	df = pd.read_csv('voltC_real.csv')
-# 	with open('voltC_real.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(value_voltC_real)
-# except : # if file doesn't exist add column names 
-# 	with open('voltC_real.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(column_names)
-# 		filewriter.writerow(value_voltC_real)
-
-# try : # if file exists 
-# 	df = pd.read_csv('voltA_imag.csv')
-# 	with open('voltA_imag.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(value_voltA_imag)
-# except : # if file doesn't exist add column names 
-# 	with open('voltA_imag.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(column_names)
-# 		filewriter.writerow(value_voltA_imag)
-
-# try : # if file exists 
-# 	df = pd.read_csv('voltB_imag.csv')
-# 	with open('voltB_imag.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(value_voltB_imag)
-# except : # if file doesn't exist add column names 
-# 	with open('voltB_imag.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(column_names)
-# 		filewriter.writerow(value_voltB_imag)
-
-# try : # if file exists 
-# 	df = pd.read_csv('voltC_imag.csv')
-# 	with open('voltC_imag.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(value_voltC_imag)
-# except : # if file doesn't exist add column names 
-# 	with open('voltC_imag.csv', 'a') as csvfile : 
-# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-# 		filewriter.writerow(column_names)
-# 		filewriter.writerow(value_voltC_imag)

--- a/models/ieee123/voltdump.py
+++ b/models/ieee123/voltdump.py
@@ -16,88 +16,88 @@ column_names.append("Time")
 #voltdump is a file with appended timstamps to the end of the file
 with open('volt_dump.csv', 'r') as textfile:
 	for row, val in enumerate(list(csv.reader(textfile))): 
-		if row == 0 : 
-			time_stamp = (str(val))[25:48]
-			value_voltA_real.append(time_stamp)
-			value_voltB_real.append(time_stamp)
-			value_voltC_real.append(time_stamp)
-			value_voltA_imag.append(time_stamp)
-			value_voltB_imag.append(time_stamp)
-			value_voltC_imag.append(time_stamp)
+		if (str(val)).startswith("['#") :
+			time_stamp.append((str(val))[31:54])
+			# value_voltA_real.append(time_stamp)
+			# value_voltB_real.append(time_stamp)
+			# value_voltC_real.append(time_stamp)
+			# value_voltA_imag.append(time_stamp)
+			# value_voltB_imag.append(time_stamp)
+			# value_voltC_imag.append(time_stamp)
 		elif row == 1 : 
 			continue 
 		else : 
 			column_names.append(val[0])
-			value_voltA_real.append(val[1])
-			value_voltB_real.append(val[3])
-			value_voltC_real.append(val[5])
-			value_voltA_imag.append(val[2])
-			value_voltB_imag.append(val[4])
-			value_voltC_imag.append(val[6])
+			# value_voltA_real.append(val[1])
+			# value_voltB_real.append(val[3])
+			# value_voltC_real.append(val[5])
+			# value_voltA_imag.append(val[2])
+			# value_voltB_imag.append(val[4])
+			# value_voltC_imag.append(val[6])
+print(time_stamp)
 
+# try : # if file exists 
+# 	df = pd.read_csv('voltA_real.csv')
+# 	with open('voltA_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltA_real)
+# except : # if file doesn't exist add column names 
+# 	with open('voltA_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltA_real)
 
-try : # if file exists 
-	df = pd.read_csv('voltA_real.csv')
-	with open('voltA_real.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(value_voltA_real)
-except : # if file doesn't exist add column names 
-	with open('voltA_real.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(column_names)
-		filewriter.writerow(value_voltA_real)
+# try : # if file exists 
+# 	df = pd.read_csv('voltB_real.csv')
+# 	with open('voltB_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltB_real)
+# except : # if file doesn't exist add column names 
+# 	with open('voltB_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltB_real)
 
-try : # if file exists 
-	df = pd.read_csv('voltB_real.csv')
-	with open('voltB_real.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(value_voltB_real)
-except : # if file doesn't exist add column names 
-	with open('voltB_real.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(column_names)
-		filewriter.writerow(value_voltB_real)
+# try : # if file exists 
+# 	df = pd.read_csv('voltC_real.csv')
+# 	with open('voltC_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltC_real)
+# except : # if file doesn't exist add column names 
+# 	with open('voltC_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltC_real)
 
-try : # if file exists 
-	df = pd.read_csv('voltC_real.csv')
-	with open('voltC_real.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(value_voltC_real)
-except : # if file doesn't exist add column names 
-	with open('voltC_real.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(column_names)
-		filewriter.writerow(value_voltC_real)
+# try : # if file exists 
+# 	df = pd.read_csv('voltA_imag.csv')
+# 	with open('voltA_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltA_imag)
+# except : # if file doesn't exist add column names 
+# 	with open('voltA_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltA_imag)
 
-try : # if file exists 
-	df = pd.read_csv('voltA_imag.csv')
-	with open('voltA_imag.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(value_voltA_imag)
-except : # if file doesn't exist add column names 
-	with open('voltA_imag.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(column_names)
-		filewriter.writerow(value_voltA_imag)
+# try : # if file exists 
+# 	df = pd.read_csv('voltB_imag.csv')
+# 	with open('voltB_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltB_imag)
+# except : # if file doesn't exist add column names 
+# 	with open('voltB_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltB_imag)
 
-try : # if file exists 
-	df = pd.read_csv('voltB_imag.csv')
-	with open('voltB_imag.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(value_voltB_imag)
-except : # if file doesn't exist add column names 
-	with open('voltB_imag.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(column_names)
-		filewriter.writerow(value_voltB_imag)
-
-try : # if file exists 
-	df = pd.read_csv('voltC_imag.csv')
-	with open('voltC_imag.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(value_voltC_imag)
-except : # if file doesn't exist add column names 
-	with open('voltC_imag.csv', 'a') as csvfile : 
-		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-		filewriter.writerow(column_names)
-		filewriter.writerow(value_voltC_imag)
+# try : # if file exists 
+# 	df = pd.read_csv('voltC_imag.csv')
+# 	with open('voltC_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltC_imag)
+# except : # if file doesn't exist add column names 
+# 	with open('voltC_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltC_imag)

--- a/models/ieee123/voltdump.py
+++ b/models/ieee123/voltdump.py
@@ -4,6 +4,7 @@ import datetime
 
 data = {}
 nodes = []
+lastnodes = []
 timestamp = None
 timezone = "UTC"
 with open('output/volt_dump.csv', 'r') as dumpfile:
@@ -20,6 +21,10 @@ with open('output/volt_dump.csv', 'r') as dumpfile:
 		elif not header :
 			header = row
 			assert(header==['node_name', 'voltA_real', 'voltA_imag', 'voltB_real', 'voltB_imag', 'voltC_real', 'voltC_imag'])
+			if lastnodes :
+				assert(lastnodes==nodes)
+			elif nodes :
+				lastnodes = nodes
 		else :
 			try :
 				node = row[0]

--- a/models/ieee123/voltdump.py
+++ b/models/ieee123/voltdump.py
@@ -78,7 +78,10 @@ for filename in os.listdir("output") :
 				timestamp = datetime.datetime.strptime(row[0],"%Y-%m-%d %H:%M:%S %Z")
 				if not timestamp in data.keys() :
 					data[timestamp] = []
-				data[timestamp].extend(list(map(lambda x:to_complex(x),row[1:])))
+				try :
+					data[timestamp].extend(list(map(lambda x:to_complex(x),row[1:])))
+				except:
+					print("%s: error parsing row '%s', values ignored" % (filename,row))
 
 with open("output/powers.csv","w") as powers:
 	writer = csv.writer(powers)

--- a/models/ieee123/voltdump.py
+++ b/models/ieee123/voltdump.py
@@ -1,0 +1,103 @@
+import csv
+import pandas as pd
+import os 
+
+#def commit_voltdump(obj,t):
+time_stamp = []
+column_names = []
+value_voltA_real = []
+value_voltB_real = []
+value_voltC_real = []
+value_voltA_imag = []
+value_voltB_imag = []
+value_voltC_imag = []
+column_names.append("Time")
+
+#voltdump is a file with appended timstamps to the end of the file
+with open('volt_dump.csv', 'r') as textfile:
+	for row, val in enumerate(list(csv.reader(textfile))): 
+		if row == 0 : 
+			time_stamp = (str(val))[25:48]
+			value_voltA_real.append(time_stamp)
+			value_voltB_real.append(time_stamp)
+			value_voltC_real.append(time_stamp)
+			value_voltA_imag.append(time_stamp)
+			value_voltB_imag.append(time_stamp)
+			value_voltC_imag.append(time_stamp)
+		elif row == 1 : 
+			continue 
+		else : 
+			column_names.append(val[0])
+			value_voltA_real.append(val[1])
+			value_voltB_real.append(val[3])
+			value_voltC_real.append(val[5])
+			value_voltA_imag.append(val[2])
+			value_voltB_imag.append(val[4])
+			value_voltC_imag.append(val[6])
+
+
+try : # if file exists 
+	df = pd.read_csv('voltA_real.csv')
+	with open('voltA_real.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(value_voltA_real)
+except : # if file doesn't exist add column names 
+	with open('voltA_real.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(column_names)
+		filewriter.writerow(value_voltA_real)
+
+try : # if file exists 
+	df = pd.read_csv('voltB_real.csv')
+	with open('voltB_real.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(value_voltB_real)
+except : # if file doesn't exist add column names 
+	with open('voltB_real.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(column_names)
+		filewriter.writerow(value_voltB_real)
+
+try : # if file exists 
+	df = pd.read_csv('voltC_real.csv')
+	with open('voltC_real.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(value_voltC_real)
+except : # if file doesn't exist add column names 
+	with open('voltC_real.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(column_names)
+		filewriter.writerow(value_voltC_real)
+
+try : # if file exists 
+	df = pd.read_csv('voltA_imag.csv')
+	with open('voltA_imag.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(value_voltA_imag)
+except : # if file doesn't exist add column names 
+	with open('voltA_imag.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(column_names)
+		filewriter.writerow(value_voltA_imag)
+
+try : # if file exists 
+	df = pd.read_csv('voltB_imag.csv')
+	with open('voltB_imag.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(value_voltB_imag)
+except : # if file doesn't exist add column names 
+	with open('voltB_imag.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(column_names)
+		filewriter.writerow(value_voltB_imag)
+
+try : # if file exists 
+	df = pd.read_csv('voltC_imag.csv')
+	with open('voltC_imag.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(value_voltC_imag)
+except : # if file doesn't exist add column names 
+	with open('voltC_imag.csv', 'a') as csvfile : 
+		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+		filewriter.writerow(column_names)
+		filewriter.writerow(value_voltC_imag)

--- a/python/csv_merge/csv_merge.py
+++ b/python/csv_merge/csv_merge.py
@@ -1,0 +1,19 @@
+import glob
+import pandas
+output_file = "multi_recorder_full.csv" #output file name
+filelist = glob.glob("output/*.csv") #dataframe list
+print(filelist)
+
+
+dfList = []
+for i,filename in enumerate(filelist) : 
+	if i!=0 : 
+		df = pandas.read_csv(filename,skiprows=7)
+		df.drop(df.columns[0],axis=1,inplace=True)
+		print(df.columns[0])
+	else :
+		df = pandas.read_csv(filename,skiprows=7)
+	dfList.append(df)
+
+concatDf=pandas.concat(dfList,axis=1,sort=False)
+concatDf.to_csv(output_file, index=None)

--- a/python/volt_dump/meter_record.py
+++ b/python/volt_dump/meter_record.py
@@ -1,0 +1,27 @@
+import csv
+
+column_names = []
+meter_objects = []
+meter_power_real = []
+meter_power_reactive = []
+with open('volt_dump.csv', 'r') as textfile:
+	for row, val in enumerate(list(csv.reader(textfile))): 
+		if (str(val)).startswith("['#") :
+			if row == 0 :
+				num_nodes = int((str(val))[58:61])
+		if row >= 2 and row <= num_nodes+1 :
+				column_names.append(val[0])
+
+for val in column_names : 
+	if "meter" in val: 
+		meter_objects.append(val)
+
+for val in meter_objects : 
+	meter_power_real.append(val + ":measured_real_power")
+	meter_power_reactive.append(val + ":measured_reactive_power")
+print(meter_power_reactive)
+
+
+with open('meter_power_real_names.txt', 'w') as textfile : 
+	for item in meter_power_real : 
+		textfile.write("%s, " %item)

--- a/python/volt_dump/voltdump.py
+++ b/python/volt_dump/voltdump.py
@@ -1,0 +1,103 @@
+import csv
+import pandas as pd
+import os 
+
+#def commit_voltdump(obj,t):
+time_stamp = []
+column_names = []
+value_voltA_real = []
+value_voltB_real = []
+value_voltC_real = []
+value_voltA_imag = []
+value_voltB_imag = []
+value_voltC_imag = []
+column_names.append("Time")
+
+#voltdump is a file with appended timstamps to the end of the file
+with open('volt_dump.csv', 'r') as textfile:
+	for row, val in enumerate(list(csv.reader(textfile))): 
+		if (str(val)).startswith("['#") :
+			time_stamp.append((str(val))[31:54])
+			# value_voltA_real.append(time_stamp)
+			# value_voltB_real.append(time_stamp)
+			# value_voltC_real.append(time_stamp)
+			# value_voltA_imag.append(time_stamp)
+			# value_voltB_imag.append(time_stamp)
+			# value_voltC_imag.append(time_stamp)
+		elif row == 1 : 
+			continue 
+		else : 
+			column_names.append(val[0])
+			# value_voltA_real.append(val[1])
+			# value_voltB_real.append(val[3])
+			# value_voltC_real.append(val[5])
+			# value_voltA_imag.append(val[2])
+			# value_voltB_imag.append(val[4])
+			# value_voltC_imag.append(val[6])
+print(time_stamp)
+
+# try : # if file exists 
+# 	df = pd.read_csv('voltA_real.csv')
+# 	with open('voltA_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltA_real)
+# except : # if file doesn't exist add column names 
+# 	with open('voltA_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltA_real)
+
+# try : # if file exists 
+# 	df = pd.read_csv('voltB_real.csv')
+# 	with open('voltB_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltB_real)
+# except : # if file doesn't exist add column names 
+# 	with open('voltB_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltB_real)
+
+# try : # if file exists 
+# 	df = pd.read_csv('voltC_real.csv')
+# 	with open('voltC_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltC_real)
+# except : # if file doesn't exist add column names 
+# 	with open('voltC_real.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltC_real)
+
+# try : # if file exists 
+# 	df = pd.read_csv('voltA_imag.csv')
+# 	with open('voltA_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltA_imag)
+# except : # if file doesn't exist add column names 
+# 	with open('voltA_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltA_imag)
+
+# try : # if file exists 
+# 	df = pd.read_csv('voltB_imag.csv')
+# 	with open('voltB_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltB_imag)
+# except : # if file doesn't exist add column names 
+# 	with open('voltB_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltB_imag)
+
+# try : # if file exists 
+# 	df = pd.read_csv('voltC_imag.csv')
+# 	with open('voltC_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(value_voltC_imag)
+# except : # if file doesn't exist add column names 
+# 	with open('voltC_imag.csv', 'a') as csvfile : 
+# 		filewriter = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+# 		filewriter.writerow(column_names)
+# 		filewriter.writerow(value_voltC_imag)

--- a/tape/multi_recorder.c
+++ b/tape/multi_recorder.c
@@ -506,6 +506,10 @@ static TIMESTAMP multi_recorder_write(OBJECT *obj)
 		my->samples++;
 
 	/* at this point we've written the sample to the normal recorder output */
+	if ( my->flush==0 || ( my->flush > 0 && gl_globalclock % my->flush == 0 ) )
+	{
+		my->ops->flush(my);
+	}
 
 	// if file based
 	if(my->multifp != NULL){


### PR DESCRIPTION
This PR addresses issues #159 and #161. The changes only apply to the IEEE123 model.

## Current issues
Multi-recorder should be changed to one object that doesn't produce multiple files when Issue #79 is fixed.

## Code changes
1. Edited IEEE123 to include a volt dump and multi_recorders that recorder real and reactive power for Triplex_meter objects + swing buses.
2. Added `csv_merge.py` file that was developed to get around Issue #79. Merges all files in a folder called "output" into one file. 
3. Added  `voltdump.py` that post-processes the `volt_dump.csv` that has appended entries to the end of the file and transforms them into nodes x time format instead.
4. Added `meter_record.py` that captures all the triplex_meter names and swing bus meter names and adds property name to each to be captured in a multi_recorder. 
5. Fixed `multi_recorder` so it flush according to `tape::flush_interval` global variable specification.

## Documentation changes
- TBD

## Test and Validation Notes
1. Run IEEE123 model with VOLT_POWERDUMP variable defined and try the above mentioned files to see if the post-processing is done correctly. 
