### PR TITLE
Fixed python exit problem

### DIFF
--- a/gldcore/main.cpp
+++ b/gldcore/main.cpp
@@ -59,13 +59,13 @@ int main
 	{
 		try {
 			return_code = my_instance->mainloop(argc,argv);
-			my_instance->run_on_exit();
 		}
 		catch (const char *msg)
 		{
 			output_fatal("uncaught exception: %s", msg);
 			return_code = errno ? errno : XC_SHFAILED;
 		}
+		my_instance->run_on_exit();
 	}
 	return return_code;
 }

--- a/gldcore/main.cpp
+++ b/gldcore/main.cpp
@@ -59,14 +59,13 @@ int main
 	{
 		try {
 			return_code = my_instance->mainloop(argc,argv);
+			my_instance->run_on_exit();
 		}
 		catch (const char *msg)
 		{
 			output_fatal("uncaught exception: %s", msg);
 			return_code = errno ? errno : XC_SHFAILED;
 		}
-		delete my_instance;
-		my_instance = NULL;
 	}
 	return return_code;
 }
@@ -171,63 +170,6 @@ GldMain::GldMain(int argc, const char *argv[])
 
 GldMain::~GldMain(void)
 {
-	/* save the model */
-	if (strcmp(global_savefile,"")!=0)
-	{
-		if (saveall(global_savefile)==FAILED)
-			output_error("save to '%s' failed", global_savefile);
-	}
-
-	/* do module dumps */
-	if (global_dumpall!=FALSE)
-	{
-		IN_MYCONTEXT output_verbose("dumping module data");
-		module_dumpall();
-	}
-
-	/* KML output */
-	if (strcmp(global_kmlfile,"")!=0)
-		kml_dump(global_kmlfile);
-
-	/* terminate */
-	module_termall();
-
-	/* wrap up */
-	IN_MYCONTEXT output_verbose("shutdown complete");
-
-	/* profile results */
-	if (global_profiler)
-	{
-		class_profiles();
-		module_profiles();
-	}
-
-#ifdef DUMP_SCHEDULES
-	/* dump a copy of the schedules for reference */
-	schedule_dumpall("schedules.txt");
-#endif
-
-	/* restore locale */
-	locale_pop();
-
-	/* if pause enabled */
-#ifndef WIN32
-	if (global_pauseatexit)
-	{
-		IN_MYCONTEXT output_verbose("pausing at exit");
-		while (true) {
-			sleep(5);
-		}
-	}
-#endif
-
-	/* compute elapsed runtime */
-	IN_MYCONTEXT output_verbose("elapsed runtime %d seconds", realtime_runtime());
-	IN_MYCONTEXT output_verbose("exit code %d", exec.getexitcode());
-
-	run_on_exit(exec.getexitcode());
-	exit(exec.getexitcode());
-
 	// TODO: remove this when reetrant code is done
 	my_instance = NULL;
 
@@ -347,11 +289,65 @@ int GldMain::add_on_exit(int xc, const char *cmd)
 	}
 }
 
-void GldMain::run_on_exit(int xc)
+void GldMain::run_on_exit()
 {
+	/* save the model */
+	if (strcmp(global_savefile,"")!=0)
+	{
+		if (saveall(global_savefile)==FAILED)
+			output_error("save to '%s' failed", global_savefile);
+	}
+
+	/* do module dumps */
+	if (global_dumpall!=FALSE)
+	{
+		IN_MYCONTEXT output_verbose("dumping module data");
+		module_dumpall();
+	}
+
+	/* KML output */
+	if (strcmp(global_kmlfile,"")!=0)
+		kml_dump(global_kmlfile);
+
+	/* terminate */
+	module_termall();
+
+	/* wrap up */
+	IN_MYCONTEXT output_verbose("shutdown complete");
+
+	/* profile results */
+	if (global_profiler)
+	{
+		class_profiles();
+		module_profiles();
+	}
+
+#ifdef DUMP_SCHEDULES
+	/* dump a copy of the schedules for reference */
+	schedule_dumpall("schedules.txt");
+#endif
+
+	/* restore locale */
+	locale_pop();
+
+	/* if pause enabled */
+#ifndef WIN32
+	if (global_pauseatexit)
+	{
+		IN_MYCONTEXT output_verbose("pausing at exit");
+		while (true) {
+			sleep(5);
+		}
+	}
+#endif
+
+	/* compute elapsed runtime */
+	IN_MYCONTEXT output_verbose("elapsed runtime %d seconds", realtime_runtime());
+	IN_MYCONTEXT output_verbose("exit code %d", exec.getexitcode());
+
 	for ( std::list<onexitcommand>::iterator cmd = exitcommands.begin() ; cmd != exitcommands.end() ; cmd++ )
 	{
-		if ( cmd->get_exitcode() == xc )
+		if ( cmd->get_exitcode() == exec.getexitcode() )
 		{
 			int rc = cmd->run();
 			if ( rc != 0 )

--- a/gldcore/main.h
+++ b/gldcore/main.h
@@ -128,7 +128,7 @@ public:
 
 		Runs the on-exit command list for the exit code given
 	 */
-	void run_on_exit(int xc);
+	void run_on_exit();
 
 private:	// private methods
 	void set_global_browser(const char *path = NULL);


### PR DESCRIPTION
This PR addresses issue(s) #299 

## Current issues
No new issues.

## Code changes
1. Changed the run_on_exit() handling code

## Documentation changes
None

## Test and Validation Notes
1. Verify that powernet simulations can complete python calls to gridlabd module after `gridlabd.start('wait')` is called.