### PR TITLE
Update cmdarg.cpp

### DIFF
--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -503,12 +503,7 @@ DEPRECATED static int version(void *main, int argc, const char *argv[])
 }
 int GldCmdarg::version(int argc, const char *argv[])
 {
-	if ( argc <= 1 )
-	{
-		output_message("%s %s-%d", PACKAGE_NAME, PACKAGE_VERSION, BUILDNUM);
-		return 0;
-	}
-	else if ( strcmp(argv[1],"all" ) == 0 )
+	if ( argc > 1 && strcmp(argv[1],"all" ) == 0 )
 	{	
 		output_message("%s %s-%d (%s) "
 #if defined MACOSX
@@ -519,27 +514,27 @@ int GldCmdarg::version(int argc, const char *argv[])
 			, PACKAGE_NAME, PACKAGE_VERSION, BUILDNUM, BRANCH);
 		return 1;
 	}
-	else if ( strcmp(argv[1],"number" ) == 0 )
+	else if ( argc > 1 && strcmp(argv[1],"number" ) == 0 )
 	{
 		output_message("%s", PACKAGE_VERSION);
 		return 1;
 	}
-	else if ( strcmp(argv[1],"build") == 0 )
+	else if ( argc > 1 && strcmp(argv[1],"build") == 0 )
 	{
 		output_message("%d", BUILDNUM);
 		return 1;
 	}
-	else if ( strcmp(argv[1],"package") == 0 )
+	else if ( argc > 1 && strcmp(argv[1],"package") == 0 )
 	{
 		output_message("%s", PACKAGE_NAME);
 		return 1;
 	}
-	else if ( strcmp(argv[1],"branch") == 0 )
+	else if ( argc > 1 && strcmp(argv[1],"branch") == 0 )
 	{
 		output_message("%s", BRANCH);
 		return 1;
 	}
-	else if ( strcmp(argv[1],"platform") == 0 )
+	else if ( argc > 1 && strcmp(argv[1],"platform") == 0 )
 	{
 		output_message(
 #if defined MACOSX
@@ -552,8 +547,8 @@ int GldCmdarg::version(int argc, const char *argv[])
 	}
 	else
 	{
-		output_error("'%s' is invalid version specifier", argv[1]);
-		return CMDERR;
+		output_message("%s %s-%d", PACKAGE_NAME, PACKAGE_VERSION, BUILDNUM);
+		return 0;
 	}
 }
 


### PR DESCRIPTION
This PR addresses issue with mishandling of command args by version option.

## Current issues
None

## Code changes
1. fixed bad argument list tests.

## Documentation changes
None

## Test and Validation Notes
Try a command line like `gridlabd --version --globals` to see that both outputs are delivered.
