### PR TITLE
Add status website

### DIFF
--- a/cloud/websites/status.gridlabd.us/index.html
+++ b/cloud/websites/status.gridlabd.us/index.html
@@ -1,0 +1,23 @@
+<HTML>
+<HEAD>
+	<TITLE>GridLAB-D Status</TITLE>
+</HEAD>
+<BODY>
+	<H1>HiPAS GridLAB-D Version 4.2 Development Status</H1>
+	<H2>Development Version Top Links</H2>
+	<OL>
+		<LI><A HREF="http://docs.gridlabd.us/index.html?branch=develop">User manuals</A></LI>
+		<LI><A HREF="http://source.gridlabd.us/tree/develop">Source code</A></LI>
+		<LI><A HREF="http://source.gridlabd.us/issues">Issue tracking</A></LI>
+		<LI><A HREF="http://source.gridlabd.us/pulls">Pull request tracking</A></LI>
+	</OL>
+	<H2>Development Status Reports</H2>
+	<OL>
+		<LI><A HREF="pulls-open.html">Open pull requests</A></LI>
+		<LI><A HREF="pulls-closed.html">Closed pull requests</A></LI>
+		<LI><A HREF="issues-open.html">Open issues</A></LI>
+	</OL>
+
+	Note: many of these links require a <A HREF="https://github.com/settings/tokens">personal GitHub access token</A>.
+</BODY>
+</HTML>

--- a/cloud/websites/status.gridlabd.us/issues-open.html
+++ b/cloud/websites/status.gridlabd.us/issues-open.html
@@ -1,0 +1,175 @@
+<HTML>
+    <HEAD>
+        <SCRIPT LANGUAGE="Javascript">
+
+            function set_default(name, value) 
+            {
+                // console.info("set_default('" + name + "',value='" + value + "') --> cookie = '" + document.cookie + "'");
+                if ( document.cookie.indexOf("BLOCKED=") >= 0 )
+                {
+                    return;
+                }
+                if ( value == null )
+                {
+                    document.cookie = name + "=;";
+                }
+                else
+                {
+                    document.cookie = name + "=" + value + ";path=/";
+                }
+            }
+
+            function get_default(name,deflt,asnull) 
+            {
+                var query = new URLSearchParams(window.location.search);
+                // console.info("get_default('" + name + "',value='" + deflt + "')...");
+                var value = query.get(name);
+                var type = 'query';
+                if ( value == null )
+                {
+                    var ca = document.cookie.split(';');
+                    // console.info("  cookie = " + ca);
+                    for ( var i = 0 ; i < ca.length ; i++ ) 
+                    {
+                        var c = ca[i].trim();
+                        if ( c.indexOf(name+'=') == 0 ) 
+                        {
+                            value = c.substring(c.indexOf('=')+1, c.length);
+                            type = 'cookie';
+                        }
+                    }
+                    if ( value == null )
+                    {
+                        value = deflt;
+                        type = 'default';
+                    }
+                }
+                if ( asnull != null && value === asnull )
+                {
+                    value = null;
+                    type += ' asnull'
+                }
+                // console.info("  " + type + " --> " + name + " = '" + deflt + "'");
+                return value;
+            }
+
+            var token = get_default("token","",null);;
+            function run_query(query)
+            {
+                // console.info("GET " + query + "'...")
+                var r = new XMLHttpRequest();
+                r.open('GET',"https://api.github.com" + query,false);
+                if ( token != null )
+                {
+                    r.setRequestHeader("Authorization","token " + token);
+                }
+                r.setRequestHeader("Accept","application/vnd.github.shadow-cat-preview+json");
+                r.send(null);
+                // console.info("  GET -> " + r.status);
+                return r;
+            }
+
+           function load_markdown(text)
+            {
+                var rr = new XMLHttpRequest();
+                rr.open('POST','https://api.github.com/markdown/raw',false);
+                if ( token != null )
+                {
+                    rr.setRequestHeader("Authorization","token " + token);
+                }
+                rr.send(text);
+                return rr;
+            }            
+
+        </SCRIPT>
+    </HEAD>
+
+    <BODY>
+        <SCRIPT LANGUAGE="Javascript">
+            stop = new Date();
+
+            if ( token == null || token === "" )
+            {
+                token = prompt("Enter your personal GitHub access token:");
+                set_default("token",token);
+            }
+
+            r = run_query("/repos/dchassin/gridlabd/issues?state=open&per_page=100&sort=updated&direction=desc");
+            if ( r.status == 200 )
+            {
+                report = "GridLAB-D Open Issues as of " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";
+                var count = 0;
+                var number = null;
+                var title = null;
+                var body = null;
+                var created_at = null;
+
+                console.info(r.getResponseHeader("link"));
+                JSON.parse(r.responseText, function (key,value)
+                {
+                    if ( key === "number" && number == null )
+                    {
+                        number = value;
+                        title = null;
+                        body = null;
+                        created_at = null;
+                        state = null;
+                        is_draft = null;
+                        // console.info("  number -> " + value);
+                    }
+                    else if ( key === "title" && title == null )
+                    {
+                        title = value;
+                        // console.info("  title -> " + value);
+                    }
+                    else if ( key === "state" && state == null )
+                    {
+                        state = value;
+                        // console.info("  state -> " + value);
+                    }
+                    else if ( key === "created_at" && created_at == null )
+                    {
+                        created_at = value;
+                        // console.info("  created_at -> " + value);
+                    }
+                    else if ( key === "body" && body == null )
+                    {
+                        if ( value == null )
+                            body = "";
+                        else
+                            body = value;
+                        // console.info("  body -> " + value);
+                        if ( number != null && title != null && body != null && state === "open" )
+                        {
+                            // console.info("*** output ***");
+                            report += "\n# Issue #" + number + ": " + title + "\n";
+                            report += "Opened " + created_at.substring(0,created_at.indexOf("T")) + "\n";
+                            report += "\n" + body + "\n\n";
+                            count += 1;
+                        }
+                        number = null;
+                        title = null;
+                        body = null;
+                        state = null;
+                        created_at = null;
+                    }
+                }) 
+                report += "\nEnd of report: " + count + " pull requests open\n";
+                // console.info(report);
+                md = load_markdown(report);
+                if ( md.status != 200 )
+                {
+                    report += "ERROR " + rr.status + ": ";
+                }
+                document.writeln(md.responseText);               
+            }
+            else
+            {
+                document.writeln("<H1>Error: " + r.status + "</H1>");
+                document.writeln(r.responseText);
+            }
+
+        </SCRIPT>
+    </BODY>
+
+</HTML>

