### PR TITLE
Fixed problem with empty set conversion to string

### DIFF
--- a/gldcore/class.cpp
+++ b/gldcore/class.cpp
@@ -451,8 +451,7 @@ int class_property_to_string(PROPERTY *prop, /**< the property type */
                              char *value,    /**< the value buffer to which the string is to be written */
                              int size)       /**< the maximum number of characters that can be written to the \p value buffer*/
 {
-	int rv = 0;
-	if (prop->ptype==PT_delegated)
+	if ( prop->ptype == PT_delegated )
 	{
 		output_error("unable to convert from delegated property value");
 		/*	TROUBLESHOOT
@@ -461,25 +460,22 @@ int class_property_to_string(PROPERTY *prop, /**< the property type */
 		 */
 		return 0;
 	}
-	else if ( prop->ptype == PT_method && value == NULL )
-	{
-		return property_write(prop,addr,NULL,0);
-	}
 	else if ( prop->ptype > _PT_FIRST && prop->ptype < _PT_LAST )
 	{
-		rv = property_write(prop,addr,value,size);
+		int rv = property_write(prop,addr,value,size);
 		if ( rv > 0 && prop->unit != 0 )
 		{
 			strcat(value+rv," ");
 			strcat(value+rv+1,prop->unit->name);
 			rv += (int)(1+strlen(prop->unit->name));
 		}
+		return rv;
 	}
 	else
 	{
-		rv = 0;
+		output_error("unable to convert from invalid property type");
+		return 0;
 	}
-	return rv;
 }
 
 

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -401,7 +401,7 @@ int GldJsonWriter::write_objects(FILE *fp)
 	{
 		PROPERTY *prop;
 		CLASS *pclass;
-		char buffer[1024];
+		char buffer[1025];
 		if ( obj != object_get_first() )
 			len += write(",");
 		if ( obj->oclass == NULL ) // ignore objects with no defined class
@@ -443,7 +443,7 @@ int GldJsonWriter::write_objects(FILE *fp)
 		{
 			for ( prop = pclass->pmap ; prop!=NULL && prop->oclass == pclass->pmap->oclass; prop = prop->next )
 			{
-				char buffer[1024];
+				char buffer[1025*5];
 				if ( prop->access != PA_PUBLIC )
 					continue;
 				else if ( prop->ptype == PT_enduse )
@@ -469,8 +469,8 @@ int GldJsonWriter::write_objects(FILE *fp)
 	                }
                 }
                 else
-                { 
-					const char *value = object_property_to_string(obj,prop->name, buffer, sizeof(buffer)-1);
+                {
+					const char *value = object_property_to_string(obj,prop->name, buffer, sizeof(buffer));
 					if ( value == NULL )
 						continue; // ignore values that don't convert propertly
 					int len = strlen(value);

--- a/gldcore/object.cpp
+++ b/gldcore/object.cpp
@@ -1363,7 +1363,7 @@ const char *object_property_to_string(OBJECT *obj, const char *name, char *buffe
 	{
 		return prop->delegation->to_string(addr,buffer,sz) ? buffer : NULL;
 	}
-	else if ( class_property_to_string(prop,addr,buffer,sz) )
+	else if ( class_property_to_string(prop,addr,buffer,sz) >= 0 )
 	{
 		return buffer;
 	}

--- a/gldcore/property.cpp
+++ b/gldcore/property.cpp
@@ -231,13 +231,9 @@ int property_read(PROPERTY *prop, void *addr, const char *string)
 
 int property_write(PROPERTY *prop, void *addr, char *string, size_t size)
 {
-	if ( prop->ptype == PT_method && string == NULL ) // size inquiry
+	if ( prop->ptype > _PT_FIRST && prop->ptype < _PT_LAST && property_type[prop->ptype].data_to_string != NULL )
 	{
-		return property_type[prop->ptype].data_to_string(NULL,0,addr,prop);
-	}
-	else if ( prop->ptype > _PT_FIRST && prop->ptype < _PT_LAST && property_type[prop->ptype].data_to_string != NULL )
-	{
-		return property_type[prop->ptype].data_to_string(string,size,addr,prop);
+		return property_type[prop->ptype].data_to_string(string,string?size:0,addr,prop);
 	}
 	else
 	{
@@ -250,7 +246,6 @@ int property_write(PROPERTY *prop, void *addr, char *string, size_t size)
 		 */
 		return 0;
 	}
-
 }
 
 int property_create(PROPERTY *prop, void *addr)


### PR DESCRIPTION
This PR addresses issue with buffers when converting sets (no issue reported).

## Current issues
None

## Code changes
1. increased size of JSON buffer
2. cleanup of data conversion pipeline buffer size handling
3. changed check of return value on class type conversion to allow empty buffers to be returned.

## Documentation changes
None

## Test and Validation Notes
The problem only occurred when running `python3 ../../absorption/run_gridlabd_main.py -i virtual_islanding_model.glm -o gridlabd.json` in the GRIP code.