### PR TITLE
Add docs browser

### DIFF
--- a/docs/_contents.html
+++ b/docs/_contents.html
@@ -1,0 +1,146 @@
+<HTML>
+<HEAD>
+<LINK rel="stylesheet" type="text/css" href="docs.css" />
+<SCRIPT LANGUAGE="JavaScript">
+	function set_host(element)
+	{
+		if ( event.key === 'Enter' )
+		{
+			host = element.value;
+		}
+	}
+	function set_owner(element)
+	{
+		if ( event.key === 'Enter' )
+		{
+			owner = element.value;
+		}
+	}
+	function set_project(element)
+	{
+		if ( event.key === 'Enter' )
+		{
+			project = element.value;
+		}
+	}
+	function load_contents()
+    {
+	    var r = new XMLHttpRequest();
+        r.open('GET','https://api.'+host+'/repos/'+owner+'/'+project+'/contents/docs?ref='+branch,false);
+        r.send(null);
+        contents = ""
+        if ( r.status == 200 )
+        {
+            JSON.parse(r.responseText, function (key,value)
+            {
+                if ( key == 'name' && value.endsWith('.md') && value.substring(0,1) != '_' )
+                {
+                	docspec = href + "?owner=" + owner + "&project=" + project + "&branch=" + branch + "&doc=" + value;
+                    contents = contents + ('<A HREF="' + docspec + '" TARGET="page">');
+                    contents = contents + (value.substring(0,value.length-3));
+                    contents = contents + ('</A>');
+	                contents = contents + ('<BR/>')
+                }
+            })
+
+        }
+        else
+        {
+	        contents = contents + ("ERROR " + r.status + ": " + r.responseText);
+        }
+        document.getElementById("contents").innerHTML = contents;
+    }
+	function set_branch(element)
+	{
+		branch = document.getElementById("branch").value;
+		load_contents();
+	}
+</SCRIPT>
+</HEAD>
+
+<BODY>
+
+<TABLE WIDTH="100%">
+<CAPTION>GridLAB-D Documentation</CAPTION>
+<SCRIPT LANGUAGE="JavaScript">
+    var query = new URLSearchParams(window.location.search);
+    var href = location.origin+location.pathname.replace('/_contents.html','/_page.html');
+    var host = "github.com";
+    if ( host == null )
+    {
+        host = "github.com";
+    }
+    document.writeln('<TR><TH ALIGN=LEFT>Host</TH><TD><INPUT ID="host" ONKEYDOWN="set_host()" NAME="host" VALUE="' + host + '" /></TD></TR>');
+
+    var owner = query.get('owner');
+    if ( owner == null )
+    {
+        owner = "dchassin";
+    }
+    document.writeln('<TR><TH ALIGN=LEFT>User/Org</TH><TD><INPUT ID="owner" ONKEYDOWN="set_owner()" NAME="owner" VALUE="' + owner + '" /></TD></TR>');
+
+    var project = query.get('project');
+    if ( project == null )
+    {
+        project = "gridlabd";
+    }
+    document.writeln('<TR><TH ALIGN=LEFT>Project</TH><TD><INPUT ID="project" ONKEYDOWN="set_project()" NAME="project" VALUE="' + project + '" /></TD></TR>');
+
+    var branch = query.get('branch');
+    if ( branch == null )
+    {
+        branch = "master";
+    }
+    document.writeln('<TR><TH ALIGN=LEFT>Branch</TH><TD>');
+    document.writeln('<SELECT ID="branch" ONCHANGE="set_branch()">')
+    var r = new XMLHttpRequest();
+    r.open('GET','https://api.'+host+'/repos/'+owner+'/'+project+'/branches?per_page=1000',false);
+    r.send(null);
+    if ( r.status == 200 )
+    {
+        JSON.parse(r.responseText, function (key,value)
+        {
+            if ( key == 'name' )
+            {
+                document.writeln('<OPTION VALUE="'+value+'"');
+            	if ( value == branch )
+            	{
+            		document.writeln(' SELECTED');
+            	}
+                document.writeln('>'+value+'</OPTION>\n');
+            }
+        })
+	}
+    document.writeln('</SELECT>');
+    document.writeln('</TD></TR>');
+
+	var doc = query.get('doc');
+	if ( doc == null )
+	{
+	    doc = "README.md";
+	}
+</SCRIPT>
+</TABLE>
+
+<HR/>
+
+<TABLE WIDTH="100%">
+<CAPTION>Table of Contents</CAPTION>
+</TABLE>
+
+<DIV ID="contents">
+<SCRIPT LANGUAGE="JavaScript">
+    try
+    {
+    	load_contents();
+    }
+    catch (err)
+    {
+        document.writeln("ERROR: " + err.message);
+    }
+</SCRIPT>
+</DIV>
+<HR/>
+
+</BODY>
+</HTML>