--- a/cloud/websites/status.gridlabd.us/issues-open.html
+++ b/cloud/websites/status.gridlabd.us/issues-open.html
@@ -90,7 +90,7 @@
 
             if ( token == null || token === "" )
             {
-                token = prompt("Enter your personal GitHub access token:");
+                token = prompt("Enter your personal GitHub access token\n(Cancel grants temporarty access)");
                 set_default("token",token);
             }
 

--- a/cloud/websites/status.gridlabd.us/pulls-closed.html
+++ b/cloud/websites/status.gridlabd.us/pulls-closed.html
@@ -89,7 +89,7 @@
 
             if ( token == null || token === "" )
             {
-                token = prompt("Enter your personal GitHub access token:");
+                token = prompt("Enter your personal GitHub access token\n(Cancel grants temporarty access)");
                 set_default("token",token);
             }
 

--- a/cloud/websites/status.gridlabd.us/pulls-closed.html
+++ b/cloud/websites/status.gridlabd.us/pulls-closed.html
@@ -1,0 +1,180 @@
+<HTML>
+    <HEAD>
+        <SCRIPT LANGUAGE="Javascript">
+
+            function set_default(name, value) 
+            {
+                // console.info("set_default('" + name + "',value='" + value + "') --> cookie = '" + document.cookie + "'");
+                if ( document.cookie.indexOf("BLOCKED=") >= 0 )
+                {
+                    return;
+                }
+                if ( value == null )
+                {
+                    document.cookie = name + "=;";
+                }
+                else
+                {
+                    document.cookie = name + "=" + value + ";path=/";
+                }
+            }
+
+            function get_default(name,deflt,asnull) 
+            {
+                var query = new URLSearchParams(window.location.search);
+                // console.info("get_default('" + name + "',value='" + deflt + "')...");
+                var value = query.get(name);
+                var type = 'query';
+                if ( value == null )
+                {
+                    var ca = document.cookie.split(';');
+                    // console.info("  cookie = " + ca);
+                    for ( var i = 0 ; i < ca.length ; i++ ) 
+                    {
+                        var c = ca[i].trim();
+                        if ( c.indexOf(name+'=') == 0 ) 
+                        {
+                            value = c.substring(c.indexOf('=')+1, c.length);
+                            type = 'cookie';
+                        }
+                    }
+                    if ( value == null )
+                    {
+                        value = deflt;
+                        type = 'default';
+                    }
+                }
+                if ( asnull != null && value === asnull )
+                {
+                    value = null;
+                    type += ' asnull'
+                }
+                // console.info("  " + type + " --> " + name + " = '" + deflt + "'");
+                return value;
+            }
+
+            var token = get_default("token","",null);;
+            function run_query(query)
+            {
+                // console.info("GET " + query + "'...")
+                var r = new XMLHttpRequest();
+                r.open('GET',"https://api.github.com" + query,false);
+                if ( token != null )
+                {
+                    r.setRequestHeader("Authorization","token " + token);
+                }
+                r.send(null);
+                // console.info("  GET -> " + r.status);
+                return r;
+            }
+
+           function load_markdown(text)
+            {
+                var rr = new XMLHttpRequest();
+                rr.open('POST','https://api.github.com/markdown/raw',false);
+                if ( token != null )
+                {
+                    rr.setRequestHeader("Authorization","token " + token);
+                }
+                rr.send(text);
+                return rr;
+            }            
+
+        </SCRIPT>
+    </HEAD>
+
+    <BODY>
+        <SCRIPT LANGUAGE="Javascript">
+            stop = new Date();
+
+            if ( token == null || token === "" )
+            {
+                token = prompt("Enter your personal GitHub access token:");
+                set_default("token",token);
+            }
+
+            start = new Date(prompt("Enter report start date (yyyy-mm-dd): ",stop.getFullYear() + "-" + (stop.getMonth()+1) + "-01"));
+
+            r = run_query("/repos/dchassin/gridlabd/pulls?state=closed&per_page=100&sort=updated&direction=desc");
+            if ( r.status == 200 )
+            {
+                report = "GridLAB-D Pull Requests Completed for period " + start.getFullYear() + "-" + (start.getMonth()+1) + "-" + start.getDate() + " - " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";
+                var count = 0;
+                var number = null;
+                var title = null;
+                var closed_at = null;
+                var body = null;
+                var state = null;
+                JSON.parse(r.responseText, function (key,value)
+                {
+                    if ( key === "number" )
+                    {
+                        number = value;
+                        title = null;
+                        body = null;
+                        closed_at = null;
+                        state = null;
+                        // console.info("  number -> " + value);
+                    }
+                    else if ( key === "title")
+                    {
+                        title = value;
+                        // console.info("  title -> " + value);
+                    }
+                    else if ( key === "body" )
+                    {
+                        body = value;
+                        // console.info("  body -> " + value);
+                    }
+                    else if ( key === "state" )
+                    {
+                        state = value;
+                        // console.info("  state -> " + value);
+                    }
+                    else if ( key === "closed_at" )
+                    {
+                        closed_at = value;
+                        // console.info("  closed_at -> " + value);
+                    }
+                    else if ( key === "author_association" )
+                    {
+                        // console.info("  author_association -> " + value);
+                        if ( number != null && title != null && closed_at != null && body != null && state === "closed" )
+                        {
+                            closed_dt = new Date(closed_at);
+                            console.info("start '" + start + "'; closed '" + closed_dt + "'; stop '" + stop + "'"); 
+                            if ( start <= closed_dt && closed_dt <= stop )
+                            {
+                                // console.info("*** output ***");
+                                report += "\n# Update #" + number + ": " + title + "\n";
+                                report += "Completed " + closed_at.substring(0,closed_at.indexOf("T")) + "\n";
+                                report += "\n" + body + "\n";
+                                count += 1;
+                            }
+                        }
+                        number = null;
+                        title = null;
+                        closed_at = null;
+                        body = null;
+                        state = null;
+                    }
+                }) 
+                report += "\nEnd of report: " + count + " pull requests closed\n";
+                console.info(report);
+                md = load_markdown(report);
+                if ( md.status != 200 )
+                {
+                    report += "ERROR " + rr.status + ": ";
+                }
+                document.writeln(md.responseText);               
+            }
+            else
+            {
+                document.writeln("<H1>Error: " + r.status + "</H1>");
+                document.writeln(r.responseText);
+            }
+
+        </SCRIPT>
+    </BODY>
+
+</HTML>

