### PR TITLE
Add git2 upgrade to docker centos:7 build image

### DIFF
--- a/utilities/docker/centos/system.sh
+++ b/utilities/docker/centos/system.sh
@@ -17,7 +17,7 @@ yum install libcurl-devel -y
 yum install which -y
 
 # upgrade git to version 2.x
-yum remove git*
+yum remove git* -y
 yum install https://centos7.iuscommunity.org/ius-release.rpm -y
 yum install git2u-all -y
 

--- a/utilities/docker/centos/system.sh
+++ b/utilities/docker/centos/system.sh
@@ -16,6 +16,11 @@ yum install epel-release -y
 yum install libcurl-devel -y
 yum install which -y
 
+# upgrade git to version 2.x
+yum remove git*
+yum install https://centos7.iuscommunity.org/ius-release.rpm -y
+yum install git2u-all -y
+
 # python3 support needed as of 4.2
 yum --disablerepo="*" --enablerepo="epel" install python36 -y
 yum install python36 python36-devel python36-pip python36-tkinter -y


### PR DESCRIPTION
This PR addresses git version issues with the docker build process for centos:7.

## Current issues
None

## Code changes
Added code to upgrade to git 2.

## Documentation changes
None

## Test and Validation Notes
Docker build should no longer produce errors when running `update_origin.sh`