### PR TITLE
Add subcommand pipes

### DIFF
--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -915,6 +915,7 @@ DEPRECATED const char *global_seq(char *buffer, int size, const char *name)
 
 DEPRECATED const char *global_shell(char *buffer, int size, const char *command)
 {
+	// TODO: reimplmenent this so it capture stderr also (see GldMain::subcommand)
 	FILE *fp = popen(command, "r");
 	if ( fp == NULL ) 
 	{

--- a/gldcore/main.h
+++ b/gldcore/main.h
@@ -202,6 +202,15 @@ public:
 	// Method: global_push
 	inline void global_push(char *name, char *value) { return globals.push(name,value);};
 
+	/* 	Method: subcommand
+
+		Run the subcommand in the current environment, redirecting output to stdout/stderr.
+
+		Returns:
+		-1	failed to start command
+		>=0 command exit code
+	 */
+	int subcommand(const char *format,...);
 };
 
 DEPRECATED extern GldMain *my_instance; // TODO: move this into main() to make system globally reentrant


### PR DESCRIPTION
This PR addresses issue arras-energy/gridlabd#84 item 7.

## Current issues
- Input streams are not supported by `popen3()`.

## Code changes
- [X] Add `popen3()` and `pclose3()` to support connecting pipes to forked processes to allow output streams to connect through to `output_message()` and `output_error()`.
- [X] Add `GldMain::subcommand()` method to allow fork/wait of processes using pipes.
- [ ] Replace all `system()`, `execv()`, etc. calls with `GldMain::subcommand()` calls.

## Documentation changes
None

## Test and Validation Notes
Standard validation run should no longer show spurious output while running simulations that output from subcommands.
