### PR TITLE
Fix python module version info

### DIFF
--- a/gldcore/link/python/setup.py
+++ b/gldcore/link/python/setup.py
@@ -1,11 +1,27 @@
 """
-To build the python module use the following command:
+The gridlabd module is automatically installed as part of a full gridlabd install:
 
-  python gldcore/link/python/setup.py build
+  host% make install
+
+To build only the python module use the following command can be run after gridlabd is installed
+
+  bash% export SRCDIR=$PWD
+  bash% python gldcore/link/python/setup.py build
+
 
 To install the python module use the following command:
 
-  python gldcore/link/python/setup.py install
+  bash% export SRCDIR=$PWD
+  bash% python gldcore/link/python/setup.py install
+
+To uninstall the python module, you must save the list of installed files
+
+  bash% export SRCDIR=$PWD
+  bash% python gldcore/link/python/setup.py install --record files.txt
+
+Then you can uninstall gridlabd's python module using the command
+
+  bash% rm $(cat files.txt)
 
 """
 import sys
@@ -16,9 +32,6 @@ srcdir = os.getenv('SRCDIR')
 if not srcdir :
 	raise Exception("SRCDIR environment variable was not set -- try the command 'export SRCDIR=$PWD' before running setup.py")
 
-#if not os.path.exists('gldcore/build.h') :
-#	raise Exception("python module must be built after the main build is completed (gldcore/build.h is missing)")
-
 try:
 	from compile_options import *
 except:
@@ -27,10 +40,8 @@ except:
 		compile_options = os.getenv("CFLAGS").split(" ")
 	except :
 		compile_options = None
-	if not compile_options :
-		compile_options=['-Wall','-O3','-g']
-if not srcdir :
-	raise Exception("SRCDIR environment variable was not set -- try the command 'export SRCDIR=$PWD' before running setup.py")
+if not compile_options :
+	compile_options=['-Wall','-O3','-g']
 compile_options.extend(['-I%s/gldcore'%srcdir,'-Igldcore','-Igldcore/rt',"-DHAVE_CONFIG_H","-DHAVE_PYTHON"])
 
 from distutils.core import setup, Extension

--- a/gldcore/link/python/setup.py
+++ b/gldcore/link/python/setup.py
@@ -101,8 +101,33 @@ gridlabd = Extension('gridlabd',
 		])),
 	)
 
-setup (	name = 'GridLAB-D',
-		version = '4.2',
+def get_version(path=None):
+	if path == None :
+		path = srcdir + "/gldcore"
+	major = None
+	minor = None
+	patch = None
+	build = None
+	with open(path + "/version.h") as f:
+		for line in f:
+			info = line.split(" ")
+			if info[0] == "#define":
+				if info[1] == "REV_MAJOR":
+					major = int(info[2])
+				elif info[1] == "REV_MINOR":
+					minor = int(info[2])
+				elif info[1] == "REV_PATCH":
+					patch = int(info[2])
+	with open(path + "/build.h") as f:
+		for line in f:
+			info = line.split(" ")
+			if info[0] == "#define":
+				if info[1] == "BUILDNUM":
+					build = int(info[2])
+	return '%d.%d.%d.%d' % (major,minor,patch,build)
+
+setup (	name = 'gridlabd',
+		version = get_version(),
 		description = 'GridLAB-D Power System Simulator',
 		author = 'David P. Chassin',
 		author_email = 'dchassin@stanford.edu',

--- a/gldcore/link/python/setup.py
+++ b/gldcore/link/python/setup.py
@@ -128,7 +128,7 @@ def get_version(path=None):
 
 setup (	name = 'gridlabd',
 		version = get_version(),
-		description = 'GridLAB-D Power System Simulator',
+		description = 'GridLAB-D Smart Grid Simulator',
 		author = 'David P. Chassin',
 		author_email = 'dchassin@stanford.edu',
 		ext_modules = [gridlabd])


### PR DESCRIPTION
This PR addresses a potential issue with the python module version information.  The version info was stored statically in `gldcore/link/python/setup.py` and it was missing the patch and build number information needed to clearly identify the module build.

Now the version information is obtained directly from the `gldcore/{version,build}.h` files and includes all the information needed to clearly identify a build, including `major`, `minor`, `patch`, and `build`.

The name of the module was also changed from `GridLAB-D` to `gridlabd` to be more consistent with the colloquial naming convention for python modules.  This means that previous python module builds of `GridLAB-D` will remain installed on the system unless they are manually deleted.

To verify that the version information is correct, use the following command:
~~~
host% pip3 freeze | grep gridlabd
~~~
which should return the most recent `make install` version information.