### PR TITLE
Add weather subcommand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ jobs:
             autoreconf -isf
             ./configure
             export PATH=/home/circleci/project/install/bin:$PATH
-            sudo make -j16 install
-            export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
-            sudo gridlabd -T 0 --validate
+            sudo make -j16 install-validate
       - run:
           name: Save validation output (if any) on failure
           command: tar cfz validate-output.tar.gz ./*/autotest/*/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,13 @@ jobs:
             ./configure --enable-silent-rules --prefix=$PWD/install
             export PATH=$PWD/install/bin:$PATH
             sudo make -j16 install
+            sudo echo "DATADIR=$PWD" > $PWD/install/shared/gridlabd/gridlabd-weather.conf
       - run:
           name: Validate gridlabd
           command: |
             export PATH=$PWD/install/bin:$PATH
             export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
-            sudo $PWD/install/bin/gridlabd -T 0  --validate
+            gridlabd -T 0  --validate
       - run:
           name: Save validation output (if any) on failure
           command: tar cfz validate-output.tar.gz ./*/autotest/*/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
           name: Build gridlabd
           command: |
             autoreconf -isf
-            ./configure --enable-silent-rules --prefix=$PWD/install
-            export PATH=$PWD/install/bin:$PATH
+            ./configure
+            export PATH=/home/circleci/project/install/bin:$PATH
             sudo make -j16 install
             export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
             sudo gridlabd -T 0 --validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             export PATH=$PWD/install/bin:$PATH
             sudo make -j16 install
             export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
-            sudo make -T 0 --validate
+            sudo gridlabd -T 0 --validate
       - run:
           name: Save validation output (if any) on failure
           command: tar cfz validate-output.tar.gz ./*/autotest/*/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ jobs:
             ./configure --enable-silent-rules --prefix=$PWD/install
             export PATH=$PWD/install/bin:$PATH
             sudo make -j16 install
-            sudo echo "DATADIR=$PWD" > $PWD/install/shared/gridlabd/gridlabd-weather.conf
+            sudo echo "DATADIR=$PWD" > $PWD/install/share/gridlabd/gridlabd-weather.conf
       - run:
           name: Validate gridlabd
           command: |
             export PATH=$PWD/install/bin:$PATH
             export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
-            gridlabd -T 0  --validate
+            gridlabd -T 0 --validate
       - run:
           name: Save validation output (if any) on failure
           command: tar cfz validate-output.tar.gz ./*/autotest/*/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |
             export PATH=$PWD/install/bin:$PATH
             export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
-            gridlabd -T 8 --validate
+            sudo gridlabd -T 8 --validate
       - run:
           name: Save validation output (if any) on failure
           command: tar cfz validate-output.tar.gz ./*/autotest/*/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,6 @@ jobs:
           path: /home/circleci/project/documents
           destination: /gridlabd/documents
       - store_artifacts:
-          path: /home/circleci/project/project.tar.gz
-          destination: project.tar.gz
+          path: /home/circleci/project/validate-output.tar.gz
+          destination: validate-output.tar.gz
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,8 @@ jobs:
             ./configure --enable-silent-rules --prefix=$PWD/install
             export PATH=$PWD/install/bin:$PATH
             sudo make -j16 install
-            sudo echo "DATADIR=$PWD" > $PWD/install/share/gridlabd/gridlabd-weather.conf
-      - run:
-          name: Validate gridlabd
-          command: |
-            export PATH=$PWD/install/bin:$PATH
             export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
-            gridlabd -T 0 --validate
+            sudo make -T 0 --validate
       - run:
           name: Save validation output (if any) on failure
           command: tar cfz validate-output.tar.gz ./*/autotest/*/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |
             export PATH=$PWD/install/bin:$PATH
             export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:.}
-            sudo gridlabd -T 8 --validate
+            sudo $PWD/install/bin/gridlabd -T 0  --validate
       - run:
           name: Save validation output (if any) on failure
           command: tar cfz validate-output.tar.gz ./*/autotest/*/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,7 @@ jobs:
       - store_artifacts:
           path: /home/circleci/project/documents
           destination: /gridlabd/documents
-      - run:
-          name: Save project files on failure
-          command: tar cfz project.tar.gz /home/circleci/project
-          when: on_fail
       - store_artifacts:
           path: /home/circleci/project/project.tar.gz
           destination: project.tar.gz
+          when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,19 +12,17 @@ jobs:
             ./configure
             export PATH=/home/circleci/project/install/bin:$PATH
             sudo make -j16 install-validate
-      - run:
-          name: Save validation output (if any) on failure
-          command: tar cfz validate-output.tar.gz ./*/autotest/*/*
-          when: on_fail
+            sudo make doxygen-run
       - store_artifacts:
           path: /home/circleci/project/validate.txt
           destination: /gridlabd/validate.txt
       - store_artifacts:
-          path: /home/circleci/project/validate-output.tar.gz
-          destination: /gridlabd/validate-output.tar.gz
-      - run:
-          name: Generate online documentation
-          command: sudo make doxygen-run
-      - store_artifacts:
           path: /home/circleci/project/documents
           destination: /gridlabd/documents
+      - run:
+          name: Save project files on failure
+          command: tar cfz project.tar.gz /home/circleci/project
+          when: on_fail
+      - store_artifacts:
+          path: /home/circleci/project/project.tar.gz
+          destination: project.tar.gz

--- a/Makefile.am
+++ b/Makefile.am
@@ -212,7 +212,7 @@ clean-wc:
 	. utilities/cleanwc
 
 install-validate: install
