### PR TITLE
Add inline interpreter macro

### DIFF
--- a/docs/GLM/Macro/Begin.md
+++ b/docs/GLM/Macro/Begin.md
@@ -1,0 +1,26 @@
+[[/GLM/Macro/Begin]] -- Macro to change language interpreter
+
+# Synopsis
+GLM
+~~~
+#begin <language>
+<code>
+#end
+~~~
+
+# Description
+
+The #begin macro is used activate a new language interpreter. The new interpreter is active until the #end macro is encountered. The languages currently supported are
+* python
+
+# Example
+
+The following example outputs the current version information.
+~~~
+#begin python
+gridlabd.output(gridlabd.version())
+#end
+~~~
+
+# See also
+* [[/GLM/Global/Python]]

--- a/docs/GLM/Macro/Begin.md
+++ b/docs/GLM/Macro/Begin.md
@@ -10,8 +10,15 @@ GLM
 
 # Description
 
-The #begin macro is used activate a new language interpreter. The new interpreter is active until the #end macro is encountered. The languages currently supported are
-* python
+The #begin macro is used activate a new language interpreter. The new interpreter is active until the #end macro is encountered. 
+
+## Built-in Languages
+
+The following languages are currently provide through built-in support.
+
+### `python`
+
+The Python3 interpreter is linked to the GLM loader automatically when GridLAB-D is built.  The `gridlabd` module is also automatically loaded when the GridLAB-D Python interface is started.  For more information on the `gridlabd` module, see [[/Module/Python]]
 
 # Example
 
@@ -24,3 +31,4 @@ gridlabd.output(gridlabd.version())
 
 # See also
 * [[/GLM/Global/Python]]
+* [[/Module/Python]]

--- a/gldcore/autotest/test_external_null_source.glm
+++ b/gldcore/autotest/test_external_null_source.glm
@@ -7,7 +7,7 @@
 // deterministic noise source
 extern "C" noise_source : noise@1 // inline "C" code follows
 {
-    #include <math.h>
+	double cos(double), sin(double);
 	int noise(int nlhs, GLXDATA *plhs, int nrhs, GLXDATA *prhs)
 	{	/* make sure the correct number of args are passed in */
 		if ( nlhs!=1 || nlhs!=1 ) return -1;

--- a/gldcore/autotest/test_inline_python.glm
+++ b/gldcore/autotest/test_inline_python.glm
@@ -1,3 +1,3 @@
 #begin python
-gridlabd.verbose(str(gridlabd.version()))
+gridlabd.output(str(gridlabd.version()))
 #end

--- a/gldcore/autotest/test_inline_python.glm
+++ b/gldcore/autotest/test_inline_python.glm
@@ -1,0 +1,3 @@
+#begin python
+gridlabd.verbose(str(gridlabd.version()))
+#end

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -7915,7 +7915,7 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 				break;
 			}
 		}
-		output_error_raw("%s(%d): " MACRO "%s macro is not recognized", filename,linenum,tmp);
+		output_error_raw("%s(%d): %s macro is not recognized", filename,linenum,tmp);
 		strcpy(line,"\n");
 		return FALSE;
 	}

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -6759,6 +6759,8 @@ static const char *for_replay()
 	}
 }
 
+typedef struct s_languagemap LANGUAGE;
+static const LANGUAGE *get_language(void);
 static int buffer_read_alt(FILE *fp, char *buffer, char *filename, int size)
 {
 	char line[0x4000];
@@ -6824,7 +6826,9 @@ static int buffer_read_alt(FILE *fp, char *buffer, char *filename, int size)
 		}
 
 		/* expand macros */
