### PR TITLE
Add support for validate subcommand

### DIFF
--- a/docs/Subcommand/Validate.md
+++ b/docs/Subcommand/Validate.md
@@ -1,0 +1,11 @@
+[[Validate]] -- Validation subcommand
+
+# Synopsis
+~~~
+bash$ gridlabd validate
+~~~
+
+# Description
+
+A complete validation test can be run using the [[validate]] subcommand.
+

--- a/gldcore/scripts/Makefile.mk
+++ b/gldcore/scripts/Makefile.mk
@@ -4,5 +4,6 @@ bin_SCRIPTS += gldcore/scripts/gridlabd-json-get
 bin_SCRIPTS += gldcore/scripts/gridlabd-library
 bin_SCRIPTS += gldcore/scripts/gridlabd-manual
 bin_SCRIPTS += gldcore/scripts/gridlabd-python
+bin_SCRIPTS += gldcore/scripts/gridlabd-validate
 bin_SCRIPTS += gldcore/scripts/gridlabd-version
 bin_SCRIPTS += gldcore/scripts/gridlabd-weather

--- a/gldcore/scripts/gridlabd-validate
+++ b/gldcore/scripts/gridlabd-validate
@@ -14,5 +14,5 @@ echo "Running CLI version validation..."
 gridlabd $* --validate
 
 echo "Running Python version validation..."
-gldcore/link/python validate.py
+gridlabd python gldcore/link/python/validate.py $*
 

--- a/gldcore/scripts/gridlabd-validate
+++ b/gldcore/scripts/gridlabd-validate
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ ! -d "build-aux" ]; then
+	echo "ERROR: validate must be run from top source directory (where build-aux is found)" > /dev/stderr
+	exit 1
+fi
+
+if [ ! "$(gridlabd version)" == "$(build-aux/version.sh --name)" ]; then
+	echo "ERROR: installed gridlabd version '$(gridlabd version)' does not match current top source version '$(build-aux/version.sh --name)'" > /dev/stderr
+	exit 1
+fi
+
+echo "Running CLI version validation..."
+gridlabd $* --validate
+
+echo "Running Python version validation..."
+gldcore/link/python validate.py
+


### PR DESCRIPTION
This PR adds a validate subcommand.

## Current issues
None

## Code changes
1. Add `validate` script to `gldcore/scripts`

## Documentation changes
- Added `docs/Subcommand/Validate.md`

## Test and Validation Notes
1. Run the command `gridlabd validate` to perform a complete validation test
