### PR TITLE
Fix switch coordinator method interface

### DIFF
--- a/gismo/switch_coordinator.cpp
+++ b/gismo/switch_coordinator.cpp
@@ -205,13 +205,18 @@ int switch_coordinator::arm(char *name, size_t len)
 		return 0;
 	}
 	else
+	{
+		strcpy(name,"");
 		return 0;
+	}
 }
 
 int switch_coordinator::disarm(char *name, size_t len)
 {
 	if ( name == NULL )
+	{
 		return 0;
+	}
 	else if ( len == 0 )
 	{
 		if ( strcmp(name,"") == 0 )
@@ -235,7 +240,10 @@ int switch_coordinator::disarm(char *name, size_t len)
 		return 0;
 	}
 	else
+	{
+		strcpy(name,"");
 		return 0;
+	}
 }
 
 int switch_coordinator::init(OBJECT *parent)

--- a/gismo/switch_coordinator.cpp
+++ b/gismo/switch_coordinator.cpp
@@ -90,7 +90,7 @@ int switch_coordinator::connect(char *value, size_t len)
 		gld_property prop(this,"armed");
 		for ( gld_keyword *kw = prop.get_first_keyword() ; kw->get_next() != NULL ; kw = kw->get_next() )
 		{
-			len = strlen(kw->get_name()) + 1;
+			len += strlen(kw->get_name()) + 1;
 		}
 		return len;
 	}
@@ -147,7 +147,7 @@ int switch_coordinator::connect(char *value, size_t len)
 		gld_property prop(this,"armed");
 		for ( gld_keyword *kw = prop.get_first_keyword() ; kw->get_next() != NULL ; kw = kw->get_next() )
 		{
-			sz = strlen(kw->get_name()) + 1;
+			sz += strlen(kw->get_name()) + 1;
 		}
 		if ( len < sz )
 		{

--- a/gismo/switch_coordinator.cpp
+++ b/gismo/switch_coordinator.cpp
@@ -149,7 +149,7 @@ int switch_coordinator::connect(char *value, size_t len)
 		{
 			sz += strlen(kw->get_name()) + 1;
 		}
-		if ( len < sz )
+		if ( len >= sz )
 		{
 			int rv = 0;
 			for ( gld_keyword *kw = prop.get_first_keyword() ; kw->get_next() != NULL ; kw = kw->get_next() )

--- a/gismo/switch_coordinator.h
+++ b/gismo/switch_coordinator.h
@@ -7,12 +7,19 @@
 
 #include "gismo.h"
 
+DECL_METHOD(switch_coordinator,connect);
+DECL_METHOD(switch_coordinator,arm);
+DECL_METHOD(switch_coordinator,disarm);
+
 class switch_coordinator : public gld_object {
 public:
 	enum {SCS_IDLE=0, SCS_ARMED=1, SCS_TOGGLE=2, SCS_DIRECT=3} SWITCHCOORDINATIONSTATUS;
 public:
 	GL_ATOMIC(enumeration,status);
 	GL_ATOMIC(set,armed);
+	GL_METHOD(switch_coordinator,connect);
+	GL_METHOD(switch_coordinator,arm);
+	GL_METHOD(switch_coordinator,disarm);
 private:
 	unsigned int n_switches;
 	unsigned int64 states;
@@ -29,9 +36,6 @@ public:
 	TIMESTAMP commit(TIMESTAMP t1, TIMESTAMP t2);
 	inline int prenotify(PROPERTY *prop, const char *value=NULL) { return 1; };
 	int postnotify(PROPERTY *prop, const char *value=NULL);
-	int connect(const char *name);
-	int arm(const char *name);
-	int disarm(const char *name);
 
 public:
 	static CLASS *oclass;

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -406,6 +406,7 @@ int GldJsonWriter::write_objects(FILE *fp)
                     if ( sz > 0 )
                     {
 	                    char *buffer = new char[sz+2];
+	                    strcpy(buffer,"");
 	                    object_property_to_string(obj,prop->name,buffer,sz+1);
 						len += write(",\n\t\t\t\"%s\": \"%s\"", prop->name, buffer);
 	                    delete [] buffer;

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -413,7 +413,7 @@ int GldJsonWriter::write_objects(FILE *fp)
 	                }
 	                else if ( sz == 0 )
 	                {
-						len += write(",\n\t\t\t\"%s\": \"%s\"", prop->name, buffer);
+						len += write(",\n\t\t\t\"%s\": \"\"", prop->name);
 	                }
 	                else
 	                {


### PR DESCRIPTION
This PR addresses a missed case in the method fixes.

## Current issues
None

## Code changes
1. Added support for new method API to switch_coordinator

## Documentation changes
None

## Test and Validation Notes
There isn't a test case the outputs the switch coordinator object to a file in the autotests for gismo.