### PR TITLE
Change origin format

### DIFF
--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -155,4 +155,4 @@ gldcore/build.h: buildnum
 
 buildnum: utilities/build_number
 	/bin/bash -c "source $(top_srcdir)/utilities/build_number $(top_srcdir) gldcore/build.h"
-	(git remote -v ; git log -n 1 ; git status -s ; git diff ) > origin.txt
+	/bin/bash -c "source utilities/update_origin.sh" > origin.txt

--- a/utilities/build_number
+++ b/utilities/build_number
@@ -24,4 +24,3 @@ if [ "${LAST_STAMP:-none}" != "$THIS_STAMP" ]; then
 	echo "#define BUILD_STATUS $(git status -b --porcelain | sed -e 's/^/\"/g;s/$/\\n\"\\/g';echo \"\")" >> $2
 	cd -
 fi
-#ls -l $2

--- a/utilities/update_origin.sh
+++ b/utilities/update_origin.sh
@@ -1,7 +1,7 @@
 #/bin/bash
 ORIGIN=$(git remote -v show | head -n 1 | cut -f1)
 COMMIT=$(git log -n 1 | head -n 1 | cut -f2 -d' ')
-URL=$(git remote get-url $ORIGIN)
+URL=$(git remote get-url $ORIGIN | sed -e 's/\.git$//')
 echo "# $URL/commits/$COMMIT" 
 git status -s | sed -e '1,$s/^/# /'
 git diff

--- a/utilities/update_origin.sh
+++ b/utilities/update_origin.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+ORIGIN=$(git remote -v show | head -n 1 | cut -f1)
+COMMIT=$(git log -n 1 | head -n 1 | cut -f2 -d' ')
+URL=$(git remote get-url $ORIGIN)
+echo "# $URL/commits/$COMMIT" 
+git status -s | sed -e '1,$s/^/# /'
+git diff


### PR DESCRIPTION
This PR addresses issue with the format of the `--origin` output.

## Current issues
None

## Code changes
1. Moved the commands to generate `origin.txt` to a new script named `utilities/update_origin.sh`
2. Change the format of the output so it's easier to go to the origin directly using a URL.

## Documentation changes
https://github.com/dchassin/gridlabd/wiki/origin

## Test and Validation Notes
Use `gridlabd --origin` anytime and see what it says.