### PR TITLE
Fixed glm_save_options bug

### DIFF
--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -727,7 +727,7 @@ typedef enum {
 } GLMSAVEOPTIONS;
 
 /* Variable:  */
-GLOBAL GLMSAVEOPTIONS global_glm_save_options INIT(GSO_LEGACY);	/**< multirun mode connection */
+GLOBAL set global_glm_save_options INIT(GSO_LEGACY);	/**< multirun mode connection */
 
 #undef GLOBAL
 #undef INIT


### PR DESCRIPTION
This PR addresses a bug using `#set glm_save_options=MINIMAL`. 

## Current issues
None

## Code changes
1. Change global variable type to set.

## Documentation changes
None

## Test and Validation Notes
None
