### PR TITLE
Add support for recorder output formatting

### DIFF
--- a/docs/Module/Tape/Recorder.md
+++ b/docs/Module/Tape/Recorder.md
@@ -139,10 +139,42 @@ TODO
 ### `property`
 
 ~~~
-  method property;
+method property;
 ~~~
 
-TODO
+The `property` field enumerates the targets that will be recorded into the file specified.  The properties must belong to the parent object. When multiple properties are specified they must be separated by commas.  Property may be specified with a unit and a format specification using the syntax:
+
+~~~
+property "<name>[<unit>:<format]";
+~~~
+
+where `<unit>` must be a valid unit that is compatible with the unit of property.  The `<format>` value must be specified as follows for `double` properties:
+
+~~~
+  <digit><letter>
+~~~
+
+where `<digit>` is a number from 0 to 9 specifying the precision of the output number, and `<letter>` is one of ['a','e','f','g','A','E','F','G'], corresponding to the double formats used by `sprintf()`.
+
+When the properties is a `complex`, the format specification must also include one of ['i','j','d','r',M','D','R','X','Y'], indicating the follow forms of the complex value
+
+* `i`: Rectangular form with 'i' as the complex variable.
+
+* `j`: Rectangular form with 'j' as the complex variable.
+
+* `r`: Polar form with angle specified in radians.
+
+* `d`: Polar form with angle specified in degrees.
+
+* `M`: Magnitude only
+
+* `D`: Angle only in degrees
+
+* `R`: Angle only in radians
+
+* `X`: Real part only
+
+* `Y`: Imaginary part only
 
 ### `output`
 

--- a/tape/autotest/test_recorder_epoch.glm
+++ b/tape/autotest/test_recorder_epoch.glm
@@ -8,7 +8,7 @@
 clock {
      timezone EST+5EDT;
      timestamp '2010-08-15 00:00:00';
-     stoptime '2010-08-15 00:02:00';
+     stoptime '2010-08-15 00:10:00';
 }
 
 #set double_format=%+.12lg
@@ -106,7 +106,8 @@ object transformer {
      to _transformer_meter;
      configuration substation_config;
      object recorder {
-          property power_out_real,power_out[VA:4fi],power_out[VA:4gd];
+          property power_out_real[uW],power_out_real[uW:4a],power_out_real[uW:4e],power_out_real[uW:4f],power_out_real[uW:4g],power_out_real[uW:4A],power_out_real[uW:4E],power_out_real[uW:4F],power_out_real[uW:4G];
+          property power_out[uVA:4fi],power_out[uVA:4fj],power_out[uVA:4fd],power_out[uVA:4fr],power_out[uVA:4fM],power_out[uVA:4fR],power_out[uVA:4fD],power_out[uVA:4fX],power_out[uVA:4fY];
           limit 100000000;
           interval 60;
           file totalload_5_houses_Aug.csv;
@@ -417,7 +418,7 @@ object house {
 //  1281844860  2010-08-15 00:01:00 EDT
 object recorder {
 	parent H_5;
-	property Rroof, Rwall,Rfloor,Rdoors;
+	property Rroof,Rwall,Rfloor,Rdoors;
 	file test_recorder_epoch.csv;
 	format 1;
 	interval 60;
@@ -425,7 +426,7 @@ object recorder {
 
 object multi_recorder {
 	parent H_5;
-	property Rroof, H_4:Rroof,H_3:Rroof,H_2:Rroof,H_1:Rroof;
+	property Rroof,H_4:Rroof,H_3:Rroof,H_2:Rroof,H_1:Rroof;
 	file test_multirecorder_epoch.csv;
 	format 1;
 	interval 60;

--- a/tape/autotest/test_recorder_epoch.glm
+++ b/tape/autotest/test_recorder_epoch.glm
@@ -106,7 +106,7 @@ object transformer {
      to _transformer_meter;
      configuration substation_config;
      object recorder {
-          property power_out_real;
+          property power_out_real,power_out[VA:4fi],power_out[VA:4gd];
           limit 100000000;
           interval 60;
           file totalload_5_houses_Aug.csv;

--- a/tape/recorder.cpp
+++ b/tape/recorder.cpp
@@ -709,7 +709,6 @@ CDECL int read_properties(struct recorder *my, OBJECT *obj, PROPERTY *prop, char
 	int fmt_count = 0;
 	for ( p = prop ;  p != NULL ; fmt_count++, p = p->next )
 	{
-		//printf("processing property %s (type %d), unit '%s', output format '%s', scalar '%g'\n", p->name, p->ptype, p->unit->name, my->output_format[fmt_count], my->output_scalar[fmt_count]);
 		void *addr = ( p->oclass == NULL ? p->addr : GETADDR(obj,p) );
 		if ( my->output_format[fmt_count] != NULL )
 		{

--- a/tape/recorder.cpp
+++ b/tape/recorder.cpp
@@ -312,7 +312,14 @@ static int recorder_open(OBJECT *obj)
 					prop = 0;
 					unitstr[0] = 0;
 					propstr[0] = 0;
-					if(2 == sscanf(token, "%[A-Za-z0-9_.][%[^]\n,]]", propstr, unitstr)){
+					if ( sscanf(token, "%[A-Za-z0-9_.][%[^]\n,]]", propstr, unitstr) == 2 )
+					{
+						char *format = strchr(unitstr,':');
+						if ( format )
+						{
+							*format++ = '\0';
+							strcpy(my->output_format,format);
+						}
 						unit = gl_find_unit(unitstr);
 						if(unit == 0){
 							gl_error("recorder:%d: unable to find unit '%s' for property '%s'", obj->id, unitstr, propstr);
@@ -573,7 +580,14 @@ PROPERTY *link_properties(struct recorder *rec, OBJECT *obj, char *property_list
 
 		// everything that looks like a property name, then read units up to ]
 		while (isspace(*item)) item++;
-		if(2 == sscanf(item,"%[A-Za-z0-9_.][%[^]\n,]]", (char*)pstr, (char*)ustr)){
+		if ( sscanf(item,"%[A-Za-z0-9_.][%[^]\n,]]", (char*)pstr, (char*)ustr) == 2 )
+		{
+			char *format = strchr(ustr,':');
+			if ( format )
+			{
+				*format++ = '\0';
+				strcpy(rec->output_format,format);
+			}
 			unit = gl_find_unit(ustr);
 			if(unit == NULL){
 				gl_error("recorder:%d: unable to find unit '%s' for property '%s'",obj->id, (char*)ustr,(char*)pstr);

--- a/tape/recorder.cpp
+++ b/tape/recorder.cpp
@@ -709,7 +709,7 @@ CDECL int read_properties(struct recorder *my, OBJECT *obj, PROPERTY *prop, char
 	int fmt_count = 0;
 	for ( p = prop ;  p != NULL ; fmt_count++, p = p->next )
 	{
-		printf("processing property %s (type %d), unit '%s', output format '%s', scalar '%g'\n", p->name, p->ptype, p->unit->name, my->output_format[fmt_count], my->output_scalar[fmt_count]);
+		//printf("processing property %s (type %d), unit '%s', output format '%s', scalar '%g'\n", p->name, p->ptype, p->unit->name, my->output_format[fmt_count], my->output_scalar[fmt_count]);
 		void *addr = ( p->oclass == NULL ? p->addr : GETADDR(obj,p) );
 		if ( my->output_format[fmt_count] != NULL )
 		{

--- a/tape/recorder.cpp
+++ b/tape/recorder.cpp
@@ -95,6 +95,8 @@ EXPORT int create_recorder(OBJECT **obj, OBJECT *parent)
 		my->flush = -1; /* -1 (default): flush when buffer full, 0 flush each line, >0 flush seconds */
 		my->property = NULL;
 		my->property_len = 0;
+		memset(my->output_format,0,sizeof(my->output_format));
+		memset(my->output_scalar,0,sizeof(my->output_scalar));
 		return 1;
 	}
 	return 0;
@@ -284,79 +286,100 @@ static int recorder_open(OBJECT *obj)
 
 	/* if type is file or file is stdin */
 	f = get_ftable(my->mode);
-	if(f != 0){
+	if ( f != 0 )
+	{
 		my->ops = f->recorder;
-	} else {
+	} 
+	else 
+	{
 		return 0;
 	}
-	if(my->ops == NULL)
+	if ( my->ops == NULL )
+	{
 		return 0;
+	}
 	set_csv_options();
 
 	// set out_property here
-	{size_t offset = 0;
-		char unit_buffer[1024];
-		char *token = 0;
-		char propstr[1024], unitstr[64];
-		PROPERTY *prop = 0;
-		UNIT *unit = 0;
-		int first = 1;
-		switch(my->header_units){
-			case HU_DEFAULT:
-				strcpy(my->out_property, my->property);
-				break;
-			case HU_ALL:
-				strcpy(unit_buffer, my->property);
-				for(token = strtok(unit_buffer, ","); token != NULL; token = strtok(NULL, ",")){
-					unit = 0;
-					prop = 0;
-					unitstr[0] = 0;
-					propstr[0] = 0;
-					if ( sscanf(token, "%[A-Za-z0-9_.][%[^]\n,]]", propstr, unitstr) == 2 )
-					{
-						char *format = strchr(unitstr,':');
-						if ( format )
-						{
-							*format++ = '\0';
-							strcpy(my->output_format,format);
-						}
-						unit = gl_find_unit(unitstr);
-						if(unit == 0){
-							gl_error("recorder:%d: unable to find unit '%s' for property '%s'", obj->id, unitstr, propstr);
-							return 0;
-						}
-					}
-					prop = gl_get_property(obj->parent, propstr,NULL);
-					if(prop->unit != 0 && unit == 0){
-						unit = prop->unit;
-					}
-					// print the property, and if there is one, the unit
-					if(unit != 0){
-						sprintf(my->out_property+offset, "%s%s[%s]", (first ? "" : ","), propstr, (unitstr[0] ? unitstr : unit->name));
-						offset += strlen(propstr) + (first ? 0 : 1) + 2 + strlen(unitstr[0] ? unitstr : unit->name);
-					} else {
-						sprintf(my->out_property+offset, "%s%s", (first ? "" : ","), propstr);
-						offset += strlen(propstr) + (first ? 0 : 1);
-					}
-					first = 0;
+	size_t offset = 0;
+	char unit_buffer[1024];
+	char *token = 0;
+	char propstr[1024], unitstr[64];
+	PROPERTY *prop = 0;
+	UNIT *unit = 0;
+	int first = 1;
+	int fmt_count = 0;
+	char *last_token;
+	switch ( my->header_units )
+	{
+	case HU_DEFAULT:
+		strcpy(my->out_property, my->property);
+		break;
+	case HU_ALL:
+		strcpy(unit_buffer, my->property);
+		for ( token = strtok_s(unit_buffer,",",&last_token) ; token != NULL ; fmt_count++, token = strtok_s(NULL, ",",&last_token) )
+		{
+			unit = 0;
+			prop = 0;
+			unitstr[0] = 0;
+			propstr[0] = 0;
+			if ( sscanf(token, "%[A-Za-z0-9_.][%[^]\n,]]", propstr, unitstr) == 2 )
+			{
+				char *colon = strchr(unitstr,':');
+				if ( colon != NULL ) 
+				{
+					*colon = '\0';
 				}
-				break;
-			case HU_NONE:
-				strcpy(unit_buffer, my->property);
-				for(token = strtok(unit_buffer, ","); token != NULL; token = strtok(NULL, ",")){
-					if(2 == sscanf(token, "%[A-Za-z0-9_.][%[^]\n,]]", propstr, unitstr)){
-						; // no logic change
-					}
-					// print just the property, regardless of type or explicitly declared property
-					sprintf(my->out_property+offset, "%s%s", (first ? "" : ","), propstr);
-					offset += strlen(propstr) + (first ? 0 : 1);
-					first = 0;
+				unit = gl_find_unit(unitstr);
+				if ( unit == NULL )
+				{
+					gl_error("recorder:%d: unable to find unit '%s' for property '%s'", obj->id, unitstr, propstr);
+					return 0;
 				}
-				break;
-			default:
-				// error
-				break;
+			}
+			prop = gl_get_property(obj->parent, propstr,NULL);
+			if ( prop == NULL )
+			{
+				gl_error("recorder:%d: property '%s' not found in parent", obj->id, propstr);
+				return 0;
+			}
+			if ( prop->unit != NULL && unit == NULL )
+			{
+				unit = prop->unit;
+			}
+			// print the property, and if there is one, the unit
+			if ( unit != NULL )
+			{
+				sprintf(my->out_property+offset, "%s%s[%s]", (first ? "" : ","), propstr, (unitstr[0] ? unitstr : unit->name));
+				offset += strlen(propstr) + (first ? 0 : 1) + 2 + strlen(unitstr[0] ? unitstr : unit->name);
+			} 
+			else 
+			{
+				sprintf(my->out_property+offset, "%s%s", (first ? "" : ","), propstr);
+				offset += strlen(propstr) + (first ? 0 : 1);
+			}
+			first = 0;
 		}
+		break;
+	case HU_NONE:
+		strcpy(unit_buffer, my->property);
+		for ( token = strtok_s(unit_buffer, ",", &last_token) ; token != NULL ; token = strtok_s(NULL, ",", &last_token) )
+		{
+			if ( sscanf(token, "%[A-Za-z0-9_.][%[^]\n,]]", propstr, unitstr) < 1 )
+			{
+				gl_error("invalid property/format specification '%s'", token);
+				return 0;
+			}
+			// print just the property, regardless of type or explicitly declared property
+			sprintf(my->out_property+offset, "%s%s", (first ? "" : ","), propstr);
+			offset += strlen(propstr) + (first ? 0 : 1);
+			first = 0;
+		}
+		break;
+	default:
+		gl_error("invalid property header unit specification");
+		return 0;
+		break;
 	}
 
 	/* set up the delta_mode recorder if enabled */
@@ -566,11 +589,13 @@ PROPERTY *link_properties(struct recorder *rec, OBJECT *obj, char *property_list
 	char256 pstr, ustr;
 	char *cpart = 0;
 	int64 cid = -1;
+	memset(list,0,sizeof(list));
+	int fmt_count = 0;
+	char *last_token;
 
 	strcpy(list,property_list); /* avoid destroying orginal list */
-	for (item=strtok(list,","); item!=NULL; item=strtok(NULL,","))
+	for ( item = strtok_s(list,",",&last_token) ; item != NULL ; fmt_count++, item = strtok_s(NULL,",",&last_token) )
 	{
-		
 		prop = NULL;
 		target = NULL;
 		scale = 1.0;
@@ -579,19 +604,30 @@ PROPERTY *link_properties(struct recorder *rec, OBJECT *obj, char *property_list
 		cid = -1;
 
 		// everything that looks like a property name, then read units up to ]
-		while (isspace(*item)) item++;
-		if ( sscanf(item,"%[A-Za-z0-9_.][%[^]\n,]]", (char*)pstr, (char*)ustr) == 2 )
+		while ( isspace(*item) ) item++;
+		if ( sscanf(item,"%255[A-Za-z0-9_.][%255[^]\n,]]", (char*)pstr, (char*)ustr) > 1 )
 		{
 			char *format = strchr(ustr,':');
 			if ( format )
 			{
 				*format++ = '\0';
-				strcpy(rec->output_format,format);
+				if ( strchr("0123456789",format[0]) == NULL 
+					|| strchr("aefgAEFG",format[1]) == NULL 
+					|| ( format[2] != '\0' && strchr("ijdrMDRXY",format[2]) == NULL ) )
+				{
+					gl_error("recorder:%d: invalid double/complex format '%s'",format);
+					return 0;
+				}
+				rec->output_format[fmt_count] = strdup(format);
 			}
-			unit = gl_find_unit(ustr);
-			if(unit == NULL){
-				gl_error("recorder:%d: unable to find unit '%s' for property '%s'",obj->id, (char*)ustr,(char*)pstr);
-				return NULL;
+			if ( ustr[0] != '\0' )
+			{
+				unit = gl_find_unit(ustr);
+				if ( unit == NULL )
+				{
+					gl_error("recorder:%d: unable to find unit '%s' for property '%s'",obj->id, (char*)ustr,(char*)pstr);
+					return NULL;
+				}
 			}
 			item = pstr;
 		}
@@ -670,10 +706,96 @@ CDECL int read_properties(struct recorder *my, OBJECT *obj, PROPERTY *prop, char
 	memset(&fake, 0, sizeof(PROPERTY));
 	fake.ptype = PT_double;
 	fake.unit = 0;
-	for ( p = prop ;  p != NULL ; p = p->next )
+	int fmt_count = 0;
+	for ( p = prop ;  p != NULL ; fmt_count++, p = p->next )
 	{
+		printf("processing property %s (type %d), unit '%s', output format '%s', scalar '%g'\n", p->name, p->ptype, p->unit->name, my->output_format[fmt_count], my->output_scalar[fmt_count]);
 		void *addr = ( p->oclass == NULL ? p->addr : GETADDR(obj,p) );
-		if(p->ptype == PT_double)
+		if ( my->output_format[fmt_count] != NULL )
+		{
+			char prec = my->output_format[fmt_count][0];
+			char type = my->output_format[fmt_count][1];
+			char part = my->output_format[fmt_count][2];
+			double &scalar = my->output_scalar[fmt_count];
+			const char *unit_name = p->unit ? p->unit->name : "";
+			if ( p->unit != NULL && scalar == 0.0 )
+			{
+				scalar = 1.0;
+				p2 = gl_get_property(obj, p->name, NULL);
+				if ( p2 != NULL && p2->unit != NULL && gl_convert_ex(p2->unit, p->unit, &scalar) == 0 )
+				{
+					gl_error("unable to convert %s to %s for output format %s", p->unit, p2->unit, my->output_format[fmt_count]);
+					return 0;
+				}
+			}
+			if ( p->ptype == PT_double )
+			{
+				if ( part != '\0' )
+				{
+					gl_error("output format part '%c' is not valid for property %s", part, p->name);
+					return 0;
+				}
+				char fmt[64];
+				sprintf(fmt,"%%.%c%c%s%s",prec,type,unit_name?" ":"",unit_name?unit_name:"");
+				double value = (*gl_get_double(obj, p)) * scalar;
+				sz = sprintf(tmp,fmt,value);
+			}
+			else if ( p->ptype == PT_complex )
+			{
+				if ( part == '\0' )
+				{
+					gl_error("output format part required missing complex specifier for property %s", p->name);
+					return 0;
+				}
+				char fmt[64];
+				complex value = (*gl_get_complex(obj, p)) * scalar;
+				switch ( part )
+				{
+				case 'i':
+				case 'j':
+					sprintf(fmt,"%%.%c%c%%+.%c%c%c%s%s",prec,type,prec,type,part,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Re(),value.Im());
+					break;
+				case 'r':
+					sprintf(fmt,"%%.%c%c%%+.%c%c%c%s%s",prec,type,prec,type,part,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Mag(),value.Arg());
+					break;
+				case 'd':
+					sprintf(fmt,"%%.%c%c%%+.%c%c%c%s%s",prec,type,prec,type,part,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Mag(),value.Ang());
+					break;
+				case 'M':
+					sprintf(fmt,"%%.%c%c%s%s",prec,type,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Mag());
+					break;
+				case 'D':
+					sprintf(fmt,"%%.%c%c%s%s",prec,type,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Ang());
+					break;
+				case 'R':
+					sprintf(fmt,"%%.%c%c%s%s",prec,type,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Arg());
+					break;
+				case 'X':
+					sprintf(fmt,"%%.%c%c%s%s",prec,type,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Re());
+					break;
+				case 'Y':
+					sprintf(fmt,"%%.%c%c%s%s",prec,type,unit_name?" ":"",unit_name?unit_name:"");
+					sz = sprintf(tmp,fmt,value.Im());
+					break;
+				default:
+					gl_error("output format '%s' is not valid for a complex value",(const char*)my->output_format[fmt_count]);
+					return 0;
+				}
+			}	
+			else
+			{
+				gl_error("output format is not valid for property type %d",p->ptype);
+				return 0;
+			}
+		}
+		else if ( p->ptype == PT_double )
 		{
 			double value;
 			switch(my->line_units)
@@ -712,7 +834,9 @@ CDECL int read_properties(struct recorder *my, OBJECT *obj, PROPERTY *prop, char
 				default:
 					break;
 			}
-		} else {
+		} 
+		else 
+		{
 			sz = gl_get_value(obj,addr,tmp,sizeof(tmp)-1,p); /* pointer => int64 */
 		}
 		if ( count + sz >= size )
@@ -793,7 +917,8 @@ EXPORT TIMESTAMP sync_recorder(OBJECT *obj, TIMESTAMP t0, PASSCONFIG pass)
 	}
 
 	/* update property value */
-	if ((my->target != NULL) && (my->interval == 0 || my->interval == -1)){	
+	if ( ( my->target != NULL ) && ( my->interval <= 0 ) )
+	{	
 		if(read_properties(my, obj->parent,my->target,buffer,sizeof(buffer))==0)
 		{
 			sprintf(buffer,"unable to read property '%s' of %s %d", my->property, obj->parent->oclass->name, obj->parent->id);
@@ -801,7 +926,8 @@ EXPORT TIMESTAMP sync_recorder(OBJECT *obj, TIMESTAMP t0, PASSCONFIG pass)
 			my->status = TS_ERROR;
 		}
 	}
-	if ((my->target != NULL) && (my->interval > 0)){
+	else if ( ( my->target != NULL ) && ( my->interval > 0 ) )
+	{
 		if((t0 >=my->last.ts + my->interval) || ((t0 == my->last.ts) && (my->last.ns == 0))){
 			if(read_properties(my, obj->parent,my->target,buffer,sizeof(buffer))==0)
 			{

--- a/tape/tape.h
+++ b/tape/tape.h
@@ -194,6 +194,7 @@ struct recorder {
 	int32 samples;
 	PROPERTY *target;
 	char256 strftime_format;
+	char32 output_format;
 };
 /** @}
 	@addtogroup collector

--- a/tape/tape.h
+++ b/tape/tape.h
@@ -194,7 +194,8 @@ struct recorder {
 	int32 samples;
 	PROPERTY *target;
 	char256 strftime_format;
-	char32 output_format;
+	char *output_format[256];
+	double output_scalar[256];
 };
 /** @}
 	@addtogroup collector


### PR DESCRIPTION
This PR addresses the need to format recorder output using a method similar to the REST API.

## Current issues
None

## Code changes
1. Add parsing of format strings with units, e.g., `name[units:format]`

## Documentation changes
- [/Module/Tape/Recorder](TODO)

## Test and Validation Notes
- Changed `tape/autotest/test_recorder_epoch.glm` to use a format string.
