### PR TITLE
Add support for output of filters, schedules, and transforms in GLM

### DIFF
--- a/gldcore/autotest/test_external_null_source.glm
+++ b/gldcore/autotest/test_external_null_source.glm
@@ -68,3 +68,6 @@ object noise {
 		interval -1;
 	};
 }
+
+#set glm_save_options=MINIMAL
+#set savefile=gridlabd.glm

--- a/gldcore/autotest/test_filter_delay.glm
+++ b/gldcore/autotest/test_filter_delay.glm
@@ -26,3 +26,6 @@ object multi_recorder {
 	interval -1;
 	property "from:value,to:value";
 }
+
+#set glm_save_options=MINIMAL
+#set savefile=gridlabd.glm

--- a/gldcore/autotest/test_filter_second.glm
+++ b/gldcore/autotest/test_filter_second.glm
@@ -47,3 +47,6 @@ object assert {
 	value -68.7143; // continuous FV is -100 final value but rounding on Gd makes it -68.7
 	within 1e-4;
 }
+
+#set glm_save_options=ORIGINAL
+#set savefile=gridlabd.glm

--- a/gldcore/autotest/test_schedule_skew.glm
+++ b/gldcore/autotest/test_schedule_skew.glm
@@ -53,3 +53,6 @@ object test {
 		within 0.00001;
 	};
 }
+
+#set glm_save_options=ORIGINAL
+#set savefile=gridlabd.glm

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -163,7 +163,8 @@ DEPRECATED static KEYWORD gso_keys[] = {
 	{"MINIMAL",		GSO_MINIMAL,	gso_keys+2},
 	{"NOGLOBALS",	GSO_NOGLOBALS,	gso_keys+3},
 	{"NODEFAULTS",	GSO_NODEFAULTS, gso_keys+4},
-	{"NOMACROS",	GSO_NOMACROS,	NULL},
+	{"NOMACROS",	GSO_NOMACROS,	gso_keys+5},
+	{"ORIGINAL",	GSO_ORIGINAL,	NULL},
 };
 
 DEPRECATED static struct s_varmap {

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -724,6 +724,7 @@ typedef enum {
 	GSO_NOGLOBALS	= 0x0004,
 	GSO_NODEFAULTS	= 0x0008,
 	GSO_MINIMAL 	= 0x000f,
+	GSO_ORIGINAL	= 0x001f,
 } GLMSAVEOPTIONS;
 
 /* Variable: */

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -4741,6 +4741,19 @@ static int object_properties(PARSER, CLASS *oclass, OBJECT *obj)
 							ACCEPT;
 						}
 					}
+					else if ( strcmp(propname,"guid")==0 )
+					{
+						if ( sscanf(propval,"%08llX%08llX",obj->guid,obj->guid+1) != 2 )
+						{
+							output_error("%s(%d): guid '%s' is not valid",filename,linenum,propval);
+							REJECT;
+							DONE;
+						}
+						else
+						{
+							ACCEPT;
+						}
+					}
 					else
 					{
 						output_error_raw("%s(%d): property %s is not defined in class %s", filename, linenum, propname, oclass->name);

--- a/gldcore/object.h
+++ b/gldcore/object.h
@@ -471,6 +471,11 @@ typedef struct s_jsondata {
 } JSONDATA;
 bool object_set_json(OBJECT *obj, const char *propname, JSONDATA *data);
 
+OBJECT *object_find_by_addr(void *addr);
+PROPERTY *object_get_first_property(OBJECT *obj, bool full=true);
+PROPERTY *object_get_next_property(PROPERTY *prop, bool full=true);
+PROPERTY *object_get_property_by_addr(OBJECT *obj, void *addr, bool full=true);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gldcore/save.cpp
+++ b/gldcore/save.cpp
@@ -165,8 +165,7 @@ int saveglm(const char *filename,FILE *fp)
 	}
 	count += module_saveall(fp);
 	count += class_saveall(fp);
-	if ( (global_glm_save_options&GSO_NOINTERNALS)==0 )
-		count += schedule_saveall(fp);
+	count += schedule_saveall(fp,(global_glm_save_options&GSO_NOINTERNALS)==GSO_NOINTERNALS);
 	count += transform_saveall(fp);
 	count += object_saveall(fp);
 

--- a/gldcore/schedule.cpp
+++ b/gldcore/schedule.cpp
@@ -1409,12 +1409,16 @@ void schedule_dump(SCHEDULE *sch, const char *file, const char *mode)
 	fclose(fp);
 }
 
-int schedule_saveall(FILE *fp)
+int schedule_saveall(FILE *fp,bool user_defined_only)
 {
 	int count = fprintf(fp,"%s\n","// schedules");
 	SCHEDULE *sch;
 	for (sch=schedule_list; sch!=NULL; sch=sch->next)
 	{
+		if ( user_defined_only && (sch->flags&SN_USERDEFINED)==0 )
+		{
+			continue;
+		}
 		char *c;
 		count += fprintf(fp,"schedule %s {\n\t",sch->name);
 		for ( c = sch->definition ; *c != '\0' ; c++ )

--- a/gldcore/schedule.h
+++ b/gldcore/schedule.h
@@ -118,7 +118,7 @@ void schedule_dump(SCHEDULE *sch, const char *file, const char *mode);
 void schedule_dumpall(const char *file);
 int schedule_createwait(void);
 SCHEDULE *schedule_getfirst(void);
-int schedule_saveall(FILE *fp);
+int schedule_saveall(FILE *fp,bool user_defined_only=true);
 
 #ifdef __cplusplus
 }

--- a/gldcore/transform.h
+++ b/gldcore/transform.h
@@ -59,6 +59,7 @@ typedef struct s_transferfunction {
 
 /* transform data structure */
 typedef struct s_transform {
+	const char *definition; ///< original definition of the transformation (needed for save operations)
 	double *source;	///< source vector of the function input
 	TRANSFORMSOURCE source_type; ///< data type of source
 	struct s_object_list *target_obj; ///< object of the target
@@ -115,6 +116,8 @@ TRANSFERFUNCTION *transform_find_filter(const char *name);
 int transform_add_filter(struct s_object_list *target_obj, struct s_property_map *target_prop, char *function, struct s_object_list *source_obj, struct s_property_map *source_prop);
 int transfer_function_add(char *tfname, char *domain, double timestep, double timeskew, unsigned int n, double *a, unsigned int m, double *b);
 
+TRANSFORM *transform_has_target(void *addr);
+int transform_write(TRANSFORM *xform, FILE *fp);
 int transform_saveall(FILE *fp);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR addresses issues with the previous work done to enable loadable GLM files.

## Current issues
1. The output GLM from models that have inline "C" code cannot be loaded because the "C" code is not available.

## Code changes
1. Added support for saving schedules when they are user-defined
2. Added support for saving filters, linear transformations, and external transforms.

## Documentation changes
None

## Test and Validation Notes
Any GLM model that contains a filter or transform should produce a save file that contains those entities now.
