### PR TITLE
Fix installs for branch names that contain one or more / characters

### DIFF
--- a/build-aux/version.sh
+++ b/build-aux/version.sh
@@ -8,7 +8,7 @@ PAT=`sed -En 's/#define REV_PATCH ([0-9]+).*/\1/p' $FIL | tr -d '\n'`
 PKG=`sed -En 's/#define PACKAGE "([a-z]+)".*/\1/p' $FIL | tr -d '\n'`
 NAM=`sed -En 's/#define PACKAGE_NAME "([-A-Za-z ]+)".*/\1/p' $FIL | tr -d '\n'`
 NUM=`git log --max-count=1 --pretty=format:"%ai" | cut -c 3,4,6,7,9,10`
-BRA=`git branch | grep '^*' | cut -f2 -d' ' | tr '-' '_'`
+BRA=`git branch | grep '^*' | cut -f2 -d' ' | tr '[-/]' '_'`
 GIT=`git --version | cut -f3 -d' '`
 SYS=`uname`
 HDW=`uname -m`


### PR DESCRIPTION
This PR addresses install problems with branches that have `/` in their names.

## Current issues
None

## Code changes
1. fixed `build-aux/version.sh` so it also changes `/` to `_`.

## Documentation changes
None

## Test and Validation Notes
None
