### PR TITLE
[MERGE] Fixed #if test 

### DIFF
--- a/gldcore/autotest/test_quoted_if_test.glm
+++ b/gldcore/autotest/test_quoted_if_test.glm
@@ -1,0 +1,18 @@
+#define TEST=yes
+
+#if TEST!=yes 
+#error test failed
+#endif
+
+#if TEST!="yes" 
+#error test failed
+#endif
+
+#if TEST != yes 
+#error test failed
+#endif
+
+#if TEST != "yes" 
+#error test failed
+#endif
+

--- a/gldcore/load.c
+++ b/gldcore/load.c
@@ -6599,8 +6599,11 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 	else if (strncmp(line,MACRO "if",3)==0)
 	{
 		char var[32], op[4], *value;
-		char val[1024];
-		if (sscanf(line+4,"%[a-zA-Z_0-9]%[!<>=]%[^\n]",var,op,val)!=3)
+		char val[1024], junk[1024]="";
+		if ( ( sscanf(line+4,"%31[a-zA-Z0-9_:.] %3[!<>=] \"%1023[^\"]\" %1023[^\n]\n",var,op,val,junk) < 3
+				&& sscanf(line+4,"%31[a-zA-Z0-9_:.] %3[!<>=] '%1023[^']' %1023[^\n]\n",var,op,val,junk) < 3
+				&& sscanf(line+4,"%31[a-zA-Z_0-9_:.] %3[!<>=] %1023[^ \t\n] %1023[^\n]\n",var,op,val,junk) < 3 )
+				|| strcmp(junk,"") != 0 )
 		{
 			output_error_raw("%s(%d): %sif macro statement syntax error", filename,linenum,MACRO);
 			strcpy(line,"\n");


### PR DESCRIPTION
This PR fixed #if test from Issue #148  so it is buffer size safe, handles quotes, module global names, and rejects trailing junk.

## Current issues
None

## Code changes
1. Small mod to `#if` macro handler. 
2. Added a `gldcore\autotest\test_quote_if_test`.

## Documentation changes
None

## Test and Validation Notes
1. Trailing junk should now cause a syntax error. Remaining tests are covered by auto test.