--- a/docs/_contents.html
+++ b/docs/_contents.html
@@ -65,6 +65,7 @@
 <SCRIPT LANGUAGE="JavaScript">
     var query = new URLSearchParams(window.location.search);
     var href = location.origin+location.pathname.replace('/_contents.html','/_page.html');
+    // TODO: the defaults should come from a config.js instead
     var host = "github.com";
     if ( host == null )
     {

--- a/docs/_footer.md
+++ b/docs/_footer.md
@@ -1,5 +1,3 @@
----
-
 This documentation is distributed under the terms of the [GridLAB-D license](https://github.com/dchassin/gridlabd/blob/master/LICENSE). The terms of the license cover all updates and modifications by all contributors to the code and documentation since the original date of the license.
 
 This version of GridLAB-D and the documentation provided with it were created with funding from the US Department of Energy's Office of Electricity, Building Technology Office, Solar Energy Technology Office, ARPA-E, and the California Energy Commission under multiple grants and programs, including EPC-17-043, EPC-17-046, and EPC-17-047.

--- a/docs/_footer.md
+++ b/docs/_footer.md
@@ -1,0 +1,7 @@
+---
+
+This documentation is distributed under the terms of the [GridLAB-D license](https://github.com/dchassin/gridlabd/blob/master/LICENSE). The terms of the license cover all updates and modifications by all contributors to the code and documentation since the original date of the license.
+
+This version of GridLAB-D and the documentation provided with it were created with funding from the US Department of Energy's Office of Electricity, Building Technology Office, Solar Energy Technology Office, ARPA-E, and the California Energy Commission under multiple grants and programs, including EPC-17-043, EPC-17-046, and EPC-17-047.
+
+SLAC National Accelerator Laboratory is operated for the US Department of Energy by Stanford University under Contract No. DE-AC02-76SF00515.

--- a/docs/_header.md
+++ b/docs/_header.md
@@ -1,2 +1,1 @@
 GridLAB-D 4.2 Documentation
----

--- a/docs/_header.md
+++ b/docs/_header.md
@@ -1,0 +1,2 @@
+GridLAB-D 4.2 Documentation
+---

--- a/docs/_page.html
+++ b/docs/_page.html
@@ -24,14 +24,14 @@ function load_markdown(url)
             var ro = re[Symbol.replace](rr.responseText,to_url)
             document.writeln(ro)
         }
-        else if ( rr.status != 404 )
+        else //if ( rr.status != 404 )
         {                
-            document.writeln('<FONT COLOR=RED>[ERROR ' + rr.status + ': '+url+']</FONT><BR/>');
+            document.writeln('<FONT COLOR=RED>[ERROR ' + rr.status + ' ['+url+'] '+rr.responseText+'</FONT><BR/>');
         }
     }
-    else if ( r.status != 404 )
+    else //if ( r.status != 404 )
     {
-        document.writeln('<FONT COLOR=RED>[ERROR ' + r.status + ': '+url+']</FONT><BR/>');
+        document.writeln('<FONT COLOR=RED>[ERROR ' + r.status + ' ['+url+'] '+r.responseText+'</FONT><BR/>');
     }
 }    
 </SCRIPT>

