### PR TITLE
Catch changes to classes after they are instantiated

### DIFF
--- a/gldcore/class.cpp
+++ b/gldcore/class.cpp
@@ -279,6 +279,16 @@ void class_add_property(CLASS *oclass,  /**< the class to which the property is 
 		last->next = prop;
 }
 
+bool has_child_class(CLASS *oclass)
+{
+	for ( CLASS *c = class_get_first_class() ; c != NULL ; c = c->next )
+	{
+		if ( c->parent == oclass )
+			return true;
+	} 
+	return false;
+}
+
 /** Add an extended property to a class 
     @return the property pointer
  **/
@@ -305,6 +315,13 @@ PROPERTY *class_add_extended_property(CLASS *oclass,      /**< the class to whic
 		// will get picked up later
 	}
 
+	if ( has_child_class(oclass) )
+	{
+		throw_exception("class_add_extended_property(oclass='%s', name='%s', ...): cannot add new properties after class has been used to derive another class", oclass->name, name);
+		/* TROUBLESHOOT
+			Once the class has been used to derive another class, it is not possible to change its size in memory.
+		 */
+	}
 	if ( oclass->profiler.numobjs > 0 )
 		throw_exception("class_add_extended_property(oclass='%s', name='%s', ...): cannot add new properties after class has been instantiated", oclass->name, name);
 		/* TROUBLESHOOT

--- a/gldcore/class.cpp
+++ b/gldcore/class.cpp
@@ -305,6 +305,11 @@ PROPERTY *class_add_extended_property(CLASS *oclass,      /**< the class to whic
 		// will get picked up later
 	}
 
+	if ( oclass->profiler.numobjs > 0 )
+		throw_exception("class_add_extended_property(oclass='%s', name='%s', ...): cannot add new properties after class has been instantiated", oclass->name, name);
+		/* TROUBLESHOOT
+			Once the class has been used to instantiate an object, it is not possible to change its size in memory.
+		 */
 	if (prop==NULL)
 		throw_exception("class_add_extended_property(oclass='%s', name='%s', ...): memory allocation failed", oclass->name, name);
 		/* TROUBLESHOOT

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -35,7 +35,15 @@ GldJsonWriter::~GldJsonWriter(void)
 
 const char * escape(const char *buffer, size_t len = 1024)
 {
-	static char result[2048];
+	static char *result = NULL;
+	static size_t result_len = 0;
+	if ( len >= result_len*5+1 )
+	{
+		result_len = (len>1024?len:1024)*5+1;
+		result = (char*)realloc(result,result_len);
+		if ( result == NULL )
+			throw_exception("escape(const char *buffer=%p, size_t len=%llu): memory allocation failed",buffer,len);
+	}
 	char *p = result;
 	const char *c;
 	for ( c = buffer ; *c != '\0' && c < buffer+len ; c++)
@@ -44,8 +52,48 @@ const char * escape(const char *buffer, size_t len = 1024)
 		{
 		case '"':
 			*p++ = '\\';
+			*p++ = '"';
+			break;
+		case '\\':
+			*p++ = '\\';
+			*p++ = '\\';
+			break;
+		// DPC: solidus is in the JSON spec (http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf, Figure 5)
+		// but it's not desirable or necessary (so far as I can tell) to escape it for gridlabd strings
+		// case '/':
+		// 	*p++ = '\\';
+		// 	*p++ = '/';
+		// 	break;
+		case '\b':
+			*p++ = '\\';
+			*p++ = 'b';
+			break;
+		case '\f':
+			*p++ = '\\';
+			*p++ = 'f';
+			break;
+		case '\n':
+			*p++ = '\\';
+			*p++ = 'n';
+			break;
+		case '\r':
+			*p++ = '\\';
+			*p++ = 'r';
+			break;
+		case '\t':
+			*p++ = '\\';
+			*p++ = 't';
+			break;
 		default:
-			*p++ = *c;
+			if ( *c >= 32 && *c < 127 )
+			{
+				*p++ = *c;
+			}
+			else
+			{
+				p += sprintf(p,"\\u%04hX", (unsigned short)*c);
+			}
+			break;
 		}
 	}
 	*p = '\0';

--- a/gldcore/object.cpp
+++ b/gldcore/object.cpp
@@ -1359,8 +1359,6 @@ const char *object_property_to_string(OBJECT *obj, const char *name, char *buffe
 		return NULL;
 	}
 	void *addr = GETADDR(obj,prop); /* warning: cast from pointer to integer of different size */
-	if (strcmp(prop->name,"supernode_name")==0)
-		output_message(""); // TODO: DELETE THIS BUG TRAP AFTER BUG IS FIXED
 	if ( prop->ptype == PT_delegated )
 	{
 		return prop->delegation->to_string(addr,buffer,sz) ? buffer : NULL;

--- a/gldcore/object.cpp
+++ b/gldcore/object.cpp
@@ -1352,36 +1352,29 @@ int object_set_dependent(OBJECT *obj, /**< the object to set */
  */
 const char *object_property_to_string(OBJECT *obj, const char *name, char *buffer, int sz)
 {
-	//static char buffer[4096];
-	void *addr;
 	PROPERTY *prop = class_find_property(obj->oclass,name);
 	if ( prop == NULL )
 	{
 		errno = ENOENT;
 		return NULL;
 	}
-	addr = GETADDR(obj,prop); /* warning: cast from pointer to integer of different size */
+	void *addr = GETADDR(obj,prop); /* warning: cast from pointer to integer of different size */
+	if (strcmp(prop->name,"supernode_name")==0)
+		output_message(""); // TODO: DELETE THIS BUG TRAP AFTER BUG IS FIXED
 	if ( prop->ptype == PT_delegated )
 	{
 		return prop->delegation->to_string(addr,buffer,sz) ? buffer : NULL;
-	}
-	else if ( prop->ptype == PT_method )
-	{
-		if ( class_property_to_string(prop,addr,buffer,sz) )
-			return buffer;
-		else
-		{
-			output_error("gldcore/object.c:object_property_to_string(obj=<%s:%d>('%s'), name='%s', buffer=%p, sz=%u): unable to extract property into buffer",
-				obj->oclass->name, obj->id, obj->name?obj->name:"(none)", prop->name, buffer, sz);
-			return "";
-		}
 	}
 	else if ( class_property_to_string(prop,addr,buffer,sz) )
 	{
 		return buffer;
 	}
 	else
+	{
+		output_error("gldcore/object.c:object_property_to_string(obj=<%s:%d>('%s'), name='%s', buffer=%p, sz=%u): unable to extract property value into buffer",
+			obj->oclass->name, obj->id, obj->name?obj->name:"(none)", prop->name, buffer, sz);
 		return "";
+	}
 }
 
 void object_profile(OBJECT *obj, OBJECTPROFILEITEM pass, clock_t t)

--- a/powerflow/powerflow_object.cpp
+++ b/powerflow/powerflow_object.cpp
@@ -132,6 +132,7 @@ powerflow_object::powerflow_object(MODULE *mod)
 				PT_KEYWORD, "NORMAL", PS_NORMAL,
 				PT_KEYWORD, "OUTAGE", PS_OUTAGE,
 #endif
+			PT_object, "supernode_name", PADDR(supernode),
          	NULL) < 1) GL_THROW("unable to publish powerflow_object properties in %s",__FILE__);
 
 		// set defaults

--- a/powerflow/powerflow_object.cpp
+++ b/powerflow/powerflow_object.cpp
@@ -132,7 +132,7 @@ powerflow_object::powerflow_object(MODULE *mod)
 				PT_KEYWORD, "NORMAL", PS_NORMAL,
 				PT_KEYWORD, "OUTAGE", PS_OUTAGE,
 #endif
-			PT_object, "supernode_name", PADDR(supernode),
+			PT_char1024, "supernode_name", PADDR(supernode),
          	NULL) < 1) GL_THROW("unable to publish powerflow_object properties in %s",__FILE__);
 
 		// set defaults

