### PR TITLE
Fix precommit problems in python

### DIFF
--- a/gldcore/link/python/example.glm
+++ b/gldcore/link/python/example.glm
@@ -21,5 +21,6 @@ object test {
 	x "type:lognormal(0,1); refresh:5min";
 
 	// dispatch commit calls to the python module
+	on_precommit "python:my_test.precommit";
 	on_commit "python:my_test.commit";
 }

--- a/gldcore/link/python/example.py
+++ b/gldcore/link/python/example.py
@@ -7,7 +7,7 @@ import gridlabd
 gridlabd.command('example.glm')
 gridlabd.command('-D')
 gridlabd.command('suppress_repeat_messages=FALSE')
-gridlabd.command('--warn')
+#gridlabd.command('--debug')
 
 # start gridlabd and wait for it to complete
 gridlabd.start('wait')

--- a/gldcore/link/python/my_test.py
+++ b/gldcore/link/python/my_test.py
@@ -23,6 +23,9 @@ def on_init(t) :
 	# successful init
 	return True
 
+def precommit(obj,t) :
+	return gridlabd.NEVER
+	
 def commit(obj,t) :
 	
 	# sample the object data

--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -1295,9 +1295,10 @@ extern "C" TIMESTAMP on_precommit(TIMESTAMP t0)
         }
         else
         {
-            output_warning("python on_postsync() is not callable");
+            output_warning("python on_precommit() is not callable");
         }
     }
+    output_debug("python on_precommit returns t=%lld",t1);
     return t1;
 }
 extern "C" TIMESTAMP on_presync(TIMESTAMP t0)
@@ -1557,6 +1558,7 @@ int python_event(OBJECT *obj, const char *function, long long *p_retval)
             {
                 Py_DECREF(result);
             }
+            output_debug("python_event(obj='%s',function='%s') -> *p_retval = %lld",objname,function,*p_retval);
             return 1;
         }    
         else 


### PR DESCRIPTION
This PR addresses issue #232

## Current issues
1. the return timestamp is used only for pass/fail and is otherwise ignored.

## Code changes
1. added some debug messages
2. changed the way the return value is interpreted to temporarily fix the failure condition.

## Documentation changes
None

## Test and Validation Notes
1. Extended the python example.py to illustrate the current solution
