### PR TITLE
Fix issue with output of complex with invalid notation

### DIFF
--- a/gldcore/complex.h
+++ b/gldcore/complex.h
@@ -228,6 +228,16 @@ public:
 	// Method: Notation
 	inline CNOTATION & Notation(void) /**< access to notation */
 	{
+		switch (f)
+		{
+		case A:
+		case I:
+		case J:
+		case R:
+			break;
+		default:
+			f = I;
+		}
 		return f;
 	};
 

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -155,7 +155,7 @@ int GldJsonWriter::write_classes(FILE *fp)
 		if ( oclass->has_runtime ) TUPLE("runtime","%s",oclass->runtime);
 		if ( oclass->pmap != NULL )
 			len += write(",");
-		for ( prop = oclass->pmap ; prop != NULL ; prop=(prop->next?prop->next:(prop->oclass->parent?prop->oclass->parent->pmap:NULL)) )
+		for ( prop = oclass->pmap ; prop != NULL ; prop=prop->next )
 		{
 			KEYWORD *key;
 			const char *ptype = class_get_property_typename(prop->ptype);

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -155,7 +155,7 @@ int GldJsonWriter::write_classes(FILE *fp)
 		if ( oclass->has_runtime ) TUPLE("runtime","%s",oclass->runtime);
 		if ( oclass->pmap != NULL )
 			len += write(",");
-		for ( prop = oclass->pmap ; prop != NULL ; prop=prop->next )
+		for ( prop = oclass->pmap ; prop != NULL ; prop=prop->next ) // note: do not output parent classes properties
 		{
 			KEYWORD *key;
 			const char *ptype = class_get_property_typename(prop->ptype);

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -155,7 +155,7 @@ int GldJsonWriter::write_classes(FILE *fp)
 		if ( oclass->has_runtime ) TUPLE("runtime","%s",oclass->runtime);
 		if ( oclass->pmap != NULL )
 			len += write(",");
-		for ( prop = oclass->pmap ; prop != NULL ; prop=prop->next ) // note: do not output parent classes properties
+		for ( prop = oclass->pmap ; prop != NULL && prop->oclass == oclass ; prop=prop->next ) // note: do not output parent classes properties
 		{
 			KEYWORD *key;
 			const char *ptype = class_get_property_typename(prop->ptype);


### PR DESCRIPTION
This PR addresses an issue with GRIP json->glm conversion.

## Current issues
1. This problem does not fix the underlying problem, which is that some module is setting the notation of the complex value to '1', 2', or '3'.

## Code changes
1. Added fix to bad notation in complex.h
2. Removed parent class property list output to json

## Documentation changes
- None

## Test and Validation Notes
1. This will hopeful fix the problem @jcald1 found in the GRIP model. 
