### PR TITLE
Change how version/build info is generated

### DIFF
--- a/utilities/build_number
+++ b/utilities/build_number
@@ -1,42 +1,27 @@
 #
 # Syntax: build_number <top_srcdir> <path-to-core/build.h>
 #
-# Updates the header file $2 by looking at the SVN info and
-# status in the folder $1.  Specifically:
-#
-# 1) BUILDNUM is set to the day since 1/1/1970 on which the
-#    build was completed.
-#
-# 2) BRANCH is set to the source commit.  When building a
-#    locally modified version the branch will be set to
-#    <user>@<host>:<path>:<commit>.  When building an
-#    unmodified fetch from a server, the branch will be
-#    set to <server>:<path>:<commit>.
-cd $1
-declare -i rev
-declare -i num
-dir=`git remote -v | head -n 1 | sed -n 's/^.*\t//; $s/ .*$//p'`
-new=`git log -n 1 | sed -n '1s/^commit //p'`
-mod=`git status -s | cut -c1-3 | sort -u | sed 's/ //g'`
-rev=`git log --max-count=1 --pretty=format:"%ai" | cut -c3,4,6,7,9,10`
-branchname=`git rev-parse --abbrev-ref HEAD`
-if [ -z "${mod}" -a -z "$(git status | grep 'Your branch is ahead')" ]; then
-	branch="${dir}/commit/${new}"
-else
-	branch="$(hostname):${PWD/$HOME/~$USER}:$branchname:$new"
+if [ -f "$2" ]; then
+	LAST_STAMP=$(head -n 1 < $2 | cut -f3- -d' ')
 fi
-cd -
-if test -f $2 ; then 
-	oldnum=`cat $2 | sed -ne 's/^#define BUILDNUM //p'`
-	oldbranch=`cat $2 | sed -ne 's/^#define BRANCH //p' | sed -e 's/\"//g'`
-else 
-	oldnum=0
-fi 
-if test -z "$oldnum" -o "$rev" -ne "$oldnum" -o -z "$oldbranch" -o "$oldbranch" != "$branch" ; then 
-	echo "Updating $2: revision $rev ($branch)"
-	echo "#define BUILDNUM $rev" > $2
-	if test "${dir:0:6}" != "branch" -o ! -z "$mod" ; then 
-		echo "#define BRANCH \"$branch\"" >> $2
-	fi
-	echo "#define REV_YEAR $(date +%Y)" >> $2
+THIS_STAMP=$(git log --max-count=1 --pretty=format:"%ai")
+#echo "LAST_STAMP='$LAST_STAMP'"
+#echo "THIS_STAMP='$THIS_STAMP'"
+#ls -l $2
+if [ "${LAST_STAMP:-none}" != "$THIS_STAMP" ]; then
+	cd $1
+	echo "// $2 $THIS_STAMP" > $2
+	echo "#define BUILDNUM $(echo $THIS_STAMP | cut -c3,4,6,7,9,10)" >> $2
+	echo "#define BRANCH \"$(git rev-parse --abbrev-ref HEAD)\"" >> $2
+	echo "#define REV_YEAR $(date '+%Y')" >> $2
+	echo "#define BUILD_NAME \"$(git remote | head -n 1)\"" >> $2
+	echo "#define BUILD_URL \"$(git remote get-url $(git remote | head -n 1) | sed -e 's/\.git//')\"" >> $2
+	echo "#define BUILD_BRANCH \"$(git rev-parse --abbrev-ref HEAD)\"" >> $2
+	echo "#define BUILD_SYSTEM \"$(uname -s)\"" >> $2
+	echo "#define BUILD_RELEASE \"$(uname -sr)\"" >> $2
+	echo "#define BUILD_ID \"$(git log -n 1 | sed -n '1s/^commit //p')\"" >> $2
+	echo "#define BUILD_OPTIONS \"$(./customize status | grep Enabled: | cut -f2 -d' ')\"" >> $2
+	echo "#define BUILD_STATUS $(git status -b --porcelain | sed -e 's/^/\"/g;s/$/\\n\"\\/g';echo \"\")" >> $2
+	cd -
 fi
+#ls -l $2

--- a/utilities/build_number
+++ b/utilities/build_number
@@ -15,7 +15,7 @@ if [ "${LAST_STAMP:-none}" != "$THIS_STAMP" ]; then
 	echo "#define BRANCH \"$(git rev-parse --abbrev-ref HEAD)\"" >> $2
 	echo "#define REV_YEAR $(date '+%Y')" >> $2
 	echo "#define BUILD_NAME \"$(git remote | head -n 1)\"" >> $2
-	echo "#define BUILD_URL \"$(git remote -v | head -n 1 | cut -f1 -d' ' | cut -f2 -d'	')\"" >> $2
+	echo "#define BUILD_URL \"$(git remote -v | head -n 1 | cut -f1 -d' ' | cut -f2 -d'	' | sed -e 's/\.git//')\"" >> $2
 	echo "#define BUILD_BRANCH \"$(git rev-parse --abbrev-ref HEAD)\"" >> $2
 	echo "#define BUILD_SYSTEM \"$(uname -s)\"" >> $2
 	echo "#define BUILD_RELEASE \"$(uname -sr)\"" >> $2

--- a/utilities/build_number
+++ b/utilities/build_number
@@ -15,7 +15,7 @@ if [ "${LAST_STAMP:-none}" != "$THIS_STAMP" ]; then
 	echo "#define BRANCH \"$(git rev-parse --abbrev-ref HEAD)\"" >> $2
 	echo "#define REV_YEAR $(date '+%Y')" >> $2
 	echo "#define BUILD_NAME \"$(git remote | head -n 1)\"" >> $2
-	echo "#define BUILD_URL \"$(git remote get-url $(git remote | head -n 1) | sed -e 's/\.git//')\"" >> $2
+	echo "#define BUILD_URL \"$(git remote -v | head -n 1 | cut -f1 -d' ' | cut -f2 -d'	')\"" >> $2
 	echo "#define BUILD_BRANCH \"$(git rev-parse --abbrev-ref HEAD)\"" >> $2
 	echo "#define BUILD_SYSTEM \"$(uname -s)\"" >> $2
 	echo "#define BUILD_RELEASE \"$(uname -sr)\"" >> $2


### PR DESCRIPTION
This PR addresses issue(s) #152 and replaces PR #155, which is now deprecated.

## Current issues
1. XML is not yet supported. Not sure anybody cares.

## Code changes
1. Changed how `./utilities/build_number` works.
2. Simplified `--version` command line option.
3. Added `--build-info [format={raw,json}]` command line option.

## Documentation changes
None

## Test and Validation Notes
None