### PR TITLE
Fix segfault in GldGlobals::init()

### DIFF
--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -380,7 +380,9 @@ STATUS GldGlobals::init(void)
 	global_version_build = version_build();
 	strncpy(global_version_branch,version_branch(),sizeof(global_version_branch));
 	strcpy(global_datadir,global_execdir);
-	strcpy(strstr(global_datadir,"/bin"),"/share/gridlabd");
+	char *bin = strstr(global_datadir,"/bin");
+	if ( bin ) *bin = '\0';
+	strcat(global_datadir,"/bin");
 	sprintf(global_version,"%d.%d.%d-%d-%s",global_version_major,global_version_minor,global_version_patch,global_version_build,global_version_branch);
 
 	for (i = 0; i < sizeof(map) / sizeof(map[0]); i++){

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -382,7 +382,7 @@ STATUS GldGlobals::init(void)
 	strcpy(global_datadir,global_execdir);
 	char *bin = strstr(global_datadir,"/bin");
 	if ( bin ) *bin = '\0';
-	strcat(global_datadir,"/bin");
+	strcat(global_datadir,"/share/gridlabd");
 	sprintf(global_version,"%d.%d.%d-%d-%s",global_version_major,global_version_minor,global_version_patch,global_version_build,global_version_branch);
 
 	for (i = 0; i < sizeof(map) / sizeof(map[0]); i++){

--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -473,7 +473,7 @@ static void *gridlabd_main(void *)
     gridlabd_module_status = GMS_RUNNING;
     return_code = main_python(argc,argv);
     gridlabd_module_status = ( return_code==0 ? GMS_SUCCESS : GMS_FAILED );
-    exec_mls_done();
+    if ( my_instance ) exec_mls_done();
     return (void*)&return_code;
 }
 

--- a/gldcore/main.cpp
+++ b/gldcore/main.cpp
@@ -82,6 +82,7 @@ int main
 			return rc;
 	}
 	delete my_instance;
+	my_instance = NULL;
 	return return_code;
 }
 unsigned int GldMain::next_id = 0;


### PR DESCRIPTION
This PR addresses issue #550.

## Current issues
None

## Code changes
1. Changed how `global_datadir` is updated in `gldcore/globals.cpp:GldGlobals::init()`

## Documentation changes
None

## Test and Validation Notes
Recommend running python scripts using command `gridlabd my-script.py` instead of `python3 my-script.py`.  These are equivalent if `python3` is in `/usr/local/bin`, but on many systems that is not the case and the latter form may not work correctly.