-	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate || (tar cfz validate-output.tar.gz */autotest/test_*/*;exit 1)
+	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate || (tar cfz validate-output.tar.gz */autotest/test_*/*;exit 1))
 
 check-local validate: 
 	gridlabd --validate

--- a/Makefile.am
+++ b/Makefile.am
@@ -309,7 +309,7 @@ distclean-local: python-clean
 libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool
 
-install-exec-hook: python-install
+install-exec-hook: python-install weather
 	@if [ "`which gridlabd`" != "$(DESTDIR)$(bindir)/gridlabd" ]; then \
 		echo >&2 "***WARNING***: install target $(DESTDIR)$(bindir)/gridlabd is not in the current path (`which gridlabd` is found instead)"; \
 	fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -212,7 +212,7 @@ clean-wc:
 	. utilities/cleanwc
 
 install-validate: install
-	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate || tar cfz validate-output.tar.gz */autotest/test_*/*)
+	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate || (tar cfz validate-output.tar.gz */autotest/test_*/*;exit 1)
 
 check-local validate: 
 	gridlabd --validate

--- a/Makefile.am
+++ b/Makefile.am
@@ -212,7 +212,7 @@ clean-wc:
 	. utilities/cleanwc
 
 install-validate: install
-	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate)
+	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate || tar cfz validate-output.tar.gz */autotest/test_*/*)
 
 check-local validate: 
 	gridlabd --validate

--- a/Makefile.am
+++ b/Makefile.am
@@ -211,6 +211,9 @@ clean-wc:
 	@unset REPLY && read -t 60 -p "Clean working copy (type 'yes' to proceed)? " && test "`echo "$$REPLY" | tr '[:upper:]' '[:lower:]'`" = "yes"
 	. utilities/cleanwc
 
+install-validate: install
+	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate)
+
 check-local validate: 
 	gridlabd --validate
 

--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -158,5 +158,5 @@ buildnum: utilities/build_number
 	@/bin/bash -c "source utilities/update_origin.sh" > origin.txt
 
 weather:
-	@(echo "Installing weather data manager" && mkdir -p $(prefix)/share/gridlabd/weather && chmod 777 $(prefix)/share/gridlabd/weather && chmod 755 $(bindir)/gridlabd-weather)
+	@(echo "Installing weather data manager" && mkdir -p $(prefix)/share/gridlabd/weather && chmod 2777 $(prefix)/share/gridlabd/weather && chmod 755 $(bindir)/gridlabd-weather)
 	@(echo "Updating weather data index" && export GLD_ETC=$(prefix)/share/gridlabd && $(bindir)/gridlabd-weather fetch_index)

--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -148,11 +148,16 @@ gridlabddir = $(prefix)/share/gridlabd
 gridlabd_DATA = origin.txt
 
 gldcore/gridlabd.in: gldcore/gridlabd.m4sh
-	autoreconf -isf
-	autom4te -l m4sh $< > $@
+	@autoreconf -isf
+	@autom4te -l m4sh $< > $@
 
 gldcore/build.h: buildnum
 
 buildnum: utilities/build_number
-	/bin/bash -c "source $(top_srcdir)/utilities/build_number $(top_srcdir) gldcore/build.h"
-	/bin/bash -c "source utilities/update_origin.sh" > origin.txt
+	@/bin/bash -c "source $(top_srcdir)/utilities/build_number $(top_srcdir) gldcore/build.h"
+	@/bin/bash -c "source utilities/update_origin.sh" > origin.txt
+
+weather:
+	@mkdir -p $(prefix)/share/gridlabd/weather
+	@chmod 777 $(prefix)/share/gridlabd/weather
+	@$(bindir)/gridlabd weather fetch_index

--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -158,5 +158,5 @@ buildnum: utilities/build_number
 	@/bin/bash -c "source utilities/update_origin.sh" > origin.txt
 
 weather:
-	@(echo "Installing weather data manager" && mkdir -p $(prefix)/share/gridlabd/weather && chmod 2777 $(prefix)/share/gridlabd/weather && chmod 755 $(bindir)/gridlabd-weather)
+	@(echo "Installing weather data manager" && mkdir -p $(prefix)/share/gridlabd/weather && chmod 2777 $(prefix)/share/gridlabd/weather && chmod 1755 $(bindir)/gridlabd-weather)
 	@(echo "Updating weather data index" && export GLD_ETC=$(prefix)/share/gridlabd && $(bindir)/gridlabd-weather fetch_index)

--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -75,7 +75,7 @@ GLD_SOURCES_EXTRA_PLACE_HOLDER += gldcore/xcore.cpp gldcore/xcore.h
 
 if HAVE_MINGW
 
-bin_SCRIPTS += gldcore/gridlabd
+bin_SCRIPTS += gldcore/gridlabd  gldcore/gridlabd-weather
 
 bin_PROGRAMS += gridlabd
 
@@ -100,7 +100,7 @@ EXTRA_gridlabd_SOURCES += $(GLD_SOURCES_EXTRA_PLACE_HOLDER)
 
 else
 
-bin_SCRIPTS += gldcore/gridlabd
+bin_SCRIPTS += gldcore/gridlabd gldcore/gridlabd-weather
 
 bin_PROGRAMS += gridlabd.bin
 

--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -158,6 +158,5 @@ buildnum: utilities/build_number
 	@/bin/bash -c "source utilities/update_origin.sh" > origin.txt
 
 weather:
-	@mkdir -p $(prefix)/share/gridlabd/weather
-	@chmod 777 $(prefix)/share/gridlabd/weather
-	@$(bindir)/gridlabd weather fetch_index
+	@(echo "Installing weather data manager" && mkdir -p $(prefix)/share/gridlabd/weather && chmod 777 $(prefix)/share/gridlabd/weather && chmod 755 $(bindir)/gridlabd-weather)
+	@(echo "Updating weather data index" && export GLD_ETC=$(prefix)/share/gridlabd && $(bindir)/gridlabd-weather fetch_index)

--- a/gldcore/autotest/test_subcommand_weather.csv
+++ b/gldcore/autotest/test_subcommand_weather.csv
@@ -1,5 +1,5 @@
-Filepath,Country,StationId,StationName,RegionName,TzOffset,Latitude,Longitude,Elevation
-"/usr/local/share/gridlabd/US/CA-San_Diego_Lindbergh_Field.tmy3",US,722900,"SAN DIEGO LINDBERGH FIELD",CA,-8.0,32.733,-117.167,4
-"/usr/local/share/gridlabd/US/CA-San_Diego_Miramar_Nas.tmy3",US,722930,"SAN DIEGO MIRAMAR NAS",CA,-8.0,32.867,-117.133,140
-"/usr/local/share/gridlabd/US/CA-San_Diego_Montgomer.tmy3",US,722903,"SAN DIEGO/MONTGOMER",CA,-8.0,32.817,-117.133,129
-"/usr/local/share/gridlabd/US/CA-San_Diego_North_Island_Nas.tmy3",US,722906,"SAN DIEGO NORTH ISLAND NAS",CA,-8.0,32.700,-117.200,15
+Country,StationId,StationName,RegionName,TzOffset,Latitude,Longitude,Elevation
+US,722900,"SAN DIEGO LINDBERGH FIELD",CA,-8.0,32.733,-117.167,4
+US,722930,"SAN DIEGO MIRAMAR NAS",CA,-8.0,32.867,-117.133,140
+US,722903,"SAN DIEGO/MONTGOMER",CA,-8.0,32.817,-117.133,129
+US,722906,"SAN DIEGO NORTH ISLAND NAS",CA,-8.0,32.700,-117.200,15

--- a/gldcore/autotest/test_subcommand_weather.csv
+++ b/gldcore/autotest/test_subcommand_weather.csv
@@ -1,0 +1,5 @@
+Filepath,Country,StationId,StationName,RegionName,TzOffset,Latitude,Longitude,Elevation
+"/usr/local/share/gridlabd/US/CA-San_Diego_Lindbergh_Field.tmy3",US,722900,"SAN DIEGO LINDBERGH FIELD",CA,-8.0,32.733,-117.167,4
+"/usr/local/share/gridlabd/US/CA-San_Diego_Miramar_Nas.tmy3",US,722930,"SAN DIEGO MIRAMAR NAS",CA,-8.0,32.867,-117.133,140
+"/usr/local/share/gridlabd/US/CA-San_Diego_Montgomer.tmy3",US,722903,"SAN DIEGO/MONTGOMER",CA,-8.0,32.817,-117.133,129
+"/usr/local/share/gridlabd/US/CA-San_Diego_North_Island_Nas.tmy3",US,722906,"SAN DIEGO NORTH ISLAND NAS",CA,-8.0,32.700,-117.200,15

--- a/gldcore/autotest/test_subcommand_weather.glm
+++ b/gldcore/autotest/test_subcommand_weather.glm
@@ -1,4 +1,4 @@
 // this test will detect changes in the download of weather data or the output of weather info
 #exec gridlabd-weather get San_Diego > /dev/null
 #exec gridlabd-weather info San_Diego | cut -f2- -d, > San_Diego.csv
-#exec diff San_Diego.csv ../${modelname/.glm/.csv} > diff.txt
+#exec diff -w San_Diego.csv ../${modelname/.glm/.csv} > diff.txt

--- a/gldcore/autotest/test_subcommand_weather.glm
+++ b/gldcore/autotest/test_subcommand_weather.glm
@@ -1,4 +1,4 @@
 // this test will detect changes in the download of weather data or the output of weather info
 #exec gridlabd-weather get San_Diego > /dev/null
-#exec gridlabd-weather info San_Diego > San_Diego.csv
+#exec gridlabd-weather info San_Diego | cut -f2- -d, > San_Diego.csv
 #exec diff San_Diego.csv ../${modelname/.glm/.csv} > diff.txt

--- a/gldcore/autotest/test_subcommand_weather.glm
+++ b/gldcore/autotest/test_subcommand_weather.glm
@@ -1,0 +1,4 @@
+// this test will detect changes in the download of weather data or the output of weather info
+#exec gridlabd-weather get San_Diego > /dev/null
+#exec gridlabd-weather info San_Diego > San_Diego.csv
+#exec diff San_Diego.csv ../${modelname/.glm/.csv} > diff.txt

--- a/gldcore/autotest/test_subcommand_weather_err.glm
+++ b/gldcore/autotest/test_subcommand_weather_err.glm
@@ -1,4 +1,4 @@
 // this test will detect changes in the download of weather data or the output of weather info
 #exec gridlabd-weather get San_Diego > /dev/null
 #exec gridlabd-weather info Miramar | cut -f2- -d, > San_Diego.csv
-#exec diff San_Diego.csv ../${modelname/_err.glm/.csv} > diff.txt
+#exec diff -w San_Diego.csv ../${modelname/_err.glm/.csv} > diff.txt

--- a/gldcore/autotest/test_subcommand_weather_err.glm
+++ b/gldcore/autotest/test_subcommand_weather_err.glm
@@ -1,4 +1,4 @@
 // this test will detect changes in the download of weather data or the output of weather info
 #exec gridlabd-weather get San_Diego > /dev/null
-#exec gridlabd-weather info Miramar > San_Diego.csv
+#exec gridlabd-weather info Miramar | cut -f2- -d, > San_Diego.csv
 #exec diff San_Diego.csv ../${modelname/_err.glm/.csv} > diff.txt

--- a/gldcore/autotest/test_subcommand_weather_err.glm
+++ b/gldcore/autotest/test_subcommand_weather_err.glm
@@ -1,0 +1,4 @@
+// this test will detect changes in the download of weather data or the output of weather info
+#exec gridlabd-weather get San_Diego > /dev/null
+#exec gridlabd-weather info Miramar > San_Diego.csv
+#exec diff San_Diego.csv ../${modelname/_err.glm/.csv} > diff.txt

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -14,6 +14,7 @@ GITUSER=dchassin
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
 SVNLSOPTIONS="--config-option=servers:global:http-timeout=60 --non-interactive -r1"
+DATADIR="$GLD_ETC/weather/$COUNTRY"
 
 # load the configuration (if any)
 CONFIGFILE="$GLD_ETC/gridlabd-weather.conf"
@@ -31,6 +32,8 @@ function config()
 		echo "GITREPO=\"$GITREPO\""
 		echo "GITBRANCH=\"$GITBRANCH\""
 		echo "CACHEDIR=\"$CACHEDIR\""
+		echo "DATADIR=\"$DATADIR\""
+		echo "SVNLSOPTIONS=\"$SVNLSOPTIONS\""
 	elif [ "$1" == "reset" ]; then
 		rm -f $CONFIGFILE || (echo "ERROR: unable to reset $CONFIGFILE"; exit 1)
 	else
@@ -40,7 +43,6 @@ function config()
 }
 
 # set the internal parameters
-DATADIR="$GLD_ETC/weather/$COUNTRY"
 CACHEDIR="$DATADIR/.gridlabd-weather"
 GITPROJ="$GITHUB/$GITUSER/$GITREPO"
 GITFILE="$GITHUBUSERCONTENT/$GITUSER/$GITREPO/$GITBRANCH"

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -46,7 +46,7 @@ function fetch_index()
 	fi
 	if [ ! -f $INDEX ]; then
 		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
-		svn ls $GITPROJ/branches/$GITBRANCH/$COUNTRY > $INDEX
+		svn ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX
 		echo "done"
 		echo $(wc -l $INDEX | cut -c1-8) "weather files found"
 	fi

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -8,6 +8,7 @@ GITUSER=dchassin
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
 CACHEDIR=".gridlabd-weather"
+SVNLSOPTIONS="--config-option=servers:global:http-timeout=60 --non-interactive -r1"
 
 # load the configuration (if any)
 CONFIGFILE="gridlabd-weather.conf"
@@ -46,7 +47,7 @@ function fetch_index()
 	fi
 	if [ ! -f $INDEX ]; then
 		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
-		svn ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX
+		svn ls $SVNLSOPTIONS $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX
 		echo "done"
 		echo $(wc -l $INDEX | cut -c1-8) "weather files found"
 	fi

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -50,12 +50,16 @@ INDEX=$CACHEDIR/$COMMIT_ID
 function fetch_index()
 {
 	if [ ! -d $CACHEDIR ]; then
-		mkdir -p $CACHEDIR
+		mkdir -p $CACHEDIR || ( echo "ERROR: unable to create cache directory"; exit 1)
 	fi
 	if [ ! -f $INDEX ]; then
 		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
-		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX
-		echo $(wc -l $INDEX | cut -c1-8) "weather files found"
+		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX || rm $INDEX
+		echo $(wc -l $INDEX | sed -e 's/ \+/ /g;s/^ //' | cut -f1 -d' ') "weather files found"
+	fi
+	if [ ! -f $INDEX ]; then
+		echo "ERROR: unable to fetch index"
+		exit 1
 	fi
 }
 
@@ -82,7 +86,7 @@ function help()
 
 function clean()
 {
-	rm -rf $CACHEDIR
+	rm -rf $CACHEDIR || echo "ERROR: unable to delete $CACHEDIR"
 	fetch_index
 }
 
@@ -113,12 +117,14 @@ function get()
 	for f in $(index $1); do
 		if [ ! -f $DATADIR/$f ]; then
 			echo -n "Downloading $f... "
-			curl -s $GITFILE/$COUNTRY/$f > $DATADIR/$f
-			echo "done"
+			(curl -s $GITFILE/$COUNTRY/$f > $DATADIR/$f && echo "done") || rm $DATADIR/$f
 		else
 			echo -n "Refreshing $f... "
-			curl -s $GITFILE/$COUNTRY/$f -z $DATADIR/$f > $DATADIR/$f
-			echo "done"
+			(curl -s $GITFILE/$COUNTRY/$f -z $DATADIR/$f > $DATADIR/$f && echo "done") || rm $DATADIR/$f
+		fi
+		if [ ! -f $DATADIR/$f ]; then
+			echo "ERROR: unable to download $f"
+			exit 1
 		fi
 	done
 }
@@ -146,7 +152,7 @@ function delete()
 	LIST=$(index $1)
 	for f in $(index $1); do
 		if [ -f $DATADIR/$f ]; then
-			rm $DATADIR/$f
+			rm $DATADIR/$f || ( echo "ERROR: unable to delete %f"; exit 1)
 		fi
 	done
 

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -120,7 +120,6 @@ function index()
 function list()
 {
 	fetch_index
-	LIST=$(index $1)
 	for f in $(index $1); do
 		if [ -f $DATADIR/$f ]; then
 			echo $f
@@ -145,7 +144,6 @@ function get()
 function info()
 {
 	fetch_index
-	LIST=$(index $1)
 	first="yes"
 	for f in $(index $1); do
 		if [ -f $DATADIR/$f ]; then
@@ -162,7 +160,6 @@ function info()
 function delete()
 {
 	fetch_index
-	LIST=$(index $1)
 	for f in $(index $1); do
 		if [ -f $DATADIR/$f ]; then
 			rm -f $DATADIR/$f || ( echo "ERROR: unable to delete %f"; exit 1)

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# check environment
+if [ ${GLD_ETC:-none} == none ]; then
+	echo "ERROR: GLD_ETC is not exported from the shell environment"
+	exit 1
+fi
+
 # configurable parameters
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
@@ -7,11 +13,10 @@ COUNTRY="US"
 GITUSER=dchassin
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
-CACHEDIR=".gridlabd-weather"
 SVNLSOPTIONS="--config-option=servers:global:http-timeout=60 --non-interactive -r1"
 
 # load the configuration (if any)
-CONFIGFILE="gridlabd-weather.conf"
+CONFIGFILE="$GLD_ETC/gridlabd-weather.conf"
 if [ -f $CONFIGFILE ]; then
 	source $CONFIGFILE
 fi
@@ -35,6 +40,8 @@ function config()
 }
 
 # set the internal parameters
+DATADIR="$GLD_ETC/$COUNTRY"
+CACHEDIR="$DATADIR/.gridlabd-weather"
 GITPROJ="$GITHUB/$GITUSER/$GITREPO"
 GITFILE="$GITHUBUSERCONTENT/$GITUSER/$GITREPO/$GITBRANCH"
 COMMIT_ID=$(git ls-remote "$GITPROJ" | grep "$GITBRANCH" | head -n 1 | cut -f1)
@@ -47,7 +54,7 @@ function fetch_index()
 	fi
 	if [ ! -f $INDEX ]; then
 		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
-		svn ls $SVNLSOPTIONS $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX
+		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX
 		echo "done"
 		echo $(wc -l $INDEX | cut -c1-8) "weather files found"
 	fi
@@ -62,12 +69,12 @@ function help()
 		cat <<-END
 			Syntax: gridlabd-weather <command> [...]
 			Commands:
-			  help               Get the list of commands
+			  help               Get the list of weather subcommands
 			  index <pattern>    Index of available weather data matching <pattern> in archive
-			  list <pattern>     List of available downloaded data matching <pattern>
+			  list <pattern>     List of available downloaded weather data matching <pattern>
 			  get <pattern>      Download weather data matching <pattern> from archive 
 			  delete <pattern>   Delete downloaded weather data matching <pattern>
-			  info <file>        Get information about weather data in <file>
+			  info <pattern>     Get information about weather data in <pattern>
 			  clean              Clean up the local cache of the archive index
 			  config             Show the current configuration
 			END
@@ -95,7 +102,7 @@ function list()
 	fetch_index
 	LIST=$(index $1)
 	for f in $(index $1); do
-		if [ -f $f ]; then
+		if [ -f $DATADIR/$f ]; then
 			echo $f
 		fi
 	done
@@ -105,13 +112,13 @@ function get()
 {
 	fetch_index
 	for f in $(index $1); do
-		if [ ! -f $f ]; then
+		if [ ! -f $DATADIR/$f ]; then
 			echo -n "Downloading $f... "
-			curl -s $GITFILE/$COUNTRY/$f > $f
+			curl -s $GITFILE/$COUNTRY/$f > $DATADIR/$f
 			echo "done"
 		else
 			echo -n "Refreshing $f... "
-			curl -s $GITFILE/$COUNTRY/$f -z $f > $f
+			curl -s $GITFILE/$COUNTRY/$f -z $DATADIR/$f > $DATADIR/$f
 			echo "done"
 		fi
 	done
@@ -123,13 +130,13 @@ function info()
 	LIST=$(index $1)
 	first="yes"
 	for f in $(index $1); do
-		if [ -f $f ]; then
+		if [ -f $DATADIR/$f ]; then
 			if [ "$first" == "yes" ]; then
-				echo "Filepath,StationId,StationName,RegionName,TzOffset,Latitude,Longitude,Elevation"
+				echo "Filepath,Country,StationId,StationName,RegionName,TzOffset,Latitude,Longitude,Elevation"
 				first="no"
 			fi
-			echo -n "\"$PWD/$f\","
-			head -n 1 $f
+			echo -n "\"$DATADIR/$f\",$COUNTRY,"
+			head -n 1 $DATADIR/$f
 		fi
 	done
 }
@@ -139,8 +146,8 @@ function delete()
 	fetch_index
 	LIST=$(index $1)
 	for f in $(index $1); do
-		if [ -f $f ]; then
-			rm $f
+		if [ -f $DATADIR/$f ]; then
+			rm $DATADIR/$f
 		fi
 	done
 

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+GITHUB="https://github.com"
+GITHUBUSERCONTENT="https://raw.githubusercontent.com"
+
+if [ -f gridlabd-weather.conf ]; then
+	source gridlabd-weather.conf
+fi
+if [ "$COUNTRY" == "" ]; then
+	COUNTRY="US"
+fi
+if [ "$GITUSER" == "" ]; then
+	GITUSER=dchassin
+fi
+if [ "$GITREPO" == "" ]; then
+	GITREPO="weather"
+fi
+if [ "$GITBRANCH" == "" ]; then
+	GITBRANCH="master"
+fi
+if [ "$CACHEDIR" == "" ]; then
+	CACHEDIR=.gridlabd-weather
+fi
+
+GITPROJ="$GITHUB/$GITUSER/$GITREPO"
+GITFILE="$GITHUBUSERCONTENT/$GITUSER/$GITREPO/$GITBRANCH"
+COMMIT_ID=$(git ls-remote "$GITPROJ" | grep "$GITBRANCH" | head -n 1 | cut -f1)
+INDEX=$CACHEDIR/$COMMIT_ID
+
+function fetch_index()
+{
+	if [ ! -d $CACHEDIR ]; then
+		mkdir -p $CACHEDIR
+	fi
+	if [ ! -f $INDEX ]; then
+		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
+		svn ls $GITPROJ/branches/$GITBRANCH/$COUNTRY > $INDEX
+		echo "done"
+		echo $(wc -l $INDEX | cut -c1-8) "weather files found"
+	fi
+}
+
+function help()
+{	
+	if [ $# == 0 ]; then
+		cat <<-END
+			Syntax: gridlabd-weather <command> [...]
+			Commands:
+			  help                   Get the list of commands
+			  index <pattern>        Index of available weather data matching <pattern> in archive
+			  list <pattern>         List of available downloaded data matching <pattern>
+			  get <pattern>          Download weather data matching <pattern> from archive 
+			  delete <pattern>       Delete downloaded weather data matching <pattern>
+			  info <file>            Get information about weather data in <file>
+			  clean                  Clean up the local cache of the archive index
+			END
+	fi
+}
+
+function clean()
+{
+	rm -rf $CACHEDIR
+	fetch_index
+}
+
+function index()
+{
+	fetch_index
+	if [ $# == 0 ]; then
+		cat $INDEX
+	else
+		grep "$1" $INDEX
+	fi
+}
+
+function list()
+{
+	fetch_index
+	LIST=$(index $1)
+	for f in $(index $1); do
+		if [ -f $f ]; then
+			echo $f
+		fi
+	done
+}
+
+function get()
+{
+	fetch_index
+	for f in $(index $1); do
+		if [ ! -f $f ]; then
+			echo -n "Downloading $f... "
+			curl -s $GITFILE/$COUNTRY/$f > $f
+			echo "done"
+		else
+			echo -n "Refreshing $f... "
+			curl -s $GITFILE/$COUNTRY/$f -z $f > $f
+			echo "done"
+		fi
+	done
+}
+
+function info()
+{
+	fetch_index
+	LIST=$(index $1)
+	first="yes"
+	for f in $(index $1); do
+		if [ -f $f ]; then
+			if [ "$first" == "yes" ]; then
+				echo "Filepath,StationId,StationName,RegionName,TzOffset,Latitude,Longitude,Elevation"
+				first="no"
+			fi
+			echo -n "\"$PWD/$f\","
+			head -n 1 $f
+		fi
+	done
+}
+
+function delete()
+{
+	fetch_index
+	LIST=$(index $1)
+	for f in $(index $1); do
+		if [ -f $f ]; then
+			rm $f
+		fi
+	done
+
+}
+
+if [ $# == 0 -o "$1" == "help" ]; then
+	help $2
+	exit 0
+elif [ "$(type -t $1)" = "function" ]; then
+	$*
+	exit 0
+else
+	echo "ERROR: '$1' is not a valid weather command"
+fi

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -40,7 +40,7 @@ function config()
 }
 
 # set the internal parameters
-DATADIR="$GLD_ETC/$COUNTRY"
+DATADIR="$GLD_ETC/weather/$COUNTRY"
 CACHEDIR="$DATADIR/.gridlabd-weather"
 GITPROJ="$GITHUB/$GITUSER/$GITREPO"
 GITFILE="$GITHUBUSERCONTENT/$GITUSER/$GITREPO/$GITBRANCH"
@@ -55,7 +55,6 @@ function fetch_index()
 	if [ ! -f $INDEX ]; then
 		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
 		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX
-		echo "done"
 		echo $(wc -l $INDEX | cut -c1-8) "weather files found"
 	fi
 }

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -36,6 +36,11 @@ function config()
 		echo "SVNLSOPTIONS=\"$SVNLSOPTIONS\""
 	elif [ "$1" == "reset" ]; then
 		rm -f $CONFIGFILE || (echo "ERROR: unable to reset $CONFIGFILE"; exit 1)
+	elif [ "$1" == "set" -a $# == 3 ]; then
+		echo "$2=\"$3\"" >> $CONFIGFILE
+	elif [ "$1" == "get" -a $# == 2 ]; then
+		value=$(grep ^$2 $CONFIGFILE | tail -n 1)
+		echo $value | cut -f2 -d= | cut -f2 -d\"
 	else
 		echo "'%s' is an invalid config option"
 		exit 1
@@ -84,7 +89,10 @@ function help()
 			  delete <pattern>   Delete downloaded weather data matching <pattern>
 			  info <pattern>     Get information about weather data in <pattern>
 			  clean              Clean up the local cache of the archive index
-			  config             Show the current configuration
+			  config show        Show the current configuration
+			         reset       Reset the current configuration
+			         set <N> <V> Set configuration variable name <N> to value <V>
+			         get <N> <V> Get configuration variable name <N>
 			END
 	fi
 }

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -1,27 +1,39 @@
 #!/bin/bash
 
+# configurable parameters
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
+COUNTRY="US"
+GITUSER=dchassin
+GITREPO="weather"
+GITBRANCH="master"
+CACHEDIR=".gridlabd-weather"
 
-if [ -f gridlabd-weather.conf ]; then
-	source gridlabd-weather.conf
-fi
-if [ "$COUNTRY" == "" ]; then
-	COUNTRY="US"
-fi
-if [ "$GITUSER" == "" ]; then
-	GITUSER=dchassin
-fi
-if [ "$GITREPO" == "" ]; then
-	GITREPO="weather"
-fi
-if [ "$GITBRANCH" == "" ]; then
-	GITBRANCH="master"
-fi
-if [ "$CACHEDIR" == "" ]; then
-	CACHEDIR=.gridlabd-weather
+# load the configuration (if any)
+CONFIGFILE="gridlabd-weather.conf"
+if [ -f $CONFIGFILE ]; then
+	source $CONFIGFILE
 fi
 
+function config()
+{
+	if [ $# == 0 -o "$1" == "show" ]; then
+		echo "GITHUB=\"$GITHUB\""
+		echo "GITHUBUSERCONTENT=\"$GITHUBUSERCONTENT\""
+		echo "COUNTRY=\"$COUNTRY\""
+		echo "GITUSER=\"$GITUSER\""
+		echo "GITREPO=\"$GITREPO\""
+		echo "GITBRANCH=\"$GITBRANCH\""
+		echo "CACHEDIR=\"$CACHEDIR\""
+	elif [ "$1" == "reset" ]; then
+		rm -f $CONFIGFILE
+	else
+		echo "'%s' is an invalid config option"
+		exit 1
+	fi
+}
+
+# set the internal parameters
 GITPROJ="$GITHUB/$GITUSER/$GITREPO"
 GITFILE="$GITHUBUSERCONTENT/$GITUSER/$GITREPO/$GITBRANCH"
 COMMIT_ID=$(git ls-remote "$GITPROJ" | grep "$GITBRANCH" | head -n 1 | cut -f1)
@@ -40,19 +52,23 @@ function fetch_index()
 	fi
 }
 
+#
+# command line interface
+#
 function help()
 {	
 	if [ $# == 0 ]; then
 		cat <<-END
 			Syntax: gridlabd-weather <command> [...]
 			Commands:
-			  help                   Get the list of commands
-			  index <pattern>        Index of available weather data matching <pattern> in archive
-			  list <pattern>         List of available downloaded data matching <pattern>
-			  get <pattern>          Download weather data matching <pattern> from archive 
-			  delete <pattern>       Delete downloaded weather data matching <pattern>
-			  info <file>            Get information about weather data in <file>
-			  clean                  Clean up the local cache of the archive index
+			  help               Get the list of commands
+			  index <pattern>    Index of available weather data matching <pattern> in archive
+			  list <pattern>     List of available downloaded data matching <pattern>
+			  get <pattern>      Download weather data matching <pattern> from archive 
+			  delete <pattern>   Delete downloaded weather data matching <pattern>
+			  info <file>        Get information about weather data in <file>
+			  clean              Clean up the local cache of the archive index
+			  config             Show the current configuration
 			END
 	fi
 }

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -32,7 +32,7 @@ function config()
 		echo "GITBRANCH=\"$GITBRANCH\""
 		echo "CACHEDIR=\"$CACHEDIR\""
 	elif [ "$1" == "reset" ]; then
-		rm -f $CONFIGFILE
+		rm -f $CONFIGFILE || (echo "ERROR: unable to reset $CONFIGFILE"; exit 1)
 	else
 		echo "'%s' is an invalid config option"
 		exit 1
@@ -49,12 +49,15 @@ INDEX=$CACHEDIR/$COMMIT_ID
 
 function fetch_index()
 {
+	if [ ! -d $DATADIR ]; then
+		mkdir -p $DATADIR || (echo "ERROR: unable to create $DATADIR"; exit 1)
+	fi
 	if [ ! -d $CACHEDIR ]; then
-		mkdir -p $CACHEDIR || ( echo "ERROR: unable to create cache directory"; exit 1)
+		mkdir -p $CACHEDIR || ( echo "ERROR: unable to create $CACHEDIR"; exit 1)
 	fi
 	if [ ! -f $INDEX ]; then
 		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
-		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX || rm $INDEX
+		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX || rm -f $INDEX
 		echo $(wc -l $INDEX | sed -e 's/ \+/ /g;s/^ //' | cut -f1 -d' ') "weather files found"
 	fi
 	if [ ! -f $INDEX ]; then
@@ -86,7 +89,11 @@ function help()
 
 function clean()
 {
-	rm -rf $CACHEDIR || echo "ERROR: unable to delete $CACHEDIR"
+	rm -rf $CACHEDIR 
+	if [ -d $CACHEDIR ]; then
+		echo "ERROR: unable to delete $CACHEDIR"
+		exit 1
+	fi
 	fetch_index
 }
 
@@ -117,14 +124,10 @@ function get()
 	for f in $(index $1); do
 		if [ ! -f $DATADIR/$f ]; then
 			echo -n "Downloading $f... "
-			(curl -s $GITFILE/$COUNTRY/$f > $DATADIR/$f && echo "done") || rm $DATADIR/$f
+			(curl -s $GITFILE/$COUNTRY/$f > /tmp/$$ && mv /tmp/$$ $DATADIR/$f && echo "done") || (echo "ERROR: unable to download $f"; rm -f /tmp/$$; exit 1)
 		else
 			echo -n "Refreshing $f... "
-			(curl -s $GITFILE/$COUNTRY/$f -z $DATADIR/$f > $DATADIR/$f && echo "done") || rm $DATADIR/$f
-		fi
-		if [ ! -f $DATADIR/$f ]; then
-			echo "ERROR: unable to download $f"
-			exit 1
+			(curl -s $GITFILE/$COUNTRY/$f -z $DATADIR/$f > /tmp/$$ && mv /tmp/$$ $DATADIR/$f && echo "done") || (echo "ERROR: unable to refresh $f"; rm -f /tmp/$$; exit 1)
 		fi
 	done
 }
@@ -152,7 +155,7 @@ function delete()
 	LIST=$(index $1)
 	for f in $(index $1); do
 		if [ -f $DATADIR/$f ]; then
-			rm $DATADIR/$f || ( echo "ERROR: unable to delete %f"; exit 1)
+			rm -f $DATADIR/$f || ( echo "ERROR: unable to delete %f"; exit 1)
 		fi
 	done
 

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -5,7 +5,7 @@ GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 COUNTRY="US"
 GITUSER=dchassin
-GITREPO="weather"
+GITREPO="gridlabd-weather"
 GITBRANCH="master"
 CACHEDIR=".gridlabd-weather"
 

--- a/gldcore/gridlabd-weather
+++ b/gldcore/gridlabd-weather
@@ -39,7 +39,14 @@ function config()
 	elif [ "$1" == "set" -a $# == 3 ]; then
 		echo "$2=\"$3\"" >> $CONFIGFILE
 	elif [ "$1" == "get" -a $# == 2 ]; then
-		value=$(grep ^$2 $CONFIGFILE | tail -n 1)
+		if [ ! -r $CONFIGFILE ]; then
+			value=$(config show | grep $2)
+		else
+			value=$(grep ^$2 $CONFIGFILE | tail -n 1)
+		fi
+		if [ -z "$value" ]; then
+			value=$(config show | grep $2)
+		fi
 		echo $value | cut -f2 -d= | cut -f2 -d\"
 	else
 		echo "'%s' is an invalid config option"

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Generated from gridlabd.m4sh by GNU Autoconf 2.69.
+# Generated from gldcore/gridlabd.m4sh by GNU Autoconf 2.69.
 ## -------------------- ##
 ## M4sh Initialization. ##
 ## -------------------- ##
@@ -333,8 +333,10 @@ elif test "x$1" = "x--valgrind" ; then :
   exit 0
 fi
 
+export GLD_ETC=$pkgdatadir
+export GLD_BIN=$bindir
+export GLD_LIB=$libdir
 if test -x "`which gridlabd-$1`" ; then :
-  cd $pkgdatadir
   gridlabd-$@
   exit
 fi

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -336,8 +336,8 @@ fi
 export GLD_ETC=$pkgdatadir
 export GLD_BIN=$bindir
 export GLD_LIB=$libdir
-if test -x "`which gridlabd-$1`" ; then :
-  gridlabd-$@
+if test -x "${bindir}/gridlabd-$1" ; then :
+  ${bindir}/gridlabd-$@
   exit
 fi
 

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Generated from gldcore/gridlabd.m4sh by GNU Autoconf 2.69.
+# Generated from gridlabd.m4sh by GNU Autoconf 2.69.
 ## -------------------- ##
 ## M4sh Initialization. ##
 ## -------------------- ##
@@ -331,6 +331,12 @@ elif test "x$1" = "x--valgrind" ; then :
   fi
   valgrind ${VALGRIND_OPTIONS} $bindir/gridlabd.bin $@
   exit 0
+fi
+
+if test -x "`which gridlabd-$1`" ; then :
+  cd $pkgdatadir
+  gridlabd-$@
+  exit
 fi
 
 if test "x$GLPATH" = x; then :

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -81,8 +81,8 @@ fi
 export GLD_ETC=$pkgdatadir 
 export GLD_BIN=$bindir
 export GLD_LIB=$libdir
-if test -x "`which gridlabd-$1`" ; then :
-  gridlabd-$@
+if test -x "${bindir}/gridlabd-$1" ; then :
+  ${bindir}/gridlabd-$@
   exit
 fi
 

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -78,6 +78,12 @@ elif test "x$1" = "x--valgrind" ; then :
   exit 0
 fi
 
+if test -x "`which gridlabd-$1`" ; then :
+  cd $pkgdatadir 
+  gridlabd-$@
+  exit
+fi
+
 AS_IF([test "x$GLPATH" = x],
   [export GLPATH="$pkglibdir:$pkgdatadir"],
   [export GLPATH="$pkglibdir:$pkgdatadir:$GLPATH"])

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -78,8 +78,10 @@ elif test "x$1" = "x--valgrind" ; then :
   exit 0
 fi
 
+export GLD_ETC=$pkgdatadir 
+export GLD_BIN=$bindir
+export GLD_LIB=$libdir
 if test -x "`which gridlabd-$1`" ; then :
-  cd $pkgdatadir 
   gridlabd-$@
   exit
 fi
@@ -89,14 +91,14 @@ AS_IF([test "x$GLPATH" = x],
   [export GLPATH="$pkglibdir:$pkgdatadir:$GLPATH"])
 
 AS_IF([test "x$TERM" = "xcygwin"],
-	[export CXXFLAGS="-I${pkgdatadir} $CXXFLAGS"],
-	[export CXXFLAGS="-I$pkgdatadir $CXXFLAGS"])
+  [export CXXFLAGS="-I${pkgdatadir} $CXXFLAGS"],
+  [export CXXFLAGS="-I$pkgdatadir $CXXFLAGS"])
 
 AS_IF([test "x$GRIDLABD_DEBUG" = "x"],
   [AS_IF([test "x$HAS_MINGW" = "xyes"],
-		["$bindir/gridlabd.exe" "$@"],
-		["$bindir/gridlabd.bin" "$@"])],
+    ["$bindir/gridlabd.exe" "$@"],
+    ["$bindir/gridlabd.bin" "$@"])],
   [AS_IF([test "x$HAS_MINGW" = "xyes"],
-		["$GRIDLABD_DEBUG" "$bindir/gridlabd.exe"],
-		["$GRIDLABD_DEBUG" "$bindir/gridlabd.bin"])])
+    ["$GRIDLABD_DEBUG" "$bindir/gridlabd.exe"],
+    ["$GRIDLABD_DEBUG" "$bindir/gridlabd.bin"])])
 

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -7400,6 +7400,31 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 			return TRUE;
 		}
 	}
+	else if (strncmp(line,MACRO "exec",5)==0)
+	{
+		char *term = strchr(line+5,' ');
+		char value[1024];
+		if (term==NULL)
+		{
+			output_error_raw("%s(%d): %ssystem missing system call",filename,linenum,MACRO);
+			strcpy(line,"\n");
+			return FALSE;
+		}
+		strcpy(value, strip_right_white(term+1));
+		IN_MYCONTEXT output_debug("%s(%d): executing system(char *cmd='%s')", filename, linenum, value);
+		global_return_code = system(value);
+		if( global_return_code != 0 )
+		{
+			output_error_raw("%s(%d): ERROR executing system(char *cmd='%s') -> non-zero exit code (status=%d)", filename, linenum, value, global_return_code);
+			strcpy(line,"\n");
+			return FALSE;
+		}
+		else
+		{
+			strcpy(line,"\n");
+			return TRUE;
+		}
+	}
 	else if (strncmp(line,MACRO "start",6)==0)
 	{
 		char *term = strchr(line+6,' ');


### PR DESCRIPTION
This PR adds the ability manage weather data using a `gridlabd weather` subcommand.

## Current issues
1. The weather index is current pegged at the first commit in `dchassin/gridlabd-weather` due to a bug in `svn list` when obtaining the weather file list from the GitHub HEAD node.  See the `SVNLSOPTIONS` variable in the `gridlabd-weather` script.  The value `-r1` should be changed if the list of weather files is updated.

## Code changes
1. A general provision for subcommands has been added to the main `gridlabd` command script.
2. A new `gridlabd-weather` subcommand has been added to the installed scripts.

## Documentation changes
1. New wiki page at https://github.com/dchassin/gridlabd/wiki/Weather-subcommand
2. A video tutorial is available at https://youtu.be/KTeOFbt-aiE

## Test and Validation Notes
1. New autotests in `gldcore/autotest/test_subcommand_weather*.glm`.
2. Suggest testing the commands indicated by `gridlabd weather help` and the examples given in the Wiki page.