### PR TITLE
Add support for RANGE global

### DIFF
--- a/docs/GLM/General/Range.md
+++ b/docs/GLM/General/Range.md
@@ -57,7 +57,7 @@ range_example.glm(6): 1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5,9,9.5,10
 
 If the last value generated is exactly equal to `<stop>`, then it is included in the range output.
 
-If the range generated to too long for the available buffer space allocated to range generation, or the `<step>` is invalid for the `<start>` and `<stop>` values specified, then an error will be generated and processing will stop.
+If the range generated is too long for the available buffer space allocated to range generation, or the `<step>` is invalid for the `<start>` and `<stop>` values specified, then an error will be generated and processing will stop.
 
 # See also
 * [[GLM/Macro/For]]

--- a/docs/GLM/General/Range.md
+++ b/docs/GLM/General/Range.md
@@ -14,6 +14,10 @@ The `RANGE` global generates a series of delimited values.  The following syntax
 
 This syntax will generate the default range, which is `0 1`.
 
+## `${RANGE<delim>}`
+
+This syntax will generate the default range, which is `0<delim>1`.
+
 ## `${RANGE<delim><start>}`
 
 This syntax will generate a range from `<start>` to `1` using `<delimiter>` between the values, and incrementing by `1.0` between values.
@@ -25,6 +29,29 @@ This syntax will generate a range from `<start>` to `<stop>` using `<delimiter>`
 ## `${RANGE<delim><start>,<stop>,<step>}`
 
 This syntax will generate a range from `<start>` to `<stop>` using `<delimiter>` between the values, and incrementing by `<step>` between values.
+
+# Example
+
+The following GLM file generates various ranges.
+
+`range_example.glm`:
+~~~
+  #set suppress_repeat_messages=FALSE
+  #print ${RANGE}
+  #print ${RANGE,}
+  #print ${RANGE -1}
+  #print ${RANGE;1,10};
+  #print ${RANGE,1,10,0.5}
+~~~
+
+The output is as follows:
+~~~
+range_example.glm(2): 0 1
+range_example.glm(3): 0,1
+range_example.glm(4): -1 0 1
+range_example.glm(5): 1;2;3;4;5;6;7;8;9;10;
+range_example.glm(6): 1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,7.5,8,8.5,9,9.5,10
+~~~
 
 # Caveats
 

--- a/docs/GLM/General/Range.md
+++ b/docs/GLM/General/Range.md
@@ -1,0 +1,36 @@
+[[GLM/General/Range]] -- Generate number series in a range
+
+# Synopsis
+GLM:
+~~~
+  ${RANGE[<delimiter>[<start>[,<stop>[,<step>]]]]}
+~~~
+
+# Description
+
+The `RANGE` global generates a series of delimited values.  The following syntaxes are supported.
+
+## `${RANGE}`
+
+This syntax will generate the default range, which is `0 1`.
+
+## `${RANGE<delim><start>}`
+
+This syntax will generate a range from `<start>` to `1` using `<delimiter>` between the values, and incrementing by `1.0` between values.
+
+## `${RANGE<delim><start>,<stop>}`
+
+This syntax will generate a range from `<start>` to `<stop>` using `<delimiter>` between the values, and incrementing by `1.0` between values.
+
+## `${RANGE<delim><start>,<stop>,<step>}`
+
+This syntax will generate a range from `<start>` to `<stop>` using `<delimiter>` between the values, and incrementing by `<step>` between values.
+
+# Caveats
+
+If the last value generated is exactly equal to `<stop>`, then it is included in the range output.
+
+If the range generated to too long for the available buffer space allocated to range generation, or the `<step>` is invalid for the `<start>` and `<stop>` values specified, then an error will be generated and processing will stop.
+
+# See also
+* [[GLM/Macro/For]]

--- a/gldcore/autotest/test_range.glm
+++ b/gldcore/autotest/test_range.glm
@@ -1,0 +1,6 @@
+#set suppress_repeat_messages=FALSE
+
+#print ${RANGE}
+#print ${RANGE:1,10}
+#print ${RANGE,1,10,0.5}
+#print ${RANGE 1,10000}