--- a/docs/_page.html
+++ b/docs/_page.html
@@ -26,12 +26,12 @@ function load_markdown(url)
         }
         else //if ( rr.status != 404 )
         {                
-            document.writeln('<FONT COLOR=RED>[ERROR ' + rr.status + ' ['+url+'] '+rr.responseText+'</FONT><BR/>');
+            throw ('<FONT COLOR=RED>[ERROR ' + rr.status + ' ['+url+'] '+rr.responseText+'</FONT><BR/>');
         }
     }
     else //if ( r.status != 404 )
     {
-        document.writeln('<FONT COLOR=RED>[ERROR ' + r.status + ' ['+url+'] '+r.responseText+'</FONT><BR/>');
+        throw ('<FONT COLOR=RED>[ERROR ' + r.status + ' ['+url+'] '+r.responseText+'</FONT><BR/>');
     }
 }    
 </SCRIPT>
@@ -84,7 +84,7 @@ Source document:
 <HR/>
 
 <SCRIPT LANGUAGE="JavaScript">
-    document.writeln('<DIV ID="footer" CLASS="footer">')
+    document.writeln('<DIV ID="header" CLASS="header">')
     try 
     { 
         load_markdown(base+'_header.md') ;
@@ -93,7 +93,7 @@ Source document:
     {
         document.writeln(banner);
     }
-    document.writeln('<HR/></DIV>')
+    document.writeln('<HR/></DIV ID">')
     try 
     {        
         load_markdown(base+doc);
@@ -102,7 +102,7 @@ Source document:
     {
         document.writeln("ERROR: "+err.message)
     }
-    document.writeln('<HR/><DIV ID="footer" CLASS="footer">')
+    document.writeln('<DIV ID="footer" CLASS="footer">')
     try 
     { 
         load_markdown(base+'_footer.md') 
@@ -113,7 +113,7 @@ Source document:
         document.writeln(copyright);
     }
 </SCRIPT>
-
+<HR/>
 </BODY>
 
 </HTML>

--- a/docs/_page.html
+++ b/docs/_page.html
@@ -1,0 +1,114 @@
+<HTML>
+
+<HEAD>
+<LINK rel="stylesheet" type="text/css" href="docs.css" />
+<SCRIPT LANGUAGE="JavaScript">
+function load_markdown(url)
+{
+    var r = new XMLHttpRequest()
+    r.open('GET',url,false)
+    r.send(null);
+    if ( r.status == 200 )
+    {
+        var rr = new XMLHttpRequest()
+        rr.open('POST','https://api.'+host+'/markdown/raw',false)
+        rr.send(r.responseText)
+        if ( rr.status == 200 )
+        {
+            var re = /\[\[[-A-Za-z_ 0-9]+\]\]/g
+            function to_url(tag)
+            {
+                ref = tag.substr(2,tag.length-4)
+                return "<A HREF=\"?owner=" + owner + "&project=" + project + "&branch=" + branch + "&doc=" + ref + ".md\">" + ref + "</A>"
+            }
+            var ro = re[Symbol.replace](rr.responseText,to_url)
+            document.writeln(ro)
+        }
+        else if ( rr.status != 404 )
+        {
+            document.writeln('<FONT COLOR=RED>[ERROR ' + rr.status + ': '+url+']</FONT><BR/>');
+        }
+    }
+    else if ( r.status != 404 )
+    {
+        document.writeln('<FONT COLOR=RED>[ERROR ' + r.status + ': '+url+']</FONT><BR/>');
+    }
+}    
+</SCRIPT>
+</HEAD>
+
+<BODY>
+
+<SCRIPT LANGUAGE="JavaScript">
+    var banner = "GridLAB-D Documentation";
+    var now = new Date();
+    var copyright = "Copyright (C) " + now.getFullYear() + ", Regents of the Leland Stanford Junior University";
+    var query = new URLSearchParams(window.location.search);
+    var href = location.origin+location.pathname.substring(0,location.pathname.lastIndexOf('/')+1);
+    var host = "github.com";
+    if ( host == null )
+    {
+        host = "github.com";
+    }
+    var owner = query.get('owner');
+    if ( owner == null )
+    {
+        owner = "dchassin";
+    }
+    var project = query.get('project');
+    if ( project == null )
+    {
+        project = "gridlabd";
+    }
+    var branch = query.get('branch');
+    if ( branch == null )
+    {
+        branch = "master";
+    }
+    var doc = query.get('doc');
+    if ( doc == null )
+    {
+        doc = "README.md";
+    }
+    // TODO: The replacement <name>.com ->raw.<name>usercontent.com is probably not general, but works for github.com.
+    //       Suggest using a static config document on the host to implement this translation.
+    var base = 'https://raw.'+host.replace(".com","usercontent.com")+'/' + owner + '/' + project + '/' + branch + '/docs/';
+</SCRIPT>
+
+Source document:
+<SCRIPT LANGUAGE="JavaScript">
+    url = 'https://'+host+'/'+owner+'/'+project+'/tree/'+branch+'/docs/' + doc;
+    document.write('<A TARGET="_new" ID="source" HREF="' + url + '">' + url + '</A>');
+</SCRIPT>
+<HR/>
+
+<SCRIPT LANGUAGE="JavaScript">
+    try 
+    { 
+        load_markdown(base+'_header.md') ;
+    } 
+    catch (e) 
+    {
+        document.writeln(banner+"<HR/>");
+    }
+    try 
+    {        
+        load_markdown(base+doc);
+    }
+    catch (err)
+    {
+        document.writeln("ERROR: "+err.message)
+    }
+    try 
+    { 
+        load_markdown(base+'_footer.md') 
+    } 
+    catch (e) 
+    {
+    }
+    document.writeln('<HR/>'+copyright);
+</SCRIPT>
+
+</BODY>
+
+</HTML>

--- a/docs/_page.html
+++ b/docs/_page.html
@@ -25,7 +25,7 @@ function load_markdown(url)
             document.writeln(ro)
         }
         else if ( rr.status != 404 )
-        {
+        {                
             document.writeln('<FONT COLOR=RED>[ERROR ' + rr.status + ': '+url+']</FONT><BR/>');
         }
     }
@@ -45,6 +45,7 @@ function load_markdown(url)
     var copyright = "Copyright (C) " + now.getFullYear() + ", Regents of the Leland Stanford Junior University";
     var query = new URLSearchParams(window.location.search);
     var href = location.origin+location.pathname.substring(0,location.pathname.lastIndexOf('/')+1);
+    // TODO: the defaults should come from a config.js instead
     var host = "github.com";
     if ( host == null )
     {
@@ -83,14 +84,16 @@ Source document:
 <HR/>
 
 <SCRIPT LANGUAGE="JavaScript">
+    document.writeln('<DIV ID="footer" CLASS="footer">')
     try 
     { 
         load_markdown(base+'_header.md') ;
     } 
     catch (e) 
     {
-        document.writeln(banner+"<HR/>");
+        document.writeln(banner);
     }
+    document.writeln('<HR/></DIV>')
     try 
     {        
         load_markdown(base+doc);
@@ -99,14 +102,16 @@ Source document:
     {
         document.writeln("ERROR: "+err.message)
     }
+    document.writeln('<HR/><DIV ID="footer" CLASS="footer">')
     try 
     { 
         load_markdown(base+'_footer.md') 
+        document.writeln('<P/>'+copyright);
     } 
     catch (e) 
     {
+        document.writeln(copyright);
     }
-    document.writeln('<HR/>'+copyright);
 </SCRIPT>
 
 </BODY>

--- a/docs/_start.md
+++ b/docs/_start.md
@@ -1,0 +1,83 @@
+The documentation for the current release of GridLAB-D is provided by the [GridLAB-D Project on ShoutWiki](http://gridlab-d.shoutwiki.com/wiki/Main_Page).  The documentation on this site is only for the improvements supported by this repository.
+
+# How To
+* [[Install]]
+* [[Docker]]
+* [[CircleCI]]
+
+# GLM Language
+* [[Curl]] macro
+* [[Dump]] directive
+* [[Insert]] macro
+* [[Events]] handlers
+* [[On_exit]] macro
+* [[Filter]] syntax
+
+# MySQL
+* [[Database]]
+* [[Player]]
+* [[Recorder]]
+
+# Server
+* [[Find]]
+* [[Modify]]
+* [[Read]]
+
+# Realtime mode
+* [[Enter_realtime]]
+* [[Realtime_metric]]
+
+# Assert
+* [[Assert]]
+
+# Residential
+* [[House]]
+* [[Rbsa]]
+* [[Paneldump]]
+
+# Commercial
+* [[Ceus]]
+
+# Powerflow
+* [[Pole]]
+* [[Pole_configuration]]
+
+# Gismo
+* [[Switch_coordinator]]
+
+# Transactive
+* [[Orderbook]]
+* [[Agent]]
+
+# Subcommands
+* [[Weather subcommand]] and [YouTube Tutorial](https://youtu.be/KTeOFbt-aiE)
+* [[Python subcommand]]
+* [[Library subcommand]]
+
+# Command line options
+* [[Automatic import conversion]]
+* --[[version]] command options
+* --[[daemon]] and --[[remote]] command line options
+* --[[gdb]], --[[lldb]], --[[valgrind]] command line options
+* --[[origin]] command line option
+* --[[cite]] command line option
+
+# Macros
+* #[[exec]]
+
+# Global variables
+* [[Deltamode_allowed]]
+* [[Glm_save_options]]
+* [[Ignore_errors]]
+* [[Filesave_options]]
+* [[Converter save options]]
+
+# New Capabilities
+* [[ISO8601]] date format
+* [[Json output]] format 
+* [[Json property]] format
+* [[Voltdump currdump]] options
+* [[Python]] module
+* [[Docker hub]] workflows
+* [[String]] property
+* [[Loader extensions]]

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1,0 +1,15 @@
+A:LINK,A:VISITED {
+	color: blue;
+	text-decoration: none;
+}
+A:ACTIVE {
+	color: blue;
+	text-decoration: underline;
+}
+
+DIV.HEADER {
+	font-size: small;
+}
+DIV.FOOTER {
+	font-size: small;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 
 <SCRIPT>
     var query = new URLSearchParams(window.location.search);
+    // TODO: the defaults should come from a config.js instead
     var owner = query.get('owner');
     if ( owner == null )
     {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML />
+<HTML>
+
+<SCRIPT>
+    var query = new URLSearchParams(window.location.search);
+    var owner = query.get('owner');
+    if ( owner == null )
+    {
+        owner = "dchassin";
+    }
+    var project = query.get('project');
+    if ( project == null )
+    {
+        project = "gridlabd";
+    }
+    var branch = query.get('branch');
+    if ( branch == null )
+    {
+        branch = "master";
+    }
+    var doc = query.get('doc');
+    if ( doc == null )
+    {
+        doc = "README.md";
+    }
+    page = "owner=" + owner + "&project=" + project + "&branch=" + branch + "&doc=" + doc;
+</SCRIPT>
+
+<SCRIPT LANGUAGE="JavaScript">
+    document.writeln('<FRAMESET COLS="300,*">');
+    document.writeln('<FRAME SRC="_contents.html?' + page + '"/>');
+    document.writeln('<FRAME NAME="page" SRC="_page.html?' + page + '" />');
+    document.writeln('</FRAMESET>');
+</SCRIPT>
+
+</HTML>


### PR DESCRIPTION
This PR adds a document browser.

## Current issues
1. Requests are not authenticated and therefore subject to rate limiting by the GitHub API.  When the rate limit is exceeded, an error 403 is returned.  You have to wait about an hour before the rate limit is reset.  It will be nice to get OAuth working.
2. The current CSS is really boring.
3. The `docs/_header.md` doesn't get displayed for some reason.

## Code changes
1. Added `docs/index.html` and supporting `_*.{md,html,css}` files.

## Documentation changes
The browser is deployed at http://www.gridlabd.us/ for convenience.

## Test and Validation Notes
1. Open the local copy of `docs/index.html` in a browser to test.
