### PR TITLE
Add support for ISO8601 output

### DIFF
--- a/gldcore/autotest/test_iso_datetime.glm
+++ b/gldcore/autotest/test_iso_datetime.glm
@@ -2,6 +2,8 @@ module tape;
 module climate; 
 module assert;
 
+#set dateformat=ISO8601
+
 clock {
 	timezone "EST+5EDT";
 	starttime "2000-01-01T00:00:00-05:00";
@@ -25,3 +27,4 @@ object test {
 };
 
 script on_term gridlabd:dump test_clock.json;
+#on_exit 0 python3 ../test_iso_datetime.py

--- a/gldcore/autotest/test_iso_datetime.py
+++ b/gldcore/autotest/test_iso_datetime.py
@@ -1,0 +1,10 @@
+import json 
+with open('test_clock.json') as json_file:
+	data = json.load(json_file)
+	for obj in data['globals'] :
+		if obj == "starttime" or obj == "stoptime": 
+			if "T" == data["globals"]["starttime"]["value"][10] : 
+				exit(0)
+			else : 
+				print("ISO format was not detected in the JSON")
+				exit(1)

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -15,7 +15,8 @@ DEPRECATED static GLOBALVAR *global_varlist = NULL, *lastvar = NULL;
 DEPRECATED static KEYWORD df_keys[] = {
 	{"ISO", DF_ISO, df_keys+1},
 	{"US", DF_US, df_keys+2},
-	{"EURO", DF_EURO, NULL},
+	{"EURO", DF_EURO, df_keys+3},
+	{"ISO8601", DF_ISO8601, NULL},
 };
 DEPRECATED static KEYWORD trl_keys[] = {
 	{"PRINCIPLE",	TRL_PRINCIPLE, trl_keys+1},

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -123,14 +123,16 @@ size_t global_saveall(FILE *fp);
 		DF_ISO = 0 - ISO standard format
 		DF_US = 1 - USA date format (i.e., mm/dd/yyyy)
 		DF_EURO = 2 - EU data format (i.e., dd/mm/yyyy)
+		DF_ISO8601 = 3 - ISO8601 standard format
 
 	See Also:
 	- <global_dateformat>
  */
 typedef enum e_dateformat {
-	DF_ISO=0, 
-	DF_US=1, 
-	DF_EURO=2,
+	DF_ISO		= 0, 
+	DF_US		= 1, 
+	DF_EURO		= 2,
+	DF_ISO8601	= 3,
 } DATEFORMAT;
 
 /*	Typedef INITSEQ

--- a/gldcore/timestamp.cpp
+++ b/gldcore/timestamp.cpp
@@ -545,7 +545,23 @@ int strdatetime(DATETIME *t, char *buffer, int size)
 	}
 
 	/* choose best format */
-	if ( global_dateformat == DF_ISO )
+	if ( global_dateformat == DF_ISO8601 )
+	{
+		char tzs = ( t->tzoffset < 0 ? '+' : '-' );
+		int tzh = (t->tzoffset<0?-t->tzoffset:t->tzoffset) / 3600 ;
+		int tzm = ((t->tzoffset<0?-t->tzoffset:t->tzoffset)-tzh*3600)/60 % 60;
+		if ( t->nanosecond != 0 ) 
+		{
+			len = sprintf(tbuffer, "%04d-%02d-%02dT%02d:%02d:%02d.%06d%c%02d:%02d",
+				t->year, t->month, t->day, t->hour, t->minute, t->second, t->nanosecond/1000, tzs, tzh, tzm);
+		} 
+		else 
+		{
+			len = sprintf(tbuffer, "%04d-%02d-%02dT%02d:%02d:%02d%c%02d:%02d",
+				t->year, t->month, t->day, t->hour, t->minute, t->second, tzs, tzh, tzm);
+		}
+	} 
+	else if ( global_dateformat == DF_ISO )
 	{
 		if ( t->nanosecond != 0 ) 
 		{


### PR DESCRIPTION
This PR addresses issue #384.

## Current issues
1. ISO8601 is not the default output format.  We need to wait to deprecate the current default before changing that.

## Code changes
1. Added ISO8601 to global enum `dateformat`.
1. Added support for ISO8601 in `gldcore/timestamp.c:strdatetime()`

## Documentation changes
None

## Test and Validation Notes
The autotest `gldcore/autotest/test_iso_datetime.glm` now changes the `datetime` format global so that the JSON output file should output using the new format.