-		if ( strncmp(line,MACRO,strlen(MACRO)) == 0 )
+		const char *m = line;
+		while ( isspace(*m) ) m++;
+		if ( get_language() || strncmp(m,MACRO,strlen(MACRO)) == 0 )
 		{
 			/* macro disables reading */
 			if ( process_macro(line,sizeof(line),filename,linenum + _linenum - 1) == FALSE )
@@ -7157,13 +7161,69 @@ char *strsep(char **from, const char *delim) {
 }
 #endif
 
+// set loader language
+// returns TRUE on success, FALSE on failure
+struct s_languagemap {
+	const char *name;
+	bool (*parser)(const char *buffer);
+} language_list[] = {
+	{"python",python_parser},
+};
+const LANGUAGE *language = NULL;
+static int set_language(const char *name)
+{
+	if ( name == NULL )
+	{
+		if ( language == NULL )
+		{
+			output_error_raw("%s(%d): no language set", filename, linenum);
+			return FALSE;
+		}
+		language = NULL;
+		return TRUE;
+	}
+	for ( unsigned long n = 0 ; n < sizeof(language_list)/sizeof(language_list[0]) ; n++ )
+	{
+		if ( strcmp(language_list[n].name,name) == 0 )
+		{
+			language = language_list+n;
+			return TRUE;
+		}
+	}
+	output_error_raw("%s(%d): language '%s' not recognized", filename, linenum, name);
+	return FALSE;
+}
+static const LANGUAGE *get_language(void)
+{
+	return language;
+}
+
 /** @return TRUE/SUCCESS for a successful macro read, FALSE/FAILED on parse error (which halts the loader) */
 static int process_macro(char *line, int size, char *_filename, int linenum)
 {
-#ifndef WIN32
-	char *var, *val, *save;	// used by *nix
-#endif
+	char *var, *val, *save;
 	char buffer[64];
+	if ( get_language() )
+	{
+		const char *m = line;
+		while ( isspace(*m) ) m++;
+		int status;
+		if ( strncmp(m,MACRO "end",4) == 0 )
+		{
+			status = language->parser(NULL);
+			set_language(NULL);
+		}
+		else
+		{
+			status = language->parser(line);
+		}
+		if ( status == true )
+		{
+			strcpy(line,"\n");
+		}
+		return status;
+	}
+	while ( isspace(*line) ) line++; // trim
 	if (strncmp(line,MACRO "endif",6)==0)
 	{
 		if (nesting>0)
@@ -7803,12 +7863,12 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 		char cmd[1024];
 		if ( sscanf(line+8,"%d %1023[^\n]",&xc,cmd) < 2 )
 		{
-			output_error_raw("%s(%d): on_exit syntax error", filename,linenum);
+			output_error_raw("%s(%d): " MACRO "on_exit syntax error", filename,linenum);
 			return FALSE;
 		}
 		else if ( ! my_instance->add_on_exit(xc,cmd) )
 		{
-			output_error_raw("%s(%d): on_exit %d command '%s'", filename,linenum,xc,cmd);
+			output_error_raw("%s(%d): " MACRO "on_exit %d command '%s' failed", filename,linenum,xc,cmd);
 			return FALSE;
 		}
 		else
@@ -7817,7 +7877,18 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 			return TRUE;
 		}
 	}
-	else if ( strncmp(line, MACRO "for",3) == 0 )
+	else if ( strncmp(line, MACRO "begin",6) == 0 )
+	{
+		char name[256];
+		if ( sscanf(line+7,"%s",name) == 0 )
+		{
+			output_error_raw("%s(%d): " MACRO "begin macro missing language term", filename, linenum);
+			return FALSE;
+		}
+		strcpy(line,"\n");
+		return set_language(name);
+	}
+	else if ( strncmp(line, MACRO "for",4) == 0 )
 	{
 		char var[64], range[1024];
 		if ( sscanf(line+4,"%s in %[^\n]",var,range) == 2 )
@@ -7828,7 +7899,7 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 		else
 		{
 			output_error_raw("%s(%d): for macro syntax error", filename, linenum);
-			return false;
+			return FALSE;
 		}
 	}
 	else
@@ -7843,7 +7914,7 @@ static int process_macro(char *line, int size, char *_filename, int linenum)
 				break;
 			}
 		}
-		output_error_raw("%s(%d): macro command '%s' is not recognized", filename,linenum,tmp);
+		output_error_raw("%s(%d): " MACRO "%s macro is not recognized", filename,linenum,tmp);
 		strcpy(line,"\n");
 		return FALSE;
 	}
