### PR TITLE
Fix master validate

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -212,7 +212,7 @@ clean-wc:
 	. utilities/cleanwc
 
 install-validate: install
-	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -T 0 --validate || (tar cfz validate-output.tar.gz */autotest/test_*/*;exit 1))
+	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd --validate || (tar cfz validate-output.tar.gz */autotest/test_*/*;exit 1))
 
 check-local validate: 
 	gridlabd --validate


### PR DESCRIPTION
This PR addresses issue #378 

## Current issues
None

## Code changes
1. Remove `-T 0` option from `install-validate` target in `Makefile.am`

## Documentation changes
None

## Test and Validation Notes
This causes the validate process to run significantly slower but avoids the parallelism that is apparently the cause of the exception.