--- a/cloud/websites/status.gridlabd.us/pulls-open.html
+++ b/cloud/websites/status.gridlabd.us/pulls-open.html
@@ -1,0 +1,195 @@
+<HTML>
+    <HEAD>
+        <SCRIPT LANGUAGE="Javascript">
+
+            function set_default(name, value) 
+            {
+                // console.info("set_default('" + name + "',value='" + value + "') --> cookie = '" + document.cookie + "'");
+                if ( document.cookie.indexOf("BLOCKED=") >= 0 )
+                {
+                    return;
+                }
+                if ( value == null )
+                {
+                    document.cookie = name + "=;";
+                }
+                else
+                {
+                    document.cookie = name + "=" + value + ";path=/";
+                }
+            }
+
+            function get_default(name,deflt,asnull) 
+            {
+                var query = new URLSearchParams(window.location.search);
+                // console.info("get_default('" + name + "',value='" + deflt + "')...");
+                var value = query.get(name);
+                var type = 'query';
+                if ( value == null )
+                {
+                    var ca = document.cookie.split(';');
+                    // console.info("  cookie = " + ca);
+                    for ( var i = 0 ; i < ca.length ; i++ ) 
+                    {
+                        var c = ca[i].trim();
+                        if ( c.indexOf(name+'=') == 0 ) 
+                        {
+                            value = c.substring(c.indexOf('=')+1, c.length);
+                            type = 'cookie';
+                        }
+                    }
+                    if ( value == null )
+                    {
+                        value = deflt;
+                        type = 'default';
+                    }
+                }
+                if ( asnull != null && value === asnull )
+                {
+                    value = null;
+                    type += ' asnull'
+                }
+                // console.info("  " + type + " --> " + name + " = '" + deflt + "'");
+                return value;
+            }
+
+            var token = get_default("token","",null);;
+            function run_query(query)
+            {
+                // console.info("GET " + query + "'...")
+                var r = new XMLHttpRequest();
+                r.open('GET',"https://api.github.com" + query,false);
+                if ( token != null )
+                {
+                    r.setRequestHeader("Authorization","token " + token);
+                }
+                r.setRequestHeader("Accept","application/vnd.github.shadow-cat-preview+json");
+                r.send(null);
+                // console.info("  GET -> " + r.status);
+                return r;
+            }
+
+           function load_markdown(text)
+            {
+                var rr = new XMLHttpRequest();
+                rr.open('POST','https://api.github.com/markdown/raw',false);
+                if ( token != null )
+                {
+                    rr.setRequestHeader("Authorization","token " + token);
+                }
+                rr.send(text);
+                return rr;
+            }            
+
+        </SCRIPT>
+    </HEAD>
+
+    <BODY>
+        <SCRIPT LANGUAGE="Javascript">
+            stop = new Date();
+
+            if ( token == null || token === "" )
+            {
+                token = prompt("Enter your personal GitHub access token:");
+                set_default("token",token);
+            }
+
+            r = run_query("/repos/dchassin/gridlabd/pulls?state=open&per_page=100&sort=updated&direction=desc");
+            if ( r.status == 200 )
+            {
+                report = "GridLAB-D Open Pull Requests as of " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";
+                var count = 0;
+                var number = null;
+                var title = null;
+                var body = null;
+                var created_at = null;
+                var is_draft = null;
+                //console.info(r.responseText);
+                JSON.parse(r.responseText, function (key,value)
+                {
+                    if ( key === "number" )
+                    {
+                        number = value;
+                        title = null;
+                        body = null;
+                        created_at = null;
+                        state = null;
+                        is_draft = null;
+                        // console.info("  number -> " + value);
+                    }
+                    else if ( key === "title")
+                    {
+                        title = value;
+                        // console.info("  title -> " + value);
+                    }
+                    else if ( key === "body" )
+                    {
+                        if ( value == null )
+                            body = "";
+                        else
+                            body = value;
+                        // console.info("  body -> " + value);
+                    }
+                    else if ( key === "state" )
+                    {
+                        state = value;
+                        // console.info("  state -> " + value);
+                    }
+                    else if ( key === "created_at" )
+                    {
+                        created_at = value;
+                        // console.info("  created_at -> " + value);
+                    }
+                    else if ( key === "draft" )
+                    {
+                        is_draft = value;
+                        console.info("  is_draft -> " + is_draft);
+                    }
+                    else if ( key === "author_association" )
+                    {
+                        // console.info("  author_association -> " + value);
+                        if ( number != null && title != null && body != null && state === "open" )
+                        {
+                            // console.info("*** output ***");
+                            if ( is_draft === true )
+                            {
+                                report += "\n# Working #" + number + ": " + title + "\n";
+                            }
+                            else if ( is_draft === false )
+                            {
+                                report += "\n# Review #" + number + ": " + title + "\n";
+                            }
+                            else
+                            {
+                                report += "\n# Request #" + number + ": " + title + "\n";
+                            }
+                            report += "Opened " + created_at.substring(0,created_at.indexOf("T")) + "\n";
+                            report += "\n" + body + "\n";
+                            count += 1;
+                        }
+                        number = null;
+                        title = null;
+                        body = null;
+                        state = null;
+                        is_draft = null;
+                    }
+                }) 
+                report += "\nEnd of report: " + count + " pull requests open\n";
+                // console.info(report);
+                md = load_markdown(report);
+                if ( md.status != 200 )
+                {
+                    report += "ERROR " + rr.status + ": ";
+                }
+                document.writeln(md.responseText);               
+            }
+            else
+            {
+                document.writeln("<H1>Error: " + r.status + "</H1>");
+                document.writeln(r.responseText);
+            }
+
+        </SCRIPT>
+    </BODY>
+
+</HTML>

