### PR TITLE
JSON support in loader

### DIFF
--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -492,3 +492,9 @@ int GldJsonWriter::dump()
 
 	return len > 0;
 }
+
+int json_to_glm(const char *jsonfile, char *glmfile)
+{
+	// TODO: convert JSON file to GLM
+	return 0;
+}

--- a/gldcore/json.h
+++ b/gldcore/json.h
@@ -17,6 +17,7 @@
 
 DEPRECATED CDECL int json_dump(const char *filename);
 DEPRECATED CDECL int json_output(FILE *fp);
+DEPRECATED CDECL int json_to_glm(const char *jsonfile, char *glmfile);
 
 class GldJsonWriter
 {

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -7634,6 +7634,10 @@ STATUS loadall(const char *fname)
 		strcpy(file,fname);
 	}
 	char *ext = fname ? strrchr(file,'.') : NULL ;
+	if ( strcmp(ext,".json") == 0 && json_to_glm(fname,file) )
+	{
+		return loadall(file);
+	}
 	unsigned int old_obj_count = object_get_count();
 	char conf[1024];
 	static int loaded_files = 0;

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -7637,7 +7637,7 @@ bool load_import(const char *from, char *to, int len)
 		output_error("load_import(from='%s',...): converter %s2glm.py not found", from, ext+1);
 		return false;
 	}
-	if ( strlen(from) >= len-1 )
+	if ( strlen(from) >= (size_t)(len-1) )
 	{
 		output_error("load_import(from='%s',...): 'from' is too long to handle", from);
 		return false;


### PR DESCRIPTION
This PR addresses issue(s) #315.

## Current issues
None

## Code changes
1. Added call to converts files to GLM using python converter. Converters must be in GLPATH and have the name `<ext>2glm.py` to function properly.  The calling convention for converters is `python3 <ext>2glm.py -i <input-file-name>.<ext> -o <output-file-name>.glm`

## Documentation changes
- https://github.com/dchassin/gridlabd/wiki/Automatic-import-conversion

## Test and Validation Notes
1. A new `gldcore` test is needed to check this for `json2glm.py` conversion.