### PR TITLE
Fix memory leaks in python link

### DIFF
--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -1321,11 +1321,8 @@ extern "C" bool on_init(void)
         PyObject *call = PyList_GetItem(python_init,n);
         if ( PyCallable_Check(call) )
         {
-            // PyObject *repr = PyObject_Repr(call);
-            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",global_clock);
             PyObject *result = PyEval_CallObject(call,arg);
-            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1361,11 +1358,8 @@ extern "C" TIMESTAMP on_precommit(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_precommit,n);
         if ( call && PyCallable_Check(call) )
         {
-            // PyObject *repr = PyObject_Repr(call);
-            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
-            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1403,11 +1397,8 @@ extern "C" TIMESTAMP on_presync(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_presync,n);
         if ( call && PyCallable_Check(call) )
         {
-            // PyObject *repr = PyObject_Repr(call);
-            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
-            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1444,11 +1435,8 @@ extern "C" TIMESTAMP on_sync(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_sync,n);
         if ( call && PyCallable_Check(call) )
         {
-            // PyObject *repr = PyObject_Repr(call);
-            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
-            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1485,11 +1473,8 @@ extern "C" TIMESTAMP on_postsync(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_postsync,n);
         if ( call && PyCallable_Check(call) )
         {
-            // PyObject *repr = PyObject_Repr(call);
-            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
-            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1525,11 +1510,8 @@ extern "C" bool on_commit(TIMESTAMP t)
         PyObject *call = PyList_GetItem(python_commit,n);
         if ( call && PyCallable_Check(call) )
         {
-            // PyObject *repr = PyObject_Repr(call);
-            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t);
             PyObject *result = PyEval_CallObject(call,arg);
-            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1562,11 +1544,8 @@ extern "C" void on_term(void)
         PyObject *call = PyList_GetItem(python_term,n);
         if ( call && PyCallable_Check(call) )
         {
-            // PyObject *repr = PyObject_Repr(call);
-            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",global_clock);
             PyObject *result = PyEval_CallObject(call,arg);
-            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1576,9 +1555,9 @@ extern "C" void on_term(void)
             }
             if ( result != Py_None ) 
             {
-                Py_DECREF(result);
                 output_warning("python on_term() return an unexpected type (expected None)");
             }
+            Py_DECREF(result);
         }
         else
         {

--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -1321,10 +1321,11 @@ extern "C" bool on_init(void)
         PyObject *call = PyList_GetItem(python_init,n);
         if ( PyCallable_Check(call) )
         {
-            PyObject *repr = PyObject_Repr(call);
-            output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
+            // PyObject *repr = PyObject_Repr(call);
+            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",global_clock);
             PyObject *result = PyEval_CallObject(call,arg);
+            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1360,10 +1361,11 @@ extern "C" TIMESTAMP on_precommit(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_precommit,n);
         if ( call && PyCallable_Check(call) )
         {
-            PyObject *repr = PyObject_Repr(call);
-            output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
+            // PyObject *repr = PyObject_Repr(call);
+            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
+            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1401,10 +1403,11 @@ extern "C" TIMESTAMP on_presync(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_presync,n);
         if ( call && PyCallable_Check(call) )
         {
-            PyObject *repr = PyObject_Repr(call);
-            output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
+            // PyObject *repr = PyObject_Repr(call);
+            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
+            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1441,10 +1444,11 @@ extern "C" TIMESTAMP on_sync(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_sync,n);
         if ( call && PyCallable_Check(call) )
         {
-            PyObject *repr = PyObject_Repr(call);
-            output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
+            // PyObject *repr = PyObject_Repr(call);
+            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
+            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1481,10 +1485,11 @@ extern "C" TIMESTAMP on_postsync(TIMESTAMP t0)
         PyObject *call = PyList_GetItem(python_postsync,n);
         if ( call && PyCallable_Check(call) )
         {
-            PyObject *repr = PyObject_Repr(call);
-            output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
+            // PyObject *repr = PyObject_Repr(call);
+            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t0);
             PyObject *result = PyEval_CallObject(call,arg);
+            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1520,10 +1525,11 @@ extern "C" bool on_commit(TIMESTAMP t)
         PyObject *call = PyList_GetItem(python_commit,n);
         if ( call && PyCallable_Check(call) )
         {
-            PyObject *repr = PyObject_Repr(call);
-            output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
+            // PyObject *repr = PyObject_Repr(call);
+            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",t);
             PyObject *result = PyEval_CallObject(call,arg);
+            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1556,10 +1562,11 @@ extern "C" void on_term(void)
         PyObject *call = PyList_GetItem(python_term,n);
         if ( call && PyCallable_Check(call) )
         {
-            PyObject *repr = PyObject_Repr(call);
-            output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
+            // PyObject *repr = PyObject_Repr(call);
+            // output_debug("calling python:%s",PyUnicode_AsUTF8(repr));
             PyObject *arg = Py_BuildValue("(i)",global_clock);
             PyObject *result = PyEval_CallObject(call,arg);
+            Py_DECREF(call);
             Py_DECREF(arg);
             if ( ! result )
             {

--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -439,7 +439,7 @@ static PyObject *gridlabd_add(PyObject *self, PyObject *args)
     }
 
     char *block;
-    PyObject *data;
+    PyObject *data, *item;
     if ( !PyArg_ParseTuple(args,"sO", &block, &data) )
         return NULL;
     if ( strcmp(block,"global") == 0 )
@@ -503,8 +503,12 @@ static PyObject *gridlabd_add(PyObject *self, PyObject *args)
         PyObject *key, *value;
         while ( PyDict_Next(data,&pos,&key,&value) )
         {
-            if ( PyObject_RichCompareBool(key,Py_BuildValue("s","name"),Py_EQ) )
+            if ( PyObject_RichCompareBool(key,item=Py_BuildValue("s","name"),Py_EQ) )
+            {
+                Py_DECREF(item);
                 continue;
+            }
+            Py_DECREF(item);
             fprintf(glmfh,"\t");
             PyObject_Print(key,glmfh,Py_PRINT_RAW);
             fprintf(glmfh," \"");
@@ -527,8 +531,12 @@ static PyObject *gridlabd_add(PyObject *self, PyObject *args)
         PyObject *key, *value;
         while ( PyDict_Next(data,&pos,&key,&value) )
         {
-            if ( PyObject_RichCompareBool(key,Py_BuildValue("s","name"),Py_EQ) )
+            if ( PyObject_RichCompareBool(key,item=Py_BuildValue("s","name"),Py_EQ) )
+            {
+                Py_DECREF(item);
                 continue;
+            }
+            Py_DECREF(item);
             fprintf(glmfh,"\t");
             PyObject_Print(key,glmfh,Py_PRINT_RAW);
             fprintf(glmfh," ");
@@ -551,8 +559,12 @@ static PyObject *gridlabd_add(PyObject *self, PyObject *args)
         PyObject *key, *value;
         while ( PyDict_Next(data,&pos,&key,&value) )
         {
-            if ( PyObject_RichCompareBool(key,Py_BuildValue("s","class"),Py_EQ) )
+            if ( PyObject_RichCompareBool(key,item=Py_BuildValue("s","class"),Py_EQ) )
+            {
+                Py_DECREF(item);
                 continue;
+            }
+            Py_DECREF(item);
             fprintf(glmfh,"\t");
             PyObject_Print(key,glmfh,Py_PRINT_RAW);
             fprintf(glmfh," \"");
@@ -885,6 +897,7 @@ static PyObject *gridlabd_set_global(PyObject *self, PyObject *args)
     }
     if ( global_setvar(name,value) == FAILED )
     {
+        if ( ret ) Py_DECREF(ret);
         return gridlabd_exception("unable to set global '%s' to value '%s'",name,value);
     }
     else
@@ -1774,7 +1787,9 @@ static bool get_callback(
 
 int python_module_setvar(const char *varname, const char *value)
 {
-    PyModule_AddObject(this_module,varname,Py_BuildValue("s", value));
+    PyObject *item = Py_BuildValue("s", value);
+    PyModule_AddObject(this_module,varname,item);
+    Py_DECREF(item);
     return strlen(value);
 }
 

--- a/gldcore/link/python/test_memory.glm
+++ b/gldcore/link/python/test_memory.glm
@@ -1,0 +1,29 @@
+//#set debug=TRUE
+
+// load the custom python module
+module try_everything;
+
+// setup the clock to run only 1 hour
+clock {
+	starttime "2018-01-01 00:00:00";
+	stoptime "2019-01-01 00:00:00";
+}
+
+// create a custom class that generates a random power
+class test {
+	randomvar x[MW];
+    double y[kW];
+}
+
+// create an instance of the custom class
+object test:..100 {
+	x "type:lognormal(0,1); refresh:5min";
+
+	// dispatch commit calls to the python module
+    on_init "python:try_everything.init";
+	on_precommit "python:try_everything.precommit";
+    on_presync "python:try_everything.presync";
+    on_sync "python:try_everything.sync";
+    on_postsync "python:try_everything.postsync";
+	on_commit "python:try_everything.commit";
+}

--- a/gldcore/link/python/test_memory.py
+++ b/gldcore/link/python/test_memory.py
@@ -1,0 +1,15 @@
+import sys
+assert(sys.version_info.major>2)
+
+import gridlabd
+
+# construct the command line (gridlabd hasn't started yet)
+gridlabd.command('test_memory.glm')
+
+# start gridlabd and wait for it to complete
+gridlabd.start('wait')
+
+# send the final model state to a file
+gridlabd.save('done.json')
+
+

--- a/gldcore/link/python/try_everything.py
+++ b/gldcore/link/python/try_everything.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+def try_everything(obj=None,t=None,context=None):
+	if obj:
+		a = gridlabd.get_object(obj)
+		#print(a)
+		b = gridlabd.get_value(obj,'x')
+		gridlabd.set_value(obj,'y',b)
+		#print('%s(obj=<%s>,t=<%s>): %s'%(context,obj,t,a))
+	else:
+		c = gridlabd.get('objects')
+		d = gridlabd.get('globals')
+		#print('%s(t=<%s>): objects=[%s], globals[%s]'%(obj,t,c,d))
+
+# enable a callback when the module is initialized by gridlabd at the start of a simulation
+def on_init(t) :
+	try_everything(None,t,'on_init')
+	return True
+def on_precommit(t) :
+	print(datetime.fromtimestamp(t))
+	try_everything(None,t,'on_precommit')
+	return gridlabd.NEVER
+def on_presync(t) :
+	try_everything(None,t,'on_presync')
+	return gridlabd.NEVER
+def on_sync(t) :
+	try_everything(None,t,'on_sync')
+	return gridlabd.NEVER
+def on_postsync(t) :
+	try_everything(None,t,'on_postsync')
+	return gridlabd.NEVER
+def on_commit(t) :
+	try_everything(None,t,'on_commit')
+	return True
+def on_term(t):
+	try_everything(None,t,'on_term')
+
+def init(obj,t):
+	try_everything(obj,t,'init')
+	return 0
+def precommit(obj,t) :
+	try_everything(obj,t,'precommit')
+	return gridlabd.NEVER
+def presync(obj,t):
+	try_everything(obj,t,'presync')
+	return gridlabd.NEVER
+def sync(obj,t):
+	try_everything(obj,t,'sync')
+	return gridlabd.NEVER
+def postsync(obj,t):
+	try_everything(obj,t,'postsync')
+	return gridlabd.NEVER
+def commit(obj,t) :
+	try_everything(obj,t,'commit')
+	return gridlabd.NEVER
+def finalize(obj,t):
+	try_everything(obj,t,'finalize')
+	return gridlabd.NEVER
+def term(obj,t):
+	try_everything(obj,t,'term')
+	return gridlabd.NEVER

--- a/gldcore/link/python/try_everything.py
+++ b/gldcore/link/python/try_everything.py
@@ -3,16 +3,15 @@ from datetime import datetime
 def try_everything(obj=None,t=None,context=None):
 	if obj:
 		a = gridlabd.get_object(obj)
-		#print(a)
 		b = gridlabd.get_value(obj,'x')
 		gridlabd.set_value(obj,'y',b)
-		#print('%s(obj=<%s>,t=<%s>): %s'%(context,obj,t,a))
+		return
 	else:
 		c = gridlabd.get('objects')
 		d = gridlabd.get('globals')
-		#print('%s(t=<%s>): objects=[%s], globals[%s]'%(obj,t,c,d))
+		return
 
-# enable a callback when the module is initialized by gridlabd at the start of a simulation
+# module event handlers
 def on_init(t) :
 	try_everything(None,t,'on_init')
 	return True
@@ -35,6 +34,7 @@ def on_commit(t) :
 def on_term(t):
 	try_everything(None,t,'on_term')
 
+# object event handlers
 def init(obj,t):
 	try_everything(obj,t,'init')
 	return 0

--- a/gldcore/link/python/try_everything.py
+++ b/gldcore/link/python/try_everything.py
@@ -4,11 +4,16 @@ def try_everything(obj=None,t=None,context=None):
 	if obj:
 		a = gridlabd.get_object(obj)
 		b = gridlabd.get_value(obj,'x')
-		gridlabd.set_value(obj,'y',b)
+		c = gridlabd.set_value(obj,'y',b)
+		d = gridlabd.set_global('test',str(t))
 		return
 	else:
-		c = gridlabd.get('objects')
-		d = gridlabd.get('globals')
+		a = gridlabd.get('objects')
+		b = gridlabd.get('globals')
+		c = gridlabd.get('classes')
+		d = gridlabd.get('modules')
+		e = gridlabd.get('transforms')
+		f = gridlabd.get('schedules')
 		return
 
 # module event handlers


### PR DESCRIPTION
This PR addresses issue with progressive memory leaks detected in the PowerNET simulations. 

## Current issues
1. Fixed verified only for most commonly used calls, e.g., get, get_object, get_value, and set_value.

## Code changes
1. Added a number of `Py_DECREF` calls in the python link.

## Documentation changes
None

## Test and Validation Notes
Create a non-validation test that attempts to consume memory by making the same calls over and over for a very long time. Running this test with `top` running show now significant change in memory use over 100,000+ calls.
