### PR TITLE
Added support for #on_exit

### DIFF
--- a/gldcore/autotest/test_json_onexit.glm
+++ b/gldcore/autotest/test_json_onexit.glm
@@ -1,0 +1,11 @@
+class test {
+    char1024 dict;
+    char1024 list;
+}
+
+object test {
+    dict "{\"a\":[\"b\",\"c\",\"d\"]}";
+    list "[\"a\",\"b\",\"c\"]";
+}
+#set savefile=gridlabd.json
+#on_exit 0 python3 ../check_json.py

--- a/gldcore/autotest/test_onexit_command.glm
+++ b/gldcore/autotest/test_onexit_command.glm
@@ -5,5 +5,5 @@
 #system echo ${VARIABLE}
 
 #if VARIABLE < 9
-#on_exit 0 gridlabd -D VARIABLE=$((${VARIABLE}+1)) ${modelname} &
+#on_exit 0 ${exename} -D VARIABLE=$((${VARIABLE}+1)) ${modelname} &
 #endif

--- a/gldcore/autotest/test_onexit_command.glm
+++ b/gldcore/autotest/test_onexit_command.glm
@@ -2,8 +2,8 @@
 #define VARIABLE=0
 #endif
 
-#system echo ${VARIABLE}
+#system echo ${VARIABLE} >> gridlabd.out
 
 #if VARIABLE < 9
-#on_exit 0 ${exename} -D VARIABLE=$((${VARIABLE}+1)) ${modelname} &
+#on_exit 0 ${exename} -D VARIABLE=$((${VARIABLE}+1)) ${modelname} & 
 #endif

--- a/gldcore/autotest/test_onexit_command.glm
+++ b/gldcore/autotest/test_onexit_command.glm
@@ -1,0 +1,2 @@
+#set verbose=TRUE
+#on_exit  echo test; exit 0

--- a/gldcore/autotest/test_onexit_command.glm
+++ b/gldcore/autotest/test_onexit_command.glm
@@ -1,2 +1,9 @@
-#set verbose=TRUE
-#on_exit  echo test; exit 0
+#ifndef VARIABLE
+#define VARIABLE=0
+#endif
+
+#system echo ${VARIABLE}
+
+#if VARIABLE < 9
+#on_exit 0 gridlabd -D VARIABLE=$((${VARIABLE}+1)) ${modelname} &
+#endif

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -7261,6 +7261,26 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 		strcpy(line,"\n");
 		return TRUE;
 	}
+	else if ( strncmp(line,MACRO "on_exit",8) == 0 )
+	{
+		int xc;
+		char cmd[1024];
+		if ( sscanf(line+8,"%d %1023[^\n]",&xc,cmd) < 2 )
+		{
+			output_error_raw("%s(%d): on_exit syntax error", filename,linenum);
+			return FALSE;
+		}
+		else if ( ! my_instance->add_on_exit(xc,cmd) )
+		{
+			output_error_raw("%s(%d): on_exit %d command '%s'", filename,linenum,xc,cmd);
+			return FALSE;
+		}
+		else
+		{
+			strcpy(line,"\n");
+			return TRUE;
+		}
+	}
 	else
 	{
 		char tmp[1024], *p;

--- a/gldcore/main.cpp
+++ b/gldcore/main.cpp
@@ -225,6 +225,7 @@ GldMain::~GldMain(void)
 	IN_MYCONTEXT output_verbose("elapsed runtime %d seconds", realtime_runtime());
 	IN_MYCONTEXT output_verbose("exit code %d", exec.getexitcode());
 
+	run_on_exit(exec.getexitcode());
 	exit(exec.getexitcode());
 
 	// TODO: remove this when reetrant code is done
@@ -329,5 +330,41 @@ void GldMain::delete_pidfile(void)
 	unlink(global_pidfile);
 }
 
+int GldMain::add_on_exit(int xc, const char *cmd)
+{
+	try
+	{
+		onexitcommand *item = new onexitcommand(xc,cmd);
+		exitcommands.push_back(*item);
+		size_t n = exitcommands.size();
+		IN_MYCONTEXT output_verbose("added on_exit(%d,'%s') -> %d", xc, cmd, n);
+		return n;
+	}
+	catch (...)
+	{
+		output_error("unable to add on_exit %d '%s'", xc, cmd);
+		return 0;
+	}
+}
+
+void GldMain::run_on_exit(int xc)
+{
+	for ( std::list<onexitcommand>::iterator cmd = exitcommands.begin() ; cmd != exitcommands.end() ; cmd++ )
+	{
+		if ( cmd->get_exitcode() == xc )
+		{
+			int rc = cmd->run();
+			if ( rc != 0 )
+			{
+				output_error("on_exit %d '%s' command failed (return code %d)", cmd->get_exitcode(), cmd->get_command(), rc);
+				return;
+			}
+			else
+			{
+				IN_MYCONTEXT output_verbose("running on_exit(%d,'%s') -> code %d", cmd->get_exitcode(), cmd->get_command(), rc);
+			}
+		}
+	}
+}
 
 /** @} **/

--- a/gldcore/main.h
+++ b/gldcore/main.h
@@ -15,11 +15,43 @@
 #include "cmdarg.h"
 #include "gui.h"
 
+#include <list>
+
+class onexitcommand {
+private:
+	int exitcode;
+	const char *command;
+public:
+	inline onexitcommand(int xc, const char *cmd)
+	{
+		exitcode = xc;
+		command = strdup(cmd);
+	};
+	inline ~onexitcommand(void)
+	{
+		free((void*)command);
+	}
+	inline int get_exitcode(void) 
+	{ 
+		return exitcode; 
+	};
+	inline const char * get_command(void)
+	{
+		return command;
+	};
+	inline int run(void)
+	{
+		return system(command);
+	};
+};
+
 /*	Class: GldMain
 
 	The GldMain class implement an instance of a GridLAB-D simulation.
  */
 class GldMain {
+private: // private variables
+	std::list<onexitcommand> exitcommands;
 private: // instance variables
 	GldGlobals globals;
 	GldExec exec;
@@ -86,6 +118,18 @@ public:
 	 */
 	int mainloop(int argc = 0, const char *argv[] = NULL);
 
+	/* 	Method: add_on_exit
+
+		Adds a command to be executed on exit of main
+	 */
+	int add_on_exit(int xc, const char *cmd);
+
+	/*	Method: run_on_exit
+
+		Runs the on-exit command list for the exit code given
+	 */
+	void run_on_exit(int xc);
+
 private:	// private methods
 	void set_global_browser(const char *path = NULL);
 	void set_global_execname(const char *path);
@@ -150,6 +194,7 @@ public:
 
 	// Method: global_push
 	inline void global_push(char *name, char *value) { return globals.push(name,value);};
+
 };
 
 DEPRECATED extern GldMain *my_instance; // TODO: move this into main() to make system globally reentrant


### PR DESCRIPTION
This PR addresses issue #270.

## Current issues
1. None

## Code changes
1. Added `#on_exit` macro handler to `gldcore/load.cpp`
2. Added `on_exit` support to `gldcore/main.{cpp, h}`

## Documentation changes
- [on_exit](https://github.com/dchassin/gridlabd/wiki/on_exit)

## Test and Validation Notes
1. Added `gldcore/autotest/test_onexit_command.glm`