### PR TITLE
Add initialize-only command-line option

### DIFF
--- a/docs/Command/Compile.md
+++ b/docs/Command/Compile.md
@@ -1,0 +1,20 @@
+[[/Command/Compile]] -- Command line option to only Compile a model
+
+# Synopsis
+~~~
+bash$ gridlabd -C filename [options ...]
+bash$ gridlabd --compile filename [options ...]
+~~~
+
+# Description
+
+The `--Compile` or `-C` command line option is used to compile the model specified in the `filename`.
+
+The option is somewhat is misnomer in the sense that GridLAB-D not only compiles the model, but it also sets the initial conditions for the solvers.  For this reason, the option is particularly useful to generate models for other solvers to use.
+
+
+# See also
+
+* [[/Command/Compileonly]]
+* [[/Global/Compileonly]]
+* [[/Global/Initializeonly]]

--- a/docs/Command/Gdb.md
+++ b/docs/Command/Gdb.md
@@ -1,4 +1,4 @@
-[[Command/Gdb]] -- Command option to start the system debugger on GridLAB-D
+[[/Command/Gdb]] -- Command option to start the system debugger on GridLAB-D
 
 # Synopsis
 ~~~
@@ -13,6 +13,6 @@ The GridLAB-D command line options may be provided `options` after the `--gdb` o
 
 # See also
 
