### PR TITLE
Fix for gridlabd.set_value bug

### DIFF
--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -889,7 +889,7 @@ static PyObject *gridlabd_set_value(PyObject *self, PyObject *args)
 
     char previous[1024]="";
     WriteLock();
-    int len = object_get_value_by_name(obj,property,value,sizeof(value));
+    int len = object_get_value_by_name(obj,property,previous,sizeof(previous));
     if ( len < 0 )
         return gridlabd_exception("unable to get old value of '%s.%s'", name,property);
     len = object_set_value_by_name(obj,property,value);


### PR DESCRIPTION
This PR addresses issue(s) #223 

## Current issues
None

## Code changes
python.cpp set function

## Documentation changes
none

## Test and Validation Notes
1. Try an example using `gridlabd.set_value(name, property,value)`