### PR TITLE
Add support for AWS subcommand

### DIFF
--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -75,8 +75,6 @@ GLD_SOURCES_EXTRA_PLACE_HOLDER += gldcore/xcore.cpp gldcore/xcore.h
 
 if HAVE_MINGW
 
-bin_SCRIPTS += gldcore/gridlabd  gldcore/gridlabd-weather
-
 bin_PROGRAMS += gridlabd
 
 gridlabd_CPPFLAGS =
@@ -100,8 +98,6 @@ EXTRA_gridlabd_SOURCES += $(GLD_SOURCES_EXTRA_PLACE_HOLDER)
 
 else
 
-bin_SCRIPTS += gldcore/gridlabd gldcore/gridlabd-weather
-
 bin_PROGRAMS += gridlabd.bin
 
 gridlabd_bin_CPPFLAGS =
@@ -123,6 +119,10 @@ gridlabd_bin_SOURCES += $(GLD_SOURCES_PLACE_HOLDER)
 EXTRA_gridlabd_bin_SOURCES =
 EXTRA_gridlabd_bin_SOURCES += $(GLD_SOURCES_EXTRA_PLACE_HOLDER)
 endif
+
+bin_SCRIPTS += gldcore/gridlabd 
+bin_SCRIPTS += gldcore/gridlabd-weather
+bin_SCRIPTS += gldcore/gridlabd-aws
 
 GLD_SOURCES_PLACE_HOLDER += gldcore/build.h
 BUILT_SOURCES += gldcore/build.h

--- a/gldcore/gridlabd-aws
+++ b/gldcore/gridlabd-aws
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+function output()
+{
+	echo "$*" > /dev/stdout
+}
+
+function error ()
+{
+	CODE="$1"
+	shift 1
+	echo "ERROR: $*" > /dev/stderr
+	exit $CODE
+}
+
+# check awscli installation
+if [ -z "$(which aws)" ]; then
+	error 1 "awscli is not installed -- run 'pip3 install awscli'"
+fi
+
+# check awscli version
+VERSION=($(aws --version | cut -f1 -d' ' | cut -f2 -d'/' | tr '.' ' '))
+MAJOR=${VERSION[0]}
+MINOR=${VERSION[1]}
+PATCH=${VERSION[2]}
+if [ $MAJOR -lt 1 -o $MINOR -lt 16 ]; then
+	error 2 "awscli is outdated -- run 'pip3 install awscli --upgrade'"
+fi
+
+aws $*


### PR DESCRIPTION
This PR addresses issue(s) #402.

## Current issues
None

## Code changes
1. Added `gldcore/gridlabd-aws` subcommand script.
1. Updated `gldcore/Makefile.mk`.

## Documentation changes
TODO: need to update documentation after `restructure-install` branch is merged.

## Test and Validation Notes
Need an active AWS account to test subcommand.
