### PR TITLE
Reverting configure.ac to python 3.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -644,7 +644,7 @@ AC_SUBST([MYSQL_LDFLAGS])
 AC_SUBST([MYSQL_LIBS])
 
 # Verify python version
-AM_PATH_PYTHON(3.7)
+AM_PATH_PYTHON(3.6)
 HAVE_PYTHON="$(which python3) ($(python3 --version))"
 
 ###############################################################################


### PR DESCRIPTION
This PR addresses issue(s) #332 

## Current issues
None

## Code changes
1. configure.ac

## Documentation changes
- none

## Test and Validation Notes
1. Check the version on the image built from this version
