### PR TITLE
Fix for ISO8601 timestamp shifting 8 years

### DIFF
--- a/gldcore/timestamp.cpp
+++ b/gldcore/timestamp.cpp
@@ -1188,8 +1188,8 @@ TIMESTAMP convert_to_timestamp(const char *value)
 		S = (unsigned short)s;
 		unsigned int ns = (s-S)*1e9;
 		DATETIME dt = {Y,m,d,H,M,S,ns,0};
-		TIMESTAMP t = mkdatetime(&dt);
-		return t - (tzh*60+tzm)*60;
+		dt.tzoffset = (tzh*60+tzm)*60;
+		return mkdatetime(&dt);
 	}
 
 	/* scan ISO format date/time */


### PR DESCRIPTION
This PR addresses issue(s) #282 
## Current issues
1. Still have to specify ISO8601 timestamp in quotes when referencing the global variables since the the global definition strips the quotes. 

## Code changes
1. timestamp.cpp

## Documentation changes
- none

## Test and Validation Notes
1. Try ISO8601 format and pay attention to the simulation time