### PR TITLE
[MERGE] Fix misdirects for wiki when using --info option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ third_party/xerces-c-src_2_8_0.tar
 *.json
 output/
 models/ieee123/config/local.glm
+*.tmp

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -236,7 +236,7 @@ typedef enum {
 GLOBAL int global_mainloopstate INIT(MLS_INIT); /**< main loop processing state */
 GLOBAL TIMESTAMP global_mainlooppauseat INIT(TS_NEVER); /**< time at which to pause main loop */
 
-GLOBAL char global_infourl[1024] INIT("http://gridlab-d.sourceforge.net/info.php?title=Special:Search/"); /**< URL for info calls */
+GLOBAL char global_infourl[1024] INIT("http://gridlab-d.shoutwiki.com/w/index.php?title=Special%3ASearch&fulltext=Search&search="); /**< URL for info calls */
 
 GLOBAL char global_hostname[1024] INIT("localhost"); /**< machine hostname */
 GLOBAL char global_hostaddr[32] INIT("127.0.0.1"); /**< machine ip addr */


### PR DESCRIPTION
This PR fixes a misdirected wiki link when the `--info <topic>` command-line option is used.

## Current issues
None

## Code changes
Changed `global_infourl` to use `http://gridlab-d.sourceforge.net/info.php?title=Special:Search/<topic>` as the url template.

## Documentation changes
None

## Test and Validation Notes
Easy check using `gridlabd --info index` to obtain the full index on Shoutwiki.