### PR TITLE
Fix for ISO timestamps and macros

### DIFF
--- a/gldcore/autotest/test_iso_datetime_macro.glm
+++ b/gldcore/autotest/test_iso_datetime_macro.glm
@@ -1,0 +1,28 @@
+module tape;
+module climate; 
+module assert;
+#define STARTTIME="2000-01-30T00:00:00-05:00"
+#define STOPTIME="2000-01-30T00:01:00-05:00"
+clock {
+	timezone "EST+5EDT";
+	starttime "${STARTTIME}";
+	stoptime "${STOPTIME}";
+}
+
+class test {
+	double test_var;
+};
+
+class climate {
+ 	randomvar clouds;
+} 
+
+object climate{
+	clouds "type:weibull(0.5,0.5); min:0.0; max:1.0; refresh:1h;";
+}
+
+object test {
+	name Test;	
+};
+
+script on_term gridlabd:dump test_clock.json;

--- a/gldcore/timestamp.cpp
+++ b/gldcore/timestamp.cpp
@@ -1182,7 +1182,7 @@ TIMESTAMP convert_to_timestamp(const char *value)
 	if (*value=='\'' || *value=='"') value++;
 
 	/* ISO8601 support */
-	if ( sscanf(value,"%4hu-%2hu-%2huT%2hu:%2hu:%lf %2hu:%2hu",&Y,&m,&d,&H,&M,&s,&tzh,&tzm) > 6 
+	if ( sscanf(value,"%4hu-%2hu-%2huT%2hu:%2hu:%lf%hd:%hu",&Y,&m,&d,&H,&M,&s,&tzh,&tzm) > 6 
 		|| ( sscanf(value,"%4hu-%2hu-%2huT%2hu:%2hu:%lf%c",&Y,&m,&d,&H,&M,&s,tz) == 7 && strcmp(tz,"Z")==0) )
 	{
 		S = (unsigned short)s;


### PR DESCRIPTION
This PR addresses issue(s) #282 
## Current issues
1. Global definition in quotes and variable name without quotes still gives an error, indicating that the global definition may strip the quotes off of the defined string

## Code changes
1. `timestamp.cpp` and additional auto test `test_iso_datetime_macro.glm`

## Documentation changes
- none

## Test and Validation Notes
1. Run `test_iso_datetime_macro.glm`