-* [[Command/Lldb]]
-* [[Command/Valgrind]]
+* [[/Command/Lldb]]
+* [[/Command/Valgrind]]
 * [GDB Documentation](https://www.gnu.org/software/gdb/documentation/)

--- a/docs/Command/Initialize.md
+++ b/docs/Command/Initialize.md
@@ -1,0 +1,19 @@
+[[/Command/Initialize]] -- Command line option to only initialize a model
+
+# Synopsis
+~~~
+bash$ gridlabd -I filename [options ...]
+bash$ gridlabd --initialize filename [options ...]
+~~~
+
+# Description
+
+The `--initialize` or `-I` command line option is used to compile and initialize the model specified in the `filename`.
+
+The option is somewhat is misnomer in the sense that GridLAB-D not only creates the model and sets initial conditions for the solvers, but it also attempts to obtain the first solution in time.  For this reason, the option is particularly useful to validate a model.
+
+# See also
+
+* [[/Command/Compileonly]]
+* [[/Global/Compileonly]]
+* [[/Global/Initializeonly]]

--- a/docs/Command/JSON input.md
+++ b/docs/Command/JSON input.md
@@ -1,4 +1,4 @@
-[[Command/JSON Input]] -- Command option for JSON input format
+[[/Command/JSON Input]] -- Command option for JSON input format
 
 # Synopsis
 ~~~
@@ -33,5 +33,5 @@ because the last command will overwrite the original input file with a GLM file 
 
 # See also
 
-* [[Command/JSON output]]
-* [[Global/json_save_options]]
+* [[/Command/JSON output]]
+* [[/Global/json_save_options]]

--- a/docs/Command/JSON output.md
+++ b/docs/Command/JSON output.md
@@ -1,4 +1,4 @@
-[[Command/JSON output]] -- JSON output format
+[[/Command/JSON output]] -- JSON output format
 
 # Synopsis
 Command line:
@@ -21,5 +21,5 @@ The file extension `.json` is supported for output. The `-o filename.json` comma
 Some advanced GLM features are not supported in JSON. For example, it is not possible to define implicit multi-object definitions using JSON as in GLM. In general, GLM *features* that are implicity often have to be implemented explicitly in JSON. That can lead to changes in the model behavior when performing "round-robin" conversions and the output GLM may not behave exactly the same as the input GLM.
 
 # See also
-* [[Command/JSON input]]
-* [[Global/json_save_options]]
+* [[/Command/JSON input]]
+* [[/Global/json_save_options]]

--- a/docs/Command/Lldb.md
+++ b/docs/Command/Lldb.md
@@ -1,4 +1,4 @@
-[[Command/Lldb]] -- Command line option to start system debugger on GridLAB-D
+[[/Command/Lldb]] -- Command line option to start system debugger on GridLAB-D
 
 # Synopsis
 ~~~
@@ -13,6 +13,6 @@ The GridLAB-D command options may be provided after the `--lldb` option.
 
 # See also
 
-* [[Command/Gdb]]
-* [[Command/Valgrind]]
+* [[/Command/Gdb]]
+* [[/Command/Valgrind]]
 * [LLDB Documentation](https://lldb.llvm.org)

--- a/docs/Command/Origin.md
+++ b/docs/Command/Origin.md
@@ -1,4 +1,4 @@
-[[Command/Origin]] -- comnmand line option to display the build origin information
+[[/Command/Origin]] -- comnmand line option to display the build origin information
 
 # Synopsis
 ~~~
@@ -50,5 +50,5 @@ index cc6f1281..ead1fb0e 100755
 
 # See also
 
-* [[Command/Version]]
-* [[Subcommand/Version]]
+* [[/Command/Version]]
+* [[/Subcommand/Version]]

--- a/docs/Command/Python input.md
+++ b/docs/Command/Python input.md
@@ -1,4 +1,4 @@
-[[Command/Python input]] -- Command line option for running Python scripts
+[[/Command/Python input]] -- Command line option for running Python scripts
 
 # Synopsis
 ~~~
@@ -18,5 +18,5 @@ will run the script `my-script.py` in the current GridLAB-D Python environment.
 Only `python3` is supported, and the Python executable must installed (or linked) in the `/usr/local/bin` folder.
 
 # See also
-* [[Module/Python]]
-* [[Subcommand/Python]]
+* [[/Module/Python]]
+* [[/Subcommand/Python]]

--- a/docs/Command/Remote.md
+++ b/docs/Command/Remote.md
@@ -1,4 +1,4 @@
-[[Command/Remote]] -- Command line option for remote GridLAB-D runs
+[[/Command/Remote]] -- Command line option for remote GridLAB-D runs
 
 # Synopsis
 ~~~
@@ -33,4 +33,4 @@ Note that the file `model.glm` must be located on the remote machine.
 
 # See also
 
-* [[Command/Daemon]]
+* [[/Command/Daemon]]

--- a/docs/Command/Valgrind.md
+++ b/docs/Command/Valgrind.md
@@ -1,4 +1,4 @@
-[[Command/Valgrind]] -- Run gridlabd with valgrind
+[[/Command/Valgrind]] -- Run gridlabd with valgrind
 
 # Synopsis
 
@@ -16,6 +16,6 @@ host% sudo yum install valgrind
 ~~~
 
 # See also
-* [[Command/Gdb]]
-* [[Command/Lldb]]
+* [[/Command/Gdb]]
+* [[/Command/Lldb]]
 * [Valgrind Documentation](https://valgrind.org/docs/)

--- a/docs/Command/Version.md
+++ b/docs/Command/Version.md
@@ -1,4 +1,4 @@
-[[Command/Version]] -- Command line option to obtain the current version information
+[[/Command/Version]] -- Command line option to obtain the current version information
 
 # Synopsis
 ~~~
@@ -53,8 +53,8 @@ Outputs the installation name, e.g., `gridlabd-4.2.0-191115-develop_fix_manual`.
 
 # See also
 
-* [[Subcommand/Version]]
-* [[Command/Origin]]
+* [[/Subcommand/Version]]
+* [[/Command/Origin]]
 
 
 Outputs `package-major.minor.patch-build-branch-system-hardware`.

--- a/docs/Global/Compileonly.md
+++ b/docs/Global/Compileonly.md
@@ -20,3 +20,6 @@ Compile only enable flag
 ~~~
 #set compileonly=FALSE
 ~~~
+
+# See also
+* [[/Command/Compile]]

--- a/docs/Global/Initializeonly.md
+++ b/docs/Global/Initializeonly.md
@@ -1,0 +1,25 @@
+[[/Global/Initializeonly]] -- Initialize only enable flag
+
+# Synopsis
+GLM:
+~~~
+#set Initializeonly=FALSE
+~~~
+Shell:
+~~~
+bash$ gridlabd -D Initializeonly=FALSE
+bash$ gridlabd --define Initializeonly=FALSE
+~~~
+
+# Description
+
+Initialize only enable flag
+
+# Example
+
+~~~
+#set compileonly=FALSE
+~~~
+
+# See also
+* [[/Command/Initialize]]

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -441,6 +441,18 @@ int GldCmdarg::compile(int argc, const char *argv[])
 	global_compileonly = !global_compileonly;
 	return 0;
 }
+
+
+DEPRECATED static int initialize(void *main, int argc, const char *argv[])
+{
+	return ((GldMain*)main)->get_cmdarg()->initialize(argc,argv);
+}
+int GldCmdarg::initialize(int argc, const char *argv[])
+{
+	global_initializeonly = !global_initializeonly;
+	return 0;
+}
+
 DEPRECATED static int license(void *main, int argc, const char *argv[])
 {
 	return ((GldMain*)main)->get_cmdarg()->license(argc,argv);
@@ -2016,6 +2028,7 @@ DEPRECATED static CMDARG main_commands[] = {
 	{"bothstdout",	NULL,	bothstdout,		NULL, "Merges all output on stdout" },
 	{"check_version", NULL,	_check_version,	NULL, "Perform online version check to see if any updates are available" },
 	{"compile",		"C",	compile,		NULL, "Toggles compile-only flags" },
+	{"initialize",	"I",	initialize,		NULL, "Toggles initialize-only flags" },
 	{"environment",	"e",	environment,	"<appname>", "Set the application to use for run environment" },
 	{"output",		"o",	output,			"<file>", "Enables save of output to a file (default is gridlabd.glm)" },
 	{"pause",		NULL,	pauseatexit,	NULL, "Toggles pause-at-exit feature" },

--- a/gldcore/cmdarg.h
+++ b/gldcore/cmdarg.h
@@ -149,6 +149,7 @@ public:
 	int mt_profile(int argc, const char *argv[]);
 	int pauseatexit(int argc, const char *argv[]);
 	int compile(int argc, const char *argv[]);
+	int initialize(int argc, const char *argv[]);
 	int license(int argc, const char *argv[]);
 	int server_portnum(int argc, const char *argv[]);
 	int server_inaddr(int argc, const char *argv[]);

--- a/gldcore/exec.cpp
+++ b/gldcore/exec.cpp
@@ -2806,6 +2806,13 @@ STATUS GldExec::exec_start(void)
 			if(sync_get(NULL) != global_clock){
 				clock_update_modules();
 			}
+
+			// initialize only stops here
+			if ( global_initializeonly )
+			{
+				break;
+			}
+
 		} // end of while loop
 
 		/* disable signal handler */
@@ -2817,7 +2824,6 @@ STATUS GldExec::exec_start(void)
 			char buffer[64];
 			IN_MYCONTEXT output_verbose("simulation at steady state at %s", convert_from_timestamp(global_clock,buffer,sizeof(buffer))?buffer:"invalid time");
 		}
-
 	}
 	catch (const char *msg)
 	{

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -421,6 +421,9 @@ GLOBAL int global_nondeterminism_warning INIT(0); /**< flag to enable nondetermi
 /* Variable: global_compileonly */
 GLOBAL int global_compileonly INIT(0); /**< flag to enable compile-only option (does not actually start the simulation) */
 
+/* Variable: global_compileonly */
+GLOBAL int global_initializeonly INIT(0); /**< flag to enable initialize-only option (does not actually start the simulation) */
+
 /* Variable: global_server_portnum */
 GLOBAL int global_server_portnum INIT(0); /**< port used in server mode (6267 was assigned by IANA Dec 2010) */
 


### PR DESCRIPTION
This PR addresses a shortcoming with the `--compile|-C` command-line option. 

## Current issues
None

## Code changes
1. Added support for `--initialize` and `-I` command-line option
2. Added support for `initializeonly` global variable

## Documentation changes
- [/Command/Initialize](http://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-initialize-only&folder=/Command&doc=/Command/Initialize.md)
- [/Global/Initializeonly](http://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-initialize-only&folder=/Global&doc=/Global/Initializeonly.md)
- A number of other docs typos that were found have been corrected but they have nothing to do with this enhancement

## Test and Validation Notes
Try the following commands:
~~~
bash$ gridlabd -I <my-model.glm> -o profile.png -D png_save_options='-t profile'
~~~
This should produce the voltage profile for the solved model at the start-time only.