--- a/powerflow/powerflow_object.h
+++ b/powerflow/powerflow_object.h
@@ -98,7 +98,7 @@ class powerflow_object : public gld_object
 public:
 	set phases;				/**< device phases (see PHASE codes) */
 	double nominal_voltage;	/**< nominal voltage */
-	object supernode; /**< node reference for hierarchical models */
+	char1024 supernode; 	/**< internal reference for hierarchical models */
 #ifdef SUPPORT_OUTAGES
 	set condition;			/**< operating condition (see OC codes) */
 	enumeration solution;	/**< solution code (PS_NORMAL=0, class-specific solution mode code>0) */

--- a/powerflow/powerflow_object.h
+++ b/powerflow/powerflow_object.h
@@ -98,6 +98,7 @@ class powerflow_object : public gld_object
 public:
 	set phases;				/**< device phases (see PHASE codes) */
 	double nominal_voltage;	/**< nominal voltage */
+	object supernode; /**< node reference for hierarchical models */
 #ifdef SUPPORT_OUTAGES
 	set condition;			/**< operating condition (see OC codes) */
 	enumeration solution;	/**< solution code (PS_NORMAL=0, class-specific solution mode code>0) */


### PR DESCRIPTION
This PR addresses junk output from extended properties (Issue #325)

## Current issues
1. When one powerflow class is derived from another, gridlabd must know how big the parent class is to calculate the position of property values in in the new class.  The way power flow defines classes, the class are all derived from power flow object, node, link, etc. when the module is loaded.  So the only way to add super node name to classes is to add them to classes that don’t have child classes (I’ve added an exception to block that if you try).  Normally this would be ok to do, even if it’s odd given how parent classes should work.  Unfortunately, because node is used both as an instantiated class (meaning it has objects associated directly with), and as an abstract class (meaning it is a parent of instantiated classes), it is not possible to add an extended variable to node without breaking that rule. This underlying problem needs to be fixed so that it's possible to extend abstract classes after they've been used as a parent to another class.
2. If we going to keep this solution permanently (which we really shouldn't), then we should name the new property something more generic because `supernode_name` is rather particular to GRIP models, and I’d prefer we use something more thought out based on a concept of super nodes that would be more general purpose to future users.

## Code changes
1. Added `supernode_name` to the power flow object for now. This is not great, but it will solve the problem.  
2. Added a check to prevent addition of extended properties to classes that are either instantiated already, or parent to another class.

## Documentation changes
None

## Test and Validation Notes
1. A validation exception test that attempts to extend `powerflow_object` should be created in power flow module attests.

[supernode_bug.zip](https://github.com/dchassin/gridlabd/files/3612138/supernode_bug.zip)