### PR TITLE
Add reconfigure target to system target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -307,7 +307,7 @@ install-exec-hook: python-install html-local index
 reconfigure: distclean
 	autoreconf -isf && ./configure
 
-system: reconfigure install
+system: install
 	$(DESTDIR)$(bindir)/gridlabd version set
 
 index: weather library template

--- a/Makefile.am
+++ b/Makefile.am
@@ -304,7 +304,10 @@ install-exec-hook: python-install html-local index
 	@echo "  $(DESTDIR)$(bindir)/gridlabd version set"
 	@echo ""
 
-system: install
+reconfigure: distclean
+	autoreconf -isf && ./configure
+
+system: reconfigure install
 	$(DESTDIR)$(bindir)/gridlabd version set
 
 index: weather library template

--- a/gldcore/scripts/gridlabd-version
+++ b/gldcore/scripts/gridlabd-version
@@ -123,7 +123,7 @@ function version-show()
 function version-delete()
 {
 	if [ "$1" == "-a" ]; then
-		L="$(cd /usr/local/opt/gridlabd; ls -1d | grep -v current)"
+		L="$(ls -1 /usr/local/opt/gridlabd | grep -v current)"
 	else
 		L="$1"
 		if [ ! -d "$L" ]; then


### PR DESCRIPTION
This PR addresses inconsistencies in how the `system` target works in `Makefile.am`

## Current issues
None known

## Code changes
1. Add a new `reconfigure` target to make distclean, autoreconf, and configure.
1. Add a new `system` target to make install and gridlabd version set.

## Documentation changes
None

## Test and Validation Notes
Try to build and install this branch the old way, e.g., `make distclean && autoreconf -isf && ./configure && make install && /usr/local/opt/gridlabd/<version>/bin/gridlabd version set`. Then checkout a new branch, and do a `make reconfigure && make system`.  It should rebuild from scratch, install in the new branches install folder and make the new branch the system install.