### PR TITLE
Add heat index to climate object

### DIFF
--- a/climate/autotest/test_WA-Yakima-tmy3.glm
+++ b/climate/autotest/test_WA-Yakima-tmy3.glm
@@ -17,6 +17,11 @@ object climate {
 	tmyfile "../WA-Yakima.tmy3"; 
 	tzoffset -8;
 	elevation 325;
+	object recorder {
+		file "test_WA-Yakima-tmy3.csv";
+		property "temperature,humidity,heat_index";
+		interval "1 h";
+	};
 	object double_assert {
 		target "temperature";
 		in '2006-02-20 23:00:00';

--- a/climate/climate.h
+++ b/climate/climate.h
@@ -198,6 +198,7 @@ class climate : public gld_object
 	GL_ATOMIC(double,cloud_reflectivity);
 	GL_ATOMIC(double,cloud_speed_factor);
 	GL_ATOMIC(enumeration,cloud_model);
+	GL_ATOMIC(double,heat_index);
 
 	// data not shared with classes in this module (no locks needed)
 private:
@@ -227,6 +228,7 @@ private:
 	int get_binary_cloud_value_for_location(double latitude, double longitude, int *cloud);
 	double convert_to_binary_cloud();
 	void convert_to_fuzzy_cloud( double cut_elevation, int num_fuzzy_layers, double alpha);
+	void update_heatindex(void);
 private:
 	TIMESTAMP prev_NTime;
 	int MIN_LAT_INDEX;

--- a/docs/Module/Climate/Climate.md
+++ b/docs/Module/Climate/Climate.md
@@ -54,6 +54,7 @@ GLM:
     cloud_alpha "<decimal> pu";
     cloud_num_layers "<decimal> pu";
     cloud_aerosol_transmissivity "<decimal> pu";
+    heat_index "<decimal> degF";
   }
 ~~~
 
@@ -446,6 +447,14 @@ Number of cloud layers
 ~~~
 
 Cloud aerosal transmissivity
+
+### `heat_index`
+
+~~~
+double heat_index[degF];
+~~~
+
+Computed heat index based on [NOAA heat index equation](https://www.wpc.ncep.noaa.gov/html/heatindex_equation.shtml).
 
 # Example
 

--- a/docs/Module/Climate/Climate.md
+++ b/docs/Module/Climate/Climate.md
@@ -60,7 +60,7 @@ GLM:
 
 # Description
 
-TODO
+The climate object contains data from the [National Renewable Energy Laboratory Typical Meteorological Year weather archive](https://rredc.nrel.gov/solar/old_data/nsrdb/1991-2005/tmy3/).  TMY data is a collection of "typical" weather months assembled into a complete year.  It does not represent a single year and is therefore not suitable for simulation where actual weather data is required.  
 
 ## Properties
 
@@ -509,6 +509,10 @@ Computed heat index based on [NOAA heat index equation](https://www.wpc.ncep.noa
     cloud_aerosol_transmissivity "0.95 pu";
   }
 ~~~
+
+# Caveat
+
+There is often a weather discontinuity at the boundary between months that can sometimes result in a disturbance input to models that are sensitivity to changes in weather.
 
 # See also
 


### PR DESCRIPTION
This PR addresses the need for a heat-index value when modeling loads in more humid conditions.

## Current issues
None

## Code changes
- [X] Add heat index calculations to climate object.

## Documentation changes
- [X] [/Module/Climate/Climate](http://docs-dev.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-add-heatindex&folder=/Module/Climate&doc=/Module/Climate/Climate.md) now describes heat index parameter.

## Test and Validation Notes
- [X] `climate/autotest/test_WA-Yakima-tmy3.glm` now generates a recording of temperature, humidity, and heat index into `test_WA-Yakima-tmy3.csv` for verification.