--- a/cloud/websites/status.gridlabd.us/pulls-open.html
+++ b/cloud/websites/status.gridlabd.us/pulls-open.html
@@ -104,7 +104,7 @@
                 var body = null;
                 var created_at = null;
                 var is_draft = null;
-                //console.info(r.responseText);
+                console.info(r.responseText);
                 JSON.parse(r.responseText, function (key,value)
                 {
                     if ( key === "number" )
@@ -117,12 +117,12 @@
                         is_draft = null;
                         // console.info("  number -> " + value);
                     }
-                    else if ( key === "title")
+                    else if ( key === "title" && title == null )
                     {
                         title = value;
                         // console.info("  title -> " + value);
                     }
-                    else if ( key === "body" )
+                    else if ( key === "body" && body == null )
                     {
                         if ( value == null )
                             body = "";
@@ -130,30 +130,27 @@
                             body = value;
                         // console.info("  body -> " + value);
                     }
-                    else if ( key === "state" )
+                    else if ( key === "state" && state == null )
                     {
                         state = value;
                         // console.info("  state -> " + value);
                     }
-                    else if ( key === "created_at" )
+                    else if ( key === "created_at" && created_at == null )
                     {
                         created_at = value;
                         // console.info("  created_at -> " + value);
                     }
-                    else if ( key === "draft" )
+                    else if ( key === "draft" && is_draft == null )
                     {
                         is_draft = value;
-                        console.info("  is_draft -> " + is_draft);
-                    }
-                    else if ( key === "author_association" )
-                    {
+                        // console.info("  is_draft -> " + is_draft);
                         // console.info("  author_association -> " + value);
                         if ( number != null && title != null && body != null && state === "open" )
                         {
                             // console.info("*** output ***");
                             if ( is_draft === true )
                             {
-                                report += "\n# Working #" + number + ": " + title + "\n";
+                                report += "\n# Draft  #" + number + ": " + title + "\n";
                             }
                             else if ( is_draft === false )
                             {

--- a/cloud/websites/status.gridlabd.us/pulls-open.html
+++ b/cloud/websites/status.gridlabd.us/pulls-open.html
@@ -90,7 +90,7 @@
 
             if ( token == null || token === "" )
             {
-                token = prompt("Enter your personal GitHub access token:");
+                token = prompt("Enter your personal GitHub access token\n(Cancel grants temporarty access)");
                 set_default("token",token);
             }
 


### PR DESCRIPTION
This PR addresses online availability of status reports.

## Current issues
1. Only the first 100 records are returned at this time.

## Code changes
1. Reimplemented `utilities/report.py` as `cloud/websites/status.gridlabd.us/index.html` and supporting files.

## Documentation changes
None

## Test and Validation Notes
1. Open http://status.gridlabd.us/ to view development status of HiPAS GridLAB-D.
2. You will need to generate a [personal access token](https://github.com/settings/tokens) to test access authorization if you want to use the report frequently.
