### PR TITLE
[DRAFT - TBD] Load and power naming convention in house_e

### DIFF
--- a/connection/autotest/test_fncs_msg_client.glm
+++ b/connection/autotest/test_fncs_msg_client.glm
@@ -122,7 +122,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint cooling_setpoint;
 			demand cooling_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			ramp_low 2;
 			ramp_high 2;

--- a/market/autotest/test_controller_override.glm
+++ b/market/autotest/test_controller_override.glm
@@ -112,7 +112,7 @@ object house {
           cooling_ramp_high 2.400;
           heating_ramp_low -2.400;
           cooling_ramp_low 2.400;
-          total total_load;
+          total total_power;
           load hvac_load;
           state power_state;
       };

--- a/market/autotest/test_market_quantity_conversion.glm
+++ b/market/autotest/test_market_quantity_conversion.glm
@@ -76,7 +76,7 @@ object house {
 		base_setpoint 60;
 		slider_setting 1;
 		demand heating_demand;
-		total total_load;
+		total total_power;
 		load hvac_load;
 		state power_state;
 		object double_assert {

--- a/market/autotest/test_markets_controller_cooling_deadband_matching_period.glm
+++ b/market/autotest/test_markets_controller_cooling_deadband_matching_period.glm
@@ -149,7 +149,7 @@ object triplex_meter {
 			cooling_setpoint cooling_setpoint;
 			cooling_demand cooling_demand;
 			deadband thermostat_deadband;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			heating_range_high 4;
 			heating_range_low -5;

--- a/market/autotest/test_markets_controller_cooling_inelastic_double.glm
+++ b/market/autotest/test_markets_controller_cooling_inelastic_double.glm
@@ -157,7 +157,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint cooling_setpoint;
 			demand cooling_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low 2;
@@ -198,7 +198,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint cooling_setpoint;
 			demand cooling_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low 2;

--- a/market/autotest/test_markets_controller_cooling_inelastic_matching_period.glm
+++ b/market/autotest/test_markets_controller_cooling_inelastic_matching_period.glm
@@ -159,7 +159,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint cooling_setpoint;
 			demand cooling_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low 2;

--- a/market/autotest/test_markets_controller_cooling_inelastic_nonmatching_periods.glm
+++ b/market/autotest/test_markets_controller_cooling_inelastic_nonmatching_periods.glm
@@ -157,7 +157,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint cooling_setpoint;
 			demand cooling_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low 2;

--- a/market/autotest/test_markets_controller_heating_deadband_matching_period.glm
+++ b/market/autotest/test_markets_controller_heating_deadband_matching_period.glm
@@ -144,7 +144,7 @@ object triplex_meter {
 			cooling_setpoint cooling_setpoint;
 			cooling_demand cooling_demand;
 			deadband thermostat_deadband;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			heating_range_high 4;
 			heating_range_low -5;

--- a/market/autotest/test_markets_controller_heating_inelastic_double.glm
+++ b/market/autotest/test_markets_controller_heating_inelastic_double.glm
@@ -129,7 +129,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint heating_setpoint;
 			demand heating_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low -2;
@@ -165,7 +165,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint heating_setpoint;
 			demand heating_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low -2;

--- a/market/autotest/test_markets_controller_heating_inelastic_matching_period.glm
+++ b/market/autotest/test_markets_controller_heating_inelastic_matching_period.glm
@@ -129,7 +129,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint heating_setpoint;
 			demand heating_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low -2;

--- a/market/autotest/test_markets_controller_heating_inelastic_nonmatching_period.glm
+++ b/market/autotest/test_markets_controller_heating_inelastic_nonmatching_period.glm
@@ -175,7 +175,7 @@ object triplex_meter {
 			target air_temperature;
 			setpoint heating_setpoint;
 			demand heating_demand;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			//slider_setting 0; //set to 0 or ramps will be overwritten
 			ramp_low -2;

--- a/market/autotest/test_unitless_bid_quantity_err.glm
+++ b/market/autotest/test_unitless_bid_quantity_err.glm
@@ -67,7 +67,7 @@ name house1;
 		base_setpoint 70;
 		slider_setting 1;
 		demand cooling_demand;
-		total total_load;
+		total total_power;
 		load hvac_load;
 		state power_state;
 	};

--- a/market/controller.cpp
+++ b/market/controller.cpp
@@ -217,7 +217,7 @@ void controller::cheat(){
 			sprintf(target, "air_temperature");
 			sprintf(setpoint, "heating_setpoint");
 			sprintf(demand, "heating_demand");
-			sprintf(total, "total_load");
+			sprintf(total, "total_power");
 			sprintf(load, "hvac_load");
 			sprintf(state, "power_state");
 			ramp_low = -2;
@@ -230,7 +230,7 @@ void controller::cheat(){
 			sprintf(target, "air_temperature");
 			sprintf(setpoint, "cooling_setpoint");
 			sprintf(demand, "cooling_demand");
-			sprintf(total, "total_load");
+			sprintf(total, "total_power");
 			sprintf(load, "hvac_load");
 			sprintf(state, "power_state");
 			ramp_low = 2;
@@ -243,7 +243,7 @@ void controller::cheat(){
 			sprintf(target, "air_temperature");
 			sprintf(setpoint, "heating_setpoint");
 			sprintf(demand, "heating_demand");
-			sprintf(total, "total_load");
+			sprintf(total, "total_power");
 			sprintf(load, "hvac_load");
 			sprintf(state, "power_state");
 			ramp_low = -2;
@@ -256,7 +256,7 @@ void controller::cheat(){
 			sprintf(target, "air_temperature");
 			sprintf(setpoint, "cooling_setpoint");
 			sprintf(demand, "cooling_demand");
-			sprintf(total, "total_load");
+			sprintf(total, "total_power");
 			sprintf(load, "hvac_load");
 			sprintf(state, "power_state");
 			ramp_low = 2;
@@ -281,15 +281,15 @@ void controller::cheat(){
 			sprintf(target, "air_temperature");
 			sprintf((char *)(&heating_setpoint), "heating_setpoint");
 			sprintf((char *)(&heating_demand), "heating_demand");
-			sprintf((char *)(&heating_total), "total_load");		// using total instead of heating_total
+			sprintf((char *)(&heating_total), "total_power");		// using total instead of heating_total
 			sprintf((char *)(&heating_load), "hvac_load");			// using load instead of heating_load
 			sprintf((char *)(&cooling_setpoint), "cooling_setpoint");
 			sprintf((char *)(&cooling_demand), "cooling_demand");
-			sprintf((char *)(&cooling_total), "total_load");		// using total instead of cooling_total
+			sprintf((char *)(&cooling_total), "total_power");		// using total instead of cooling_total
 			sprintf((char *)(&cooling_load), "hvac_load");			// using load instead of cooling_load
 			sprintf((char *)(&deadband), "thermostat_deadband");
 			sprintf(load, "hvac_load");
-			sprintf(total, "total_load");
+			sprintf(total, "total_power");
 			heat_ramp_low = -2;
 			heat_ramp_high = -2;
 			heat_range_low = -5;

--- a/market/double_controller.cpp
+++ b/market/double_controller.cpp
@@ -106,7 +106,7 @@ void double_controller::cheat( ) {
 			strcpy(heat_setpoint_name, "heating_setpoint");
 			strcpy(heat_demand_name, "heating_demand");
 			strcpy(load_name, "hvac_load");
-			strcpy(total_load_name, "total_load");
+			strcpy(total_load_name, "total_power");
 			strcpy(state_name,"power_state");
 			break;
 		default:

--- a/models/transactive_controller_example.glm
+++ b/models/transactive_controller_example.glm
@@ -141,7 +141,7 @@ object triplex_meter {
 			cooling_setpoint cooling_setpoint;
 			cooling_demand cooling_demand;
 			deadband thermostat_deadband;
-			total total_load;
+			total total_power;
 			load hvac_load;
 			heating_range_high 4;
 			heating_range_low -5;

--- a/obsolete_test_case/residential_test/evcharger.glm
+++ b/obsolete_test_case/residential_test/evcharger.glm
@@ -141,7 +141,7 @@ object transformer:..10 {
 object collector{
 	name HouseCollector;
 	group class=house;
-	property sum(total_load.mag),sum(enduse_load.mag),sum(power.mag);
+	property sum(total_power.mag),sum(enduse_load.mag),sum(power.mag);
 	file house_load.csv;
 	interval 3600;
 };

--- a/residential/autotest/test_residential_exercise_5_2_1.glm
+++ b/residential/autotest/test_residential_exercise_5_2_1.glm
@@ -34,7 +34,7 @@ object triplex_meter {
 		window_wall_ratio 0.07;
 		heating_COP 1.00;
 		object recorder {
-			property total_load;
+			property total_power;
 			file "exercise_5_2_1.csv";
 			interval 3600;
 			limit 168;

--- a/residential/autotest/test_total_power.glm
+++ b/residential/autotest/test_total_power.glm
@@ -1,0 +1,70 @@
+//This will test compares the total_power to hvac_load
+#set minimum_timestep=1;
+
+module residential{
+	implicit_enduses NONE;
+}
+module tape;
+module assert;
+module climate;
+module powerflow;
+
+clock{
+	timezone PST+8PDT;
+	starttime '2001-05-5 05:00:00';
+	stoptime '2001-05-6 05:00:02';
+}
+
+
+object climate{
+	name climate;
+	tmyfile "../WA-Yakima.tmy3";
+}
+
+schedule heatspt{
+	* * * * * 55;
+}
+
+schedule coolspt{
+	* * * * * 90;
+}
+
+object triplex_meter{
+	nominal_voltage 120;
+	phases AS;
+	object house{
+		system_mode OFF;
+		auxiliary_strategy DEADBAND;
+		heating_system_type HEAT_PUMP;
+		cooling_system_type ELECTRIC;
+		air_temperature 61.8;
+		mass_temperature 62.2;
+		heating_setpoint heatspt*1;
+		cooling_setpoint coolspt*1;
+		object recorder{
+			property total_power[kVA], hvac_power[kW];
+			file "test_total_power.csv";
+			interval -1;
+		};
+	//	object complex_assert{
+	//		target "panel.energy";
+	//		in '2001-05-2 5:00:00';
+	//		once ONCE_TRUE;
+	//		value 0+0i;
+	//		within 0.001;//asserting house_e within 1 percent of Rob's ETP result
+	//	};
+	};
+	object recorder{
+		property measured_real_power,measured_real_energy;
+		file "test_HVAC_balance_measured_power_energy.csv";
+		interval -1;
+	//	limit 86444;
+	};
+//	object double_assert{
+//		target "measured_real_energy";
+//		in '2001-05-2 5:00:00';
+//		once ONCE_TRUE;
+//		value 0;
+//		within 0.001;
+//	};
+}

--- a/residential/autotest/test_total_power.glm
+++ b/residential/autotest/test_total_power.glm
@@ -1,4 +1,5 @@
-//This will test compares the total_power to hvac_load
+//This will test compares the total_power to hvac_load to ensure consistency of units in house_e.cpp 
+// Author: aivanova@slac.stanford.edu
 #set minimum_timestep=1;
 
 module residential{
@@ -12,7 +13,7 @@ module powerflow;
 clock{
 	timezone PST+8PDT;
 	starttime '2001-05-5 05:00:00';
-	stoptime '2001-05-6 05:00:02';
+	stoptime '2001-05-6 05:00:00';
 }
 
 
@@ -22,11 +23,20 @@ object climate{
 }
 
 schedule heatspt{
-	* * * * * 55;
+	* * * * * 70;
 }
 
 schedule coolspt{
 	* * * * * 90;
+}
+
+schedule waterheater_demand_prob {
+	* 5-21 * * * 0.99;
+	* 22-4 * * * 0.01;
+}
+
+class waterheater{
+	loadshape wh_shape;
 }
 
 object triplex_meter{
@@ -41,30 +51,19 @@ object triplex_meter{
 		mass_temperature 62.2;
 		heating_setpoint heatspt*1;
 		cooling_setpoint coolspt*1;
+		object waterheater {
+			wh_shape "type: pulsed; schedule: waterheater_demand_prob; energy: 7.2 kWh; count: 6; power: 300 W";
+			tank_setpoint 140;
+			water_demand this.wh_shape*0.115; //scaling issue with loadshape/schedules 
+			heating_element_capacity 4500 W;
+			tank_volume 80 gal;
+		};
 		object recorder{
-			property total_power[kVA], hvac_power[kW];
+			property total_power[kVA], hvac_load[kVA], hvac_power[kVA], system_mode;
 			file "test_total_power.csv";
 			interval -1;
 		};
-	//	object complex_assert{
-	//		target "panel.energy";
-	//		in '2001-05-2 5:00:00';
-	//		once ONCE_TRUE;
-	//		value 0+0i;
-	//		within 0.001;//asserting house_e within 1 percent of Rob's ETP result
-	//	};
 	};
-	object recorder{
-		property measured_real_power,measured_real_energy;
-		file "test_HVAC_balance_measured_power_energy.csv";
-		interval -1;
-	//	limit 86444;
-	};
-//	object double_assert{
-//		target "measured_real_energy";
-//		in '2001-05-2 5:00:00';
-//		once ONCE_TRUE;
-//		value 0;
-//		within 0.001;
-//	};
 }
+
+script on_term "python3 ../test_total_power.py";

--- a/residential/autotest/test_total_power.py
+++ b/residential/autotest/test_total_power.py
@@ -1,0 +1,28 @@
+import csv 
+import os 
+import numpy as np
+
+csv_exists = os.path.isfile("test_total_power.csv")
+
+if csv_exists : 
+	with open("test_total_power.csv", 'r') as csvfile : 
+		#print(data)
+		if os.stat("test_total_power.csv").st_size == 0 : 
+			exit(1) #empty file 
+		else : 
+			data_file = list(csv.reader(csvfile))
+			for data in data_file[9:]: 
+				if  '# end of tape' in data :
+					exit(0)
+				else : 
+					total_power = data[1].split()[0] #magnitude of total_power
+					hvac_power = data[2].split()[0] #magnitude of hvac_power
+					total_power = float(total_power.split("+")[1]) #magnitude of total_power
+					hvac_power = float(hvac_power.split("+")[1]) #magnitude of hvac_power
+					if total_power >= hvac_power : 
+						continue
+					else : 
+						exit(1)
+
+
+			

--- a/residential/house_e.cpp
+++ b/residential/house_e.cpp
@@ -557,7 +557,7 @@ house_e::house_e(MODULE *mod) : residential_enduse(mod)
 			PT_double,"last_heating_load[kW]",PADDR(last_heating_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_double,"last_cooling_load[kW]",PADDR(last_cooling_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_complex,"hvac_power[kVA]",PADDR(hvac_power),PT_DESCRIPTION,"describes hvac load complex power consumption",
-			PT_double,"total_load[kW]",PADDR(total_load),
+			PT_double,"total_power[kW]",PADDR(total_power),
 			PT_enduse,"panel",PADDR(total),PT_DESCRIPTION,"total panel enduse load",
 			PT_double,"design_internal_gain_density[W/sf]",PADDR(design_internal_gain_density),PT_DESCRIPTION,"average density of heat generating devices in the house",
 			PT_bool,"compressor_on",PADDR(compressor_on),
@@ -3240,7 +3240,7 @@ TIMESTAMP house_e::sync_panel(TIMESTAMP t0, TIMESTAMP t1)
 	 * and it should not sync the struct! ~MH */
 	//TIMESTAMP t = gl_enduse_sync(&total,t1); if (t<t2) t2 = t;
 
-	total_load = total.total.Mag();
+	total_power = total.total.Mag();
 
 	// compute line currents and post to meter
 	if (obj->parent != NULL)

--- a/residential/house_e.cpp
+++ b/residential/house_e.cpp
@@ -553,7 +553,7 @@ house_e::house_e(MODULE *mod) : residential_enduse(mod)
 			PT_double, "hvac_breaker_rating[A]", PADDR(hvac_breaker_rating), PT_DESCRIPTION,"determines the amount of current the HVAC circuit breaker can handle",
 			PT_double, "hvac_power_factor[unit]", PADDR(hvac_power_factor), PT_DESCRIPTION,"power factor of hvac",
 			
-			PT_double,"hvac_load[kW]",PADDR(hvac_load),PT_DESCRIPTION,"heating/cooling system load",
+			PT_double,"hvac_load[kVA]",PADDR(hvac_load),PT_DESCRIPTION,"heating/cooling system load (magnitude of power component)",
 			PT_double,"last_heating_load[kW]",PADDR(last_heating_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_double,"last_cooling_load[kW]",PADDR(last_cooling_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_complex,"hvac_power[kVA]",PADDR(hvac_power),PT_DESCRIPTION,"describes hvac load complex power consumption",

--- a/residential/house_e.cpp
+++ b/residential/house_e.cpp
@@ -557,7 +557,7 @@ house_e::house_e(MODULE *mod) : residential_enduse(mod)
 			PT_double,"last_heating_load[kW]",PADDR(last_heating_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_double,"last_cooling_load[kW]",PADDR(last_cooling_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_complex,"hvac_power[kVA]",PADDR(hvac_power),PT_DESCRIPTION,"describes hvac load complex power consumption",
-			PT_double,"total_power[kVA]",PADDR(total_power),"magnitude of the panel power"
+			PT_double,"total_power[kVA]",PADDR(total_power),"magnitude of the panel power",
 			PT_enduse,"panel",PADDR(total),PT_DESCRIPTION,"total panel enduse load",
 			PT_double,"design_internal_gain_density[W/sf]",PADDR(design_internal_gain_density),PT_DESCRIPTION,"average density of heat generating devices in the house",
 			PT_bool,"compressor_on",PADDR(compressor_on),

--- a/residential/house_e.cpp
+++ b/residential/house_e.cpp
@@ -557,7 +557,7 @@ house_e::house_e(MODULE *mod) : residential_enduse(mod)
 			PT_double,"last_heating_load[kW]",PADDR(last_heating_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_double,"last_cooling_load[kW]",PADDR(last_cooling_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_complex,"hvac_power[kVA]",PADDR(hvac_power),PT_DESCRIPTION,"describes hvac load complex power consumption",
-			PT_double,"total_power[kW]",PADDR(total_power),
+			PT_double,"total_power[kVA]",PADDR(total_power),"magnitude of the panel power"
 			PT_enduse,"panel",PADDR(total),PT_DESCRIPTION,"total panel enduse load",
 			PT_double,"design_internal_gain_density[W/sf]",PADDR(design_internal_gain_density),PT_DESCRIPTION,"average density of heat generating devices in the house",
 			PT_bool,"compressor_on",PADDR(compressor_on),

--- a/residential/house_e.cpp
+++ b/residential/house_e.cpp
@@ -557,7 +557,7 @@ house_e::house_e(MODULE *mod) : residential_enduse(mod)
 			PT_double,"last_heating_load[kW]",PADDR(last_heating_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_double,"last_cooling_load[kW]",PADDR(last_cooling_load),PT_DESCRIPTION,"stores the previous heating/cooling system load",
 			PT_complex,"hvac_power[kVA]",PADDR(hvac_power),PT_DESCRIPTION,"describes hvac load complex power consumption",
-			PT_double,"total_power[kVA]",PADDR(total_power),"magnitude of the panel power",
+			PT_double,"total_power[kVA]",PADDR(total_power),PT_DESCRIPTION, "magnitude of the panel power",
 			PT_enduse,"panel",PADDR(total),PT_DESCRIPTION,"total panel enduse load",
 			PT_double,"design_internal_gain_density[W/sf]",PADDR(design_internal_gain_density),PT_DESCRIPTION,"average density of heat generating devices in the house",
 			PT_bool,"compressor_on",PADDR(compressor_on),

--- a/residential/house_e.h
+++ b/residential/house_e.h
@@ -224,7 +224,7 @@ public:
 
 	/* inherited res_enduse::load is hvac system load */
 	double hvac_load;
-	double total_load;
+	double total_power;
 	enduse total; /* total load */
 	double heating_demand;
 	double cooling_demand;

--- a/tape/metrics_collector.cpp
+++ b/tape/metrics_collector.cpp
@@ -665,7 +665,7 @@ int metrics_collector::read_line(OBJECT *obj)
 	else if (strcmp(parent_string, "house") == 0)
 	{
 		// Get load values
-		double totalload = *gl_get_double_by_name(obj->parent, "total_load");
+		double totalload = *gl_get_double_by_name(obj->parent, "total_power");
 		interpolate (total_load_array, last_index, curr_index, totalload);
 		double hvacload = *gl_get_double_by_name(obj->parent, "hvac_load");
 		interpolate (hvac_load_array, last_index, curr_index, hvacload);


### PR DESCRIPTION
This PR addresses issue(s) #215 
## Current issues
1. Comparison of variable total_load to hvac_load shows inconsistency since total_load is a magnitude of power and hvac load is only real power. 

## Code changes
1. house_e and the autotests that use `total_load` variable
2. Created an autotest `residential/test_total_power.glm` to verify that the total_power is larger than hvac load.

## Documentation changes
- none

## Test and Validation Notes
1. Run validate. 
2. Check test file  in `residential/autotest/test_total_power.glm`