@@ -8118,129 +8189,154 @@ STATUS load_python(const char *filename)
  **/
 STATUS loadall(const char *fname)
 {
-	/* if nothing requested only config files are loaded */
-	if ( fname == NULL )
-		return SUCCESS;
-
-	char file[1024] = "";
-	if ( fname )
+	try 
 	{
-		strcpy(file,fname);
-	}
-	char *ext = fname ? strrchr(file,'.') : NULL ;
+		/* if nothing requested only config files are loaded */
+		if ( fname == NULL )
+			return SUCCESS;
 
-	// python script
+		char file[1024] = "";
+		if ( fname )
+		{
+			strcpy(file,fname);
+		}
+		char *ext = fname ? strrchr(file,'.') : NULL ;
 
-	if ( ext != NULL && strcmp(ext,".py") == 0 )
-	{
-		return load_python(fname);
-	}
-	// non-glm data file
-	if ( ext != NULL && strcmp(ext,".glm") != 0 )
-	{
-		return load_import(fname,file,sizeof(file)) ? loadall(file) : FAILED;
-	}
-	unsigned int old_obj_count = object_get_count();
-	char conf[1024];
-	static int loaded_files = 0;
-	STATUS load_status = FAILED;
+		// python script
 
-	if ( !inline_code_init() ) return FAILED;
+		if ( ext != NULL && strcmp(ext,".py") == 0 )
+		{
+			return load_python(fname);
+		}
+		// non-glm data file
+		if ( ext != NULL && strcmp(ext,".glm") != 0 )
+		{
+			return load_import(fname,file,sizeof(file)) ? loadall(file) : FAILED;
+		}
+		unsigned int old_obj_count = object_get_count();
+		char conf[1024];
+		static int loaded_files = 0;
+		STATUS load_status = FAILED;
 
-	if(old_obj_count > 1 && global_forbid_multiload){
-		output_error("loadall: only one file load is supported at this time.");
-		return FAILED; /* not what they expected--do not proceed */
-	}
+		if ( !inline_code_init() ) return FAILED;
 
-	/* first time only */
-	if (loaded_files==0)
-	{
-		/* load the gridlabd.conf file */
-		if (find_file("gridlabd.conf",NULL,R_OK,conf,sizeof(conf))==NULL)
-			output_warning("gridlabd.conf was not found");
-			/* TROUBLESHOOT
-				The <code>gridlabd.conf</code> was not found in the <b>GLPATH</b> environment path.
-				This file is always loaded before a GLM file is loaded.
-				Make sure that <b>GLPATH</b> includes the <code>.../etc</code> folder and try again.
-			 */
-		else{
-			strcpy(filename, "gridlabd.conf");
-			if(loadall_glm_roll(conf)==FAILED){
+		if ( old_obj_count > 1 && global_forbid_multiload )
+		{
+			output_error("loadall: only one file load is supported at this time.");
+			return FAILED; /* not what they expected--do not proceed */
+		}
+
+		/* first time only */
+		if ( loaded_files == 0 ) 
+		{
+			/* load the gridlabd.conf file */
+			if (find_file("gridlabd.conf",NULL,R_OK,conf,sizeof(conf))==NULL)
+			{
+				output_warning("gridlabd.conf was not found");
+				/* TROUBLESHOOT
+					The <code>gridlabd.conf</code> was not found in the <b>GLPATH</b> environment path.
+					This file is always loaded before a GLM file is loaded.
+					Make sure that <b>GLPATH</b> includes the <code>.../etc</code> folder and try again.
+				 */
+			}
+			else
+			{
+				strcpy(filename, "gridlabd.conf");
+				if ( loadall_glm_roll(conf)==FAILED )
+				{
+					return FAILED;
+				}
+			}
+
+			/* load the debugger.conf file */
+			if (global_debug_mode)
+			{
+				char dbg[1024];
+				
+				if (find_file("debugger.conf",NULL,R_OK,dbg,sizeof(dbg))==NULL)
+				{
+					output_warning("debugger.conf was not found");
+					/* TROUBLESHOOT
+						The <code>debugger.conf</code> was not found in the <b>GLPATH</b> environment path.
+						This file is loaded when the debugger is enabled.
+						Make sure that <b>GLPATH</b> includes the <code>.../etc</code> folder and try again.
+					 */
+				}
+				else if (loadall_glm_roll(dbg)==FAILED)
+				{
+					return FAILED;
+				}
+			}
+		}
+
+		/* handle default extension */
+		strcpy(filename,file);
+		if (ext==NULL || ext<file+strlen(file)-5)
+		{
+			ext = filename+strlen(filename);
+			strcat(filename,".glm");
+		}
+
+		/* load the appropriate type of file */
+		if (global_streaming_io_enabled || (ext!=NULL && isdigit(ext[1])) )
+		{
+			FILE *fp = fopen(file,"rb");
+			if (fp==NULL || stream(fp,SF_IN)<0)
+			{
+				output_error("%s: unable to read stream", file);
+				return FAILED;
+			}
+			else
+			{
+				load_status = SUCCESS;
+			}
+		}
+		else if (ext==NULL || strcmp(ext, ".glm")==0)
+		{
+			load_status = loadall_glm_roll(filename);
+		}
+#ifdef HAVE_XERCES
+		else if(strcmp(ext, ".xml")==0)
+		{
+			load_status = loadall_xml(filename);
+		}
+#endif
+		else
+		{
+			output_error("%s: unable to load unknown file type", filename, ext);
+		}
+
+		/* objects should not be started until all deferred schedules are done */
+		if ( global_threadcount>1 )
+		{
+			if ( schedule_createwait()==FAILED )
+			{
+				output_error_raw("%s(%d): load failed on schedule error", filename, linenum);
 				return FAILED;
 			}
 		}
 
-		/* load the debugger.conf file */
-		if (global_debug_mode)
-		{
-			char dbg[1024];
-			
-			if (find_file("debugger.conf",NULL,R_OK,dbg,sizeof(dbg))==NULL)
-				output_warning("debugger.conf was not found");
-				/* TROUBLESHOOT
-					The <code>debugger.conf</code> was not found in the <b>GLPATH</b> environment path.
-					This file is loaded when the debugger is enabled.
-					Make sure that <b>GLPATH</b> includes the <code>.../etc</code> folder and try again.
-				 */
-			else if (loadall_glm_roll(dbg)==FAILED)
-				return FAILED;
-		}
-	}
+		/* handle new objects */
+	//	new_obj_count = object_get_count();
+	//	if((load_status == FAILED) && (old_obj_count < new_obj_count)){
+	//		for(i = old_obj_count+1; i <= new_obj_count; ++i){
+	//			object_remove_by_id(i);
+	//		}
+	//	}
 
-	/* handle default extension */
-	strcpy(filename,file);
-	if (ext==NULL || ext<file+strlen(file)-5)
+		calculate_trl();
+
+		/* destroy inline code buffers */
+		inline_code_term();
+
+		loaded_files++;
+		return load_status;
+	}
+	catch (const char *message)
 	{
-		ext = filename+strlen(filename);
-		strcat(filename,".glm");
+		output_error_raw("%s(%d): %s",filename,linenum,message);
+		return FAILED;
 	}
-
-	/* load the appropriate type of file */
-	if (global_streaming_io_enabled || (ext!=NULL && isdigit(ext[1])) )
-	{
-		FILE *fp = fopen(file,"rb");
-		if (fp==NULL || stream(fp,SF_IN)<0)
-		{
-			output_error("%s: unable to read stream", file);
-			return FAILED;
-		}
-		else
-			load_status = SUCCESS;
-	}
-	else if (ext==NULL || strcmp(ext, ".glm")==0)
-		load_status = loadall_glm_roll(filename);
-#ifdef HAVE_XERCES
-	else if(strcmp(ext, ".xml")==0)
-		load_status = loadall_xml(filename);
-#endif
-	else
-		output_error("%s: unable to load unknown file type", filename, ext);
-
-	/* objects should not be started until all deferred schedules are done */
-	if ( global_threadcount>1 )
-	{
-		if ( schedule_createwait()==FAILED )
-		{
-			output_error_raw("%s(%d): load failed on schedule error", filename, linenum);
-			return FAILED;
-		}
-	}
-
-	/* handle new objects */
-//	new_obj_count = object_get_count();
-//	if((load_status == FAILED) && (old_obj_count < new_obj_count)){
-//		for(i = old_obj_count+1; i <= new_obj_count; ++i){
-//			object_remove_by_id(i);
-//		}
-//	}
-
-	calculate_trl();
-
-	/* destroy inline code buffers */
-	inline_code_term();
-
-	loaded_files++;
-	return load_status;
 }
 
 /** @} */

--- a/gldcore/load.h
+++ b/gldcore/load.h
@@ -57,6 +57,15 @@ typedef struct s_unresolved_static {
 	struct s_unresolved_static *next;
 } UNR_STATIC;
 
+typedef struct s_languagemap LANGUAGE;
+// set loader language
+// returns TRUE on success, FALSE on failure
+struct s_languagemap {
+	const char *name;
+	bool (*parser)(const char *buffer);
+	struct s_languagemap *next;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -73,6 +82,7 @@ UNRESOLVED *add_unresolved(OBJECT *by, PROPERTYTYPE ptype, void *ref, CLASS *ocl
 STATUS load_resolve_all();
 OBJECT *load_get_current_object(void);
 MODULE *load_get_current_module(void);
+void load_add_language(const char *name, bool (*parser)(const char*));
 
 #ifdef __cplusplus
 }

--- a/gldcore/output.h
+++ b/gldcore/output.h
@@ -38,6 +38,7 @@ void output_both_stdout();
 FILE *output_set_stream(FILESTREAM fs, FILE *newfp);
 FILE* output_redirect(const char *name, const char *path);
 FILE* output_redirect_stream(const char *name, FILE *fp);
+FILE* output_get_stream(const char *name);
 int output_fatal(const char *format,...);
 int output_error(const char *format,...);
 int output_error_raw(const char *format,...);

--- a/gldcore/python_embed.cpp
+++ b/gldcore/python_embed.cpp
@@ -4,12 +4,21 @@
 #include <string.h>
 
 const wchar_t *program = NULL;
+PyObject *main_module = NULL;
 
 void python_embed_init(int argc, const char *argv[])
 {
     program = Py_DecodeLocale(argv[0],NULL);
     Py_SetProgramName(program);
     Py_Initialize();
+    main_module = PyModule_GetDict(PyImport_AddModule("__main__"));
+    if ( main_module == NULL )
+    {
+        output_error("python_embed_init(argc=%d,argv=[...]: unable to load module __main__ module",argc);
+        throw "python exception";
+    }
+    python_parser("import " PACKAGE);
+    python_parser();
     output_verbose("python initialization ok");
 }
 
@@ -25,18 +34,22 @@ void python_embed_term()
 
 PyObject *python_embed_import(const char *module, const char *path)
 {
-    char tmp[1024] = ".";
     if ( path != NULL )
     {
-        snprintf(tmp,sizeof(tmp)-1,"import sys\nsys.path.append('%s')\n",path);
-    }
-    if ( PyRun_SimpleString(tmp) )
-    {
-        PyObject *pType, *pValue, *pTraceback;
-        PyErr_Fetch(&pType, &pValue, &pTraceback);
-        const char *msg = pValue?PyBytes_AS_STRING(pValue):"PyRun_SimpleString failed with no information";
-        output_error("python_embed_import(module='%s',path='%s'): %s; string='%s'",module,path,msg,tmp);
-        return NULL;
+        char tmp[1024];
+        int len = snprintf(tmp,sizeof(tmp)-1,"import sys");
+        if ( path != NULL )
+        {
+            snprintf(tmp+len,sizeof(tmp)-len-1,"\nsys.path.append('%s')\n",path);
+        }
+        if ( PyRun_SimpleString(tmp) )
+        {
+            PyObject *pType, *pValue, *pTraceback;
+            PyErr_Fetch(&pType, &pValue, &pTraceback);
+            const char *msg = pValue?PyBytes_AS_STRING(pValue):"PyRun_SimpleString failed with no information";
+            output_error("python_embed_import(module='%s',path='%s'): %s; string='%s'",module,path,msg,tmp);
+            return NULL;
+        }
     }
 
     PyObject *pModule = PyImport_ImportModule(module);
@@ -54,11 +67,26 @@ PyObject *python_embed_import(const char *module, const char *path)
     }
 }
 
+const char *truncate(const char *command)
+{
+    while ( isspace(*command) ) command++;
+    static char buf[20];
+    memset(buf,0,sizeof(buf));
+    strncpy(buf,command,sizeof(buf));
+    char *eol = strchr(buf,'\n');
+    if ( eol ) *eol = '\0';
+    if ( buf[sizeof(buf)-1] != '\0' ) 
+    {
+        strcpy(buf+sizeof(buf)-4,"...");
+    }
+    return buf;
+}
+
 bool python_embed_call(PyObject *pModule, const char *name)
 {
     if ( pModule == NULL )
     {
-        output_error("python_embed_call(pModule,name='%s'): no module loaded",name);
+        output_error("python_embed_call(pModule,name='%s'): no module loaded",truncate(name));
         return false;
     }
 
@@ -66,13 +94,13 @@ bool python_embed_call(PyObject *pModule, const char *name)
     if ( pFunc == NULL )
     {
         PyErr_Print();
-        output_error("python_embed_call(pModule,name='%s'): function not defined",name);
+        output_error("python_embed_call(pModule,name='%s'): function not defined",truncate(name));
         return false;
     }
     if ( ! PyCallable_Check(pFunc) )
     {
         PyErr_Print();
-        output_error("python_embed_call(name='%s'): function not callable",name);
+        output_error("python_embed_call(name='%s'): function not callable",truncate(name));
         Py_DECREF(pFunc);
         return false;
     }
@@ -90,66 +118,118 @@ bool python_embed_call(PyObject *pModule, const char *name)
     return true;
 }
 
-std::string python_eval(const char *command)
+void traceback(const char *command)
 {
-    output_debug("python_eval(const char *command='%s')...",command);
-    PyObject *result = PyRun_String(command,Py_eval_input,Py_None,Py_None);
-    if ( result == NULL )
+    PyObject *err = PyErr_Occurred();
+    if ( err == NULL )
     {
-        output_error("python_eval(command='%s'): python exception caught",command);
-        PyObject *err = PyErr_Occurred();
-        if ( err != NULL ) 
-        {
-            PyObject *ptype, *pvalue, *ptraceback;
-            PyErr_Fetch(&ptype, &pvalue, &ptraceback);
-            PyObject *pystr = PyUnicode_AsEncodedString(pvalue,"utf-8","~E~");
-            char *str = pystr ? PyBytes_AsString(pystr) : NULL;
-            if ( str )
-            {
-                output_error("python_eval(command='%s'): %s",command, str);
-            }
-
-            /* See if we can get a full traceback */
-            PyObject *pyth_module = PyImport_ImportModule("traceback");
-            if ( pyth_module == NULL ) 
-            {
-                output_error("python_eval(command='%s'): no traceback module available",command);
-            }
-            else
-            {
-                PyObject *pyth_val, *pyth_func = PyObject_GetAttrString(pyth_module, "format_exception");
-                if ( pyth_func && PyCallable_Check(pyth_func) && (pyth_val = PyObject_CallFunctionObjArgs(pyth_func, ptype, pvalue, ptraceback, NULL)) != NULL ) 
-                {
-                    pystr = PyUnicode_AsEncodedString(pyth_val,"utf-8","~E~");
-                    str = pystr ? PyBytes_AsString(pystr) : NULL;
-                    if ( str )
-                    {
-                        output_error("python_eval(command='%s'): traceback follows",command);
-                        output_error("  %s",command,str);
-                    }
-                    else
-                    {
-                        output_error("python_eval(command='%s'): traceback not available",command);
-                    }
-                    Py_DECREF(pyth_val);
-                }
-                else
-                {
-                    output_error("python_eval(command='%s'): unable to read traceback",command);
-                }
-            }
-            Py_DECREF(err);
-        }
-        return std::string("");
+        output_error("python_eval(command='%s'): no error occurred",command);
+        return;
+    }
+    PyObject *pyth_val, *ptype, *pvalue, *ptraceback;
+    PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+    Py_DECREF(err);
+    if ( ptype == NULL || pvalue == NULL || ptraceback == NULL )
+    {
+        output_error("python_eval(command='%s'): no error to fetch",command);
+        return;
+    }
+    PyObject *pystr = PyUnicode_AsEncodedString(pvalue,"utf-8","~E~");
+    char *str = pystr ? PyBytes_AsString(pystr) : NULL;
+    if ( str )
+    {
+        output_error("python_eval(command='%s'): python exception caught: %s",command, str);
+    }
+    PyObject *pyth_module = PyImport_ImportModule("traceback");
+    if ( pyth_module == NULL ) 
+    {
+        output_error("python_eval(command='%s'): no traceback module available",command);
     }
     else
     {
-        PyObject *repr = PyObject_Repr(result);
-        PyObject *str = PyUnicode_AsEncodedString(repr,"utf-8","~E~");
-        std::string bytes(PyBytes_AS_STRING(str));
-        Py_XDECREF(repr);
-        Py_XDECREF(str);
+        PyObject *pyth_func = PyObject_GetAttrString(pyth_module, "format_exception");
+        if ( pyth_func == NULL )
+        {
+            output_error("python_eval(command='%s'): traceback.format_exception() not found",command);
+        }
+        else if ( ! PyCallable_Check(pyth_func) )
+        {
+            output_error("python_eval(command='%s'): traceback.format_exception() not callable",command);
+        }
+        else if ( (pyth_val = PyObject_CallFunctionObjArgs(pyth_func, ptype, pvalue, ptraceback, NULL)) != NULL ) 
+        {
+            PyObject *pystr = PyUnicode_AsEncodedString(pyth_val,"utf-8","~E~");
+            const char *str = pystr ? PyBytes_AsString(pystr) : NULL;
+            if ( str )
+            {
+                output_error("python_eval(command='%s'): traceback follows",command);
+                output_error_raw("BEGIN TRACEBACK\n%s\nEND TRACEBACK",command,str);
+            }
+            else
+            {
+                output_error("python_eval(command='%s'): no traceback found",command);
+            }
+            Py_DECREF(pyth_val);
+        }
+        else
+        {
+            output_error("python_eval(command='%s'): unable to format traceback, arguments follow",command);
+            FILE *error = output_get_stream("error");
+            output_error_raw("BEGIN TRACEBACK");
+            fprintf(error,"function: "); PyObject_Print(pyth_func,error,Py_PRINT_RAW); fprintf(error,"\n");
+            fprintf(error,"type: "); PyObject_Print(ptype,error,Py_PRINT_RAW); fprintf(error,"\n");
+            fprintf(error,"value: "); PyObject_Print(pvalue,error,Py_PRINT_RAW); fprintf(error,"\n");
+            fprintf(error,"traceback: "); PyObject_Print(ptraceback,error,Py_PRINT_RAW); fprintf(error,"\n");
+            output_error_raw("END TRACEBACK");
+        }
+    }
+}
+
+std::string python_eval(const char *command)
+{
+    PyObject *result = PyRun_String(command,Py_eval_input,main_module,main_module);
+    if ( result == NULL )
+    {
+        output_error("python_eval(command='%s') failed",truncate(command));
+        traceback(truncate(command));
+        throw "python exception";
+    }
+    PyObject *repr = PyObject_Repr(result);
+    PyObject *str = PyUnicode_AsEncodedString(repr,"utf-8","~E~");
+    std::string bytes(PyBytes_AS_STRING(str));
+    Py_XDECREF(repr);
+    Py_XDECREF(str);
+    Py_XDECREF(result);
+    return bytes;
+}
+
+// Parser implementation
+//   python_parse(<string>) to append <string> to input buffer
+//   python_parser(NULL) to parse input buffer
+// Returns true on success, false on failure
+static std::string input_buffer("");
+bool python_parser(const char *line)
+{
+    // end input -> run code
+    if ( line != NULL )
+    {
+        input_buffer.append(line);
+        return true;
+    }
+
+    const char *command = input_buffer.c_str();
+    PyObject *result = PyRun_String(command,Py_file_input,main_module,main_module);
+    if ( result == NULL )
+    {
+        output_error("python_embed_call(parser_module='gridlabd',command='%s') failed",truncate(command));
+        traceback(truncate(command));
+        input_buffer = "";
+        return false;
+    }
+    else
+    {
         Py_XDECREF(result);
-        return bytes;
+        input_buffer = "";
+        return true;
     }
 }

--- a/gldcore/python_embed.h
+++ b/gldcore/python_embed.h
@@ -14,5 +14,6 @@ void python_embed_term();
 PyObject *python_embed_import(const char *module, const char *path=NULL);
 bool python_embed_call(PyObject *pModule, const char *name);
 std::string python_eval(const char *command);
+bool python_parser(const char *line=NULL);
 
 #endif


### PR DESCRIPTION
This PR adds a macro to control the interpreter used by the loader.

## Current issues
None

## Code changes
1. Added language handler to loader using the `#begin` macro
2. Changed embedded python handler to support extended python requests.

## Documentation changes
- Added [`/GLM/Macro/Begin/`](http://docs.gridlabd.us/_page.html?owner=dchassin&project=gridlabd&branch=develop-add-inline-python&folder=/GLM/Macro&doc=/GLM/Macro/Begin.md)

## Test and Validation Notes
1. Added [`gldcore/autotest/test_inline_python.glm`](https://github.com/dchassin/gridlabd/blob/develop-add-inline-python/gldcore/autotest/test_inline_python.glm)