--- a/gldcore/autotest/test_range.glm
+++ b/gldcore/autotest/test_range.glm
@@ -1,6 +1,6 @@
 #set suppress_repeat_messages=FALSE
-
 #print ${RANGE}
+#print ${RANGE,}
 #print ${RANGE -1}
-#print ${RANGE;1,10}
+#print ${RANGE;1,10};
 #print ${RANGE,1,10,0.5}

--- a/gldcore/autotest/test_range.glm
+++ b/gldcore/autotest/test_range.glm
@@ -1,6 +1,6 @@
 #set suppress_repeat_messages=FALSE
 
 #print ${RANGE}
-#print ${RANGE:1,10}
+#print ${RANGE -1}
+#print ${RANGE;1,10}
 #print ${RANGE,1,10,0.5}
-#print ${RANGE 1,10000}

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -920,6 +920,11 @@ DEPRECATED const char *global_range(char *buffer, int size, const char *name)
 	double step = 1.0;
 	char delim = ' ';
 	sscanf(name,"RANGE%c%lg,%lg,%lg",&delim,&start,&stop,&step);
+	if ( strchr(" ;,",delim) == NULL )
+	{
+		output_error("global_range(buffer=%x,size=%d,name='%s'): delimiter '%s' is not supported, using space",buffer,size,name,delim);
+		delim = ' ';
+	}
 	int len = 0;
 	char temp[size+100];
 	for ( double value = start ; value <= stop ; value += step )
@@ -929,12 +934,12 @@ DEPRECATED const char *global_range(char *buffer, int size, const char *name)
 		len += sprintf(temp+len,"%g",value);
 		if ( len > size )
 		{
-			output_error("global_range(buffer=%x,size=%d,name='%s'): buffer too small",buffer,size,name);
+			output_error("global_range(buffer=%x,size=%d,name='%s'): buffer too small, range truncated",buffer,size,name);
 			len = size-1;
 			break;
 		}
 	}
-	return strncpy(buffer,temp,len);
+	return strncpy(buffer,temp,len+1);
 }
 
 bool GldGlobals::isdefined(const char *name)

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -913,6 +913,30 @@ DEPRECATED const char *global_seq(char *buffer, int size, const char *name)
 	}
 }
 
+DEPRECATED const char *global_range(char *buffer, int size, const char *name)
+{
+	double start = 0.0;
+	double stop = 1.0;
+	double step = 1.0;
+	char delim = ' ';
+	sscanf(name,"RANGE%c%lg,%lg,%lg",&delim,&start,&stop,&step);
+	int len = 0;
+	char temp[size+100];
+	for ( double value = start ; value <= stop ; value += step )
+	{
+		if ( len > 0 )
+			len += sprintf(temp+len,"%c",delim);
+		len += sprintf(temp+len,"%g",value);
+		if ( len > size )
+		{
+			output_error("global_range(buffer=%x,size=%d,name='%s'): buffer too small",buffer,size,name);
+			len = size-1;
+			break;
+		}
+	}
+	return strncpy(buffer,temp,len);
+}
+
 bool GldGlobals::isdefined(const char *name)
 {
 	return find(name)!=NULL;
@@ -1192,6 +1216,10 @@ const char *GldGlobals::getvar(const char *name, char *buffer, size_t size)
 	/* expansions */
 	if ( parameter_expansion(buffer,size,name) )
 		return buffer;
+
+	// ranges
+	if ( strncmp(name,"RANGE",5) == 0 )
+		return global_range(buffer,size,name);
 
 	var = global_find(name);
 	if(var == NULL)


### PR DESCRIPTION
This PR adds support for the `RANGE` syntax in globals.

## Current issues
None

## Code changes
1. Added `global_range(buffer,size,name)` to `gldcore/globals.cpp`.

## Documentation changes
See `docs/GLM/General/Range.md`

## Test and Validation Notes
1. See `gldcore/autotest/test_range.glm`
