### PR TITLE
Fix missing initialization of last_t in meter and triplex meter

### DIFF
--- a/powerflow/meter.cpp
+++ b/powerflow/meter.cpp
@@ -266,7 +266,8 @@ int meter::init(OBJECT *parent)
 	}
 
 	check_prices();
-	last_t = dt = 0;
+	last_t = gl_globalclock;
+	dt = 0;
 
 	//Update tracking flag
 	//Get server mode variable

--- a/powerflow/triplex_meter.cpp
+++ b/powerflow/triplex_meter.cpp
@@ -215,6 +215,7 @@ int triplex_meter::init(OBJECT *parent)
 		}
 	}
 	check_prices();
+	last_t = gl_globalclock;
 
 	return triplex_node::init(parent);
 }


### PR DESCRIPTION
This PR addresses a problem when loading `meter` and `triplex_meter` objects that have non-zero initial measured power values. The initial value of measure energy is absurdly large. This is because the value of `last_t` is initially 0, so `dt=t1-last_t` ends up being very large on the first time step. Normally this isn't a problem because the measured power is 0 by default. But if the measure power is non-zero, the integration is *very* non-zero.

## Current issues
None

## Code changes
1. Changed `meter` and `triplex_meter` initialization so that `last_t=gl_globalclock` to avoid integrating the initial value from the 0 to the start time.

## Documentation changes
None

## Test and Validation Notes
None
