### PR TITLE
Added support for basic ISO8601 date time values

### DIFF
--- a/gldcore/autotest/test_iso_datetime.glm
+++ b/gldcore/autotest/test_iso_datetime.glm
@@ -1,0 +1,27 @@
+module tape;
+module climate; 
+module assert;
+
+clock {
+	timezone "EST+5EDT";
+	starttime "2000-01-01T00:00:00-05:00";
+	stoptime "2000-01-02T02:00:00-05:00";
+}
+
+class test {
+	double test_var;
+};
+
+class climate {
+ 	randomvar clouds;
+} 
+
+object climate{
+	clouds "type:weibull(0.5,0.5); min:0.0; max:1.0; refresh:1h;";
+}
+
+object test {
+	name Test;	
+};
+
+script on_term gridlabd:dump test_clock.json;

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -2357,6 +2357,26 @@ static int time_value_datetimezone(PARSER, TIMESTAMP *t)
 	DONE;
 }
 
+static int time_value_isodatetime(PARSER, TIMESTAMP *t)
+{
+	START;
+	if WHITE ACCEPT;
+	char timevalue[1024];
+	if (LITERAL("\"") && TERM(delim_value(HERE,timevalue,sizeof(timevalue),"\"")) && LITERAL("\"") )
+	{
+		*t = convert_to_timestamp(timevalue);
+		if (*t!=-1) 
+		{
+			ACCEPT;
+		}
+		else
+			REJECT;
+	}
+	else
+		REJECT;
+	DONE;
+}
+
 static int time_value(PARSER, TIMESTAMP *t)
 {
 	START;
@@ -2373,8 +2393,13 @@ static int time_value(PARSER, TIMESTAMP *t)
 	OR
 	if (TERM(time_value_datetimezone(HERE,t)) && (WHITE,LITERAL(";"))) {ACCEPT; DONE; }
 	OR
+	if (TERM(time_value_isodatetime(HERE,t)) && (WHITE,LITERAL(";"))) {ACCEPT; DONE; }
+	OR
 	if (TERM(integer(HERE,t)) && (WHITE,LITERAL(";"))) {ACCEPT; DONE; }
-	else REJECT;
+	else 
+	{
+		REJECT;
+	}
 	DONE;
 }
 


### PR DESCRIPTION
This PR addresses issue #21.

## Current issues
1. Only 8601 formats are supported: `yyyy-mm-ddTHH:MM:SS[.SSSSSSSSS]Z` and `yyyy-mm-ddTHH:MM:SS[.SSSSSSSSS]{+,-}HH:MM`

## Code changes
1. Added date time pattern to `gldcore/load.cpp` and added ISO format reader to `gldcore/timestamp.cpp`

## Documentation changes
- https://github.com/dchassin/gridlabd/wiki/ISO8601

## Test and Validation Notes
1. Added `gldcore/autotest/test_iso_datetime.glm`