### PR TITLE
Adding tag to dockerhub build hook

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -f Dockerfile --build-arg BRANCH=$SOURCE_BRANCH .
+docker build -f Dockerfile -t $IMAGE_NAME --build-arg BRANCH=$SOURCE_BRANCH .


### PR DESCRIPTION
This PR addresses issue(s) #518 

## Current issues
None

## Code changes
1. Tagged the build hook for dockerhub in docker/hooks/build

## Documentation changes
- NA

## Test and Validation Notes
1. Check that develop image is functional on dockerhub by pulling it from the hub and checking `gridlabd --version=all` to ensure it says "develop"
