### PR TITLE
Fix segfault when inverter has no parent

### DIFF
--- a/generators/inverter.cpp
+++ b/generators/inverter.cpp
@@ -576,6 +576,11 @@ int inverter::init(OBJECT *parent)
 			return 2; // defer
 		}
 	}
+	else
+	{
+		throw "cannot initialize an inverter without a parent";
+	}
+
 	// construct circuit variable map to meter
 	static complex default_line123_voltage[3], default_line1_current[3];
 	static int default_meter_status;	//Not really a good place to do this, but keep consistent


### PR DESCRIPTION
This PR addresses issue #497 

## Current issues
None

## Code changes
- [X] Add check of parent during initialization

## Documentation changes
None

## Test and Validation Notes
None
