### PR TITLE
Fix internal filter definition

### DIFF
--- a/gldcore/autotest/test_schedule_xform_external.glm
+++ b/gldcore/autotest/test_schedule_xform_external.glm
@@ -59,7 +59,7 @@ object house {
 	cooling_setpoint House1.cooling_setpoint+1;
 	
 	// transform references property in this object
-	heating_setpoint myfunction2(this.cooling_setpoint);
+	heating_setpoint myfunction2(cooling_setpoint);
 	
 	// transform references schedule
 	air_temperature test_schedule+70;

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -4439,50 +4439,6 @@ static int object_properties(PARSER, CLASS *oclass, OBJECT *obj)
 					ACCEPT;
 				}
 			}
-			else if (prop!=NULL && prop->ptype==PT_double && TERM(external_transform(HERE, &xstype, sources, sizeof(sources), transformname, sizeof(transformname), obj)))
-			{
-				// TODO handle more than one source
-				char sobj[64], sprop[64];
-				int n = sscanf(sources,"%[^.].%[^,]",sobj,sprop);
-				OBJECT *source_obj;
-				PROPERTY *source_prop;
-
-				/* get source object */
-				source_obj = (n==1||strcmp(sobj,"this")==0) ? obj : object_find_name(sobj);
-				if ( !source_obj )
-				{
-					output_error_raw("%s(%d): transform source object '%s' not found", filename, linenum, n==1?"this":sobj);
-					REJECT;
-					DONE;
-				}
-
-				/* get source property */
-				source_prop = object_get_property(source_obj, n==1?sobj:sprop,NULL);
-				if ( !source_prop )
-				{
-					output_error_raw("%s(%d): transform source property '%s' of object '%s' not found", filename, linenum, n==1?sobj:sprop, n==1?"this":sobj);
-					REJECT;
-					DONE;
-				}
-
-				/* add to external transform list */
-				if ( !transform_add_external(obj,prop,transformname,source_obj,source_prop) )
-				{
-					output_error_raw("%s(%d): external transform could not be created - %s", filename, linenum, errno?strerror(errno):"(no details)");
-					REJECT;
-					DONE;
-				}
-				else if ( source!=NULL )
-				{
-					/* a transform is unresolved */
-					if (first_unresolved==source)
-
-						/* source was the unresolved entry, for now it will be the transform itself */
-						first_unresolved->ref = (void*)transform_getnext(NULL);
-
-					ACCEPT;
-				}
-			}
 			else if (prop!=NULL && prop->ptype==PT_double && TERM(filter_transform(HERE, &xstype, sources, sizeof(sources), transformname, sizeof(transformname), obj)))
 			{
 				// TODO handle more than one source
@@ -4513,6 +4469,50 @@ static int object_properties(PARSER, CLASS *oclass, OBJECT *obj)
 				if ( !transform_add_filter(obj,prop,transformname,source_obj,source_prop) )
 				{
 					output_error_raw("%s(%d): filter transform could not be created - %s", filename, linenum, errno?strerror(errno):"(no details)");
+					REJECT;
+					DONE;
+				}
+				else if ( source!=NULL )
+				{
+					/* a transform is unresolved */
+					if (first_unresolved==source)
+
+						/* source was the unresolved entry, for now it will be the transform itself */
+						first_unresolved->ref = (void*)transform_getnext(NULL);
+
+					ACCEPT;
+				}
+			}
+			else if (prop!=NULL && prop->ptype==PT_double && TERM(external_transform(HERE, &xstype, sources, sizeof(sources), transformname, sizeof(transformname), obj)))
+			{
+				// TODO handle more than one source
+				char sobj[64], sprop[64];
+				int n = sscanf(sources,"%[^.].%[^,]",sobj,sprop);
+				OBJECT *source_obj;
+				PROPERTY *source_prop;
+
+				/* get source object */
+				source_obj = (n==1||strcmp(sobj,"this")==0) ? obj : object_find_name(sobj);
+				if ( !source_obj )
+				{
+					output_error_raw("%s(%d): transform source object '%s' not found", filename, linenum, n==1?"this":sobj);
+					REJECT;
+					DONE;
+				}
+
+				/* get source property */
+				source_prop = object_get_property(source_obj, n==1?sobj:sprop,NULL);
+				if ( !source_prop )
+				{
+					output_error_raw("%s(%d): transform source property '%s' of object '%s' not found", filename, linenum, n==1?sobj:sprop, n==1?"this":sobj);
+					REJECT;
+					DONE;
+				}
+
+				/* add to external transform list */
+				if ( !transform_add_external(obj,prop,transformname,source_obj,source_prop) )
+				{
+					output_error_raw("%s(%d): external transform could not be created - %s", filename, linenum, errno?strerror(errno):"(no details)");
 					REJECT;
 					DONE;
 				}

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -3916,7 +3916,11 @@ static int filter_transform(PARSER, TRANSFORMSOURCE *xstype, char *sources, size
 	START;
 	if ( TERM(name(HERE,fncname,sizeof(fncname))) && (WHITE,LITERAL("(")) && (WHITE,TERM(property_list(HERE,varlist,sizeof(varlist)))) && LITERAL(")") )
 	{
-		if ( strlen(fncname)<namesize && strlen(varlist)<srcsize )
+		if ( transform_find_filter(fncname) == NULL )
+		{
+			REJECT;
+		}
+		else if ( strlen(fncname)<namesize && strlen(varlist)<srcsize )
 		{
 			strcpy(filtername,fncname);
 			strcpy(sources,varlist);

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -4447,7 +4447,7 @@ static int object_properties(PARSER, CLASS *oclass, OBJECT *obj)
 			{
 				// TODO handle more than one source
 				char sobj[64], sprop[64];
-				int n = sscanf(sources,"%[^:]:%[^,]",sobj,sprop);
+				int n = sscanf(sources,"%[^:,]:%[^,]",sobj,sprop);
 				OBJECT *source_obj;
 				PROPERTY *source_prop;
 
@@ -4491,7 +4491,7 @@ static int object_properties(PARSER, CLASS *oclass, OBJECT *obj)
 			{
 				// TODO handle more than one source
 				char sobj[64], sprop[64];
-				int n = sscanf(sources,"%[^.].%[^,]",sobj,sprop);
+				int n = sscanf(sources,"%[^:,]:%[^,]",sobj,sprop);
 				OBJECT *source_obj;
 				PROPERTY *source_prop;
 

--- a/gldcore/transform.cpp
+++ b/gldcore/transform.cpp
@@ -166,16 +166,20 @@ int transfer_function_add(char *name,		///< transfer function name
 	}
 	return 1;
 }
-TRANSFERFUNCTION *find_filter(char *name)
+
+TRANSFERFUNCTION *transform_find_filter(const char *name)
 {
 	TRANSFERFUNCTION *tf;
 	for ( tf = tflist ; tf != NULL ; tf = tf->next )
 	{
-		if ( strcmp(tf->name,name)==0 )
+		if ( strcmp(tf->name,name) == 0 )
+		{
 			return tf;
+		}
 	}
 	return NULL;
 }
+
 TRANSFORMSOURCE get_source_type(PROPERTY *prop)
 {
 	/* TODO extend this to support multiple sources */
@@ -202,7 +206,7 @@ int transform_add_filter(OBJECT *target_obj,		/* pointer to the target object (l
 	TRANSFERFUNCTION *tf;
 
 	// find the filter
-	tf = find_filter(filter);
+	tf = transform_find_filter(filter);
 	if ( tf == NULL )
 	{
 		output_error("transform_add_filter(source='%s:%s',filter='%s',target='%s:%s'): transfer function not defined",

--- a/gldcore/transform.h
+++ b/gldcore/transform.h
@@ -111,7 +111,7 @@ PROPERTYTYPE gldvar_gettype(GLDVAR *var, unsigned int n);
 const char *gldvar_getname(GLDVAR *var, unsigned int n);
 const char *gldvar_getstring(GLDVAR *var, unsigned int n, char *buffer, int size);
 UNIT *gldvar_getunits(GLDVAR *var, unsigned int n);
-
+TRANSFERFUNCTION *transform_find_filter(const char *name);
 int transform_add_filter(struct s_object_list *target_obj, struct s_property_map *target_prop, char *function, struct s_object_list *source_obj, struct s_property_map *source_prop);
 int transfer_function_add(char *tfname, char *domain, double timestep, double timeskew, unsigned int n, double *a, unsigned int m, double *b);
 


### PR DESCRIPTION
This PR addresses issue(s) #292 

## Current issues
1. None.

## Code changes
1. Swapped the order in which internal and external filters are tested in parsing. 
2. Changed the syntax for external filter to use ":" instead of "."

## Documentation changes
- See https://github.com/dchassin/gridlabd/wiki/Filter

## Test and Validation Notes
1. Try adding the filter
~~~
filter sum5(z,5min) = (1+z+z^2+z^3+z^4)/(z^5);
~~~
to `gldcore/link/python/example.glm` after the clock.  It should work ok now.