### PR TITLE
Add armadillo to docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,10 @@ jobs:
           command: |
             sudo /usr/bin/influxd run 1>/tmp/influxd.log 2>/tmp/influxd.err &
             sleep 5
+            cd /home/circleci/project/third_party/armadillo-7.800.1
+            cmake .
+            make
+            sudo make install
             cd /home/circleci/project
             autoreconf -isf
             ./configure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
           name: Install python libraries (TODO add to base image)
           command: |
             sudo pip3 -q install Pillow
+      - checkout   
       - run:
           name: Install armadillo
           command: |
@@ -44,8 +45,6 @@ jobs:
             cd armadillo-7.800.1
             cmake .
             make
-
-      - checkout   
       - run:
           name: Build gridlabd
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,17 +35,22 @@ jobs:
           name: Install python libraries (TODO add to base image)
           command: |
             sudo pip3 -q install Pillow
+      - run:
+          name: Install armadillo
+          command: |
+            sudo apt-get install cmake -y
+            cd /home/circleci/project/third_party
+            tar xfz armadillo-7.800.1.tar.gz
+            cd armadillo-7.800.1
+            cmake .
+            make
+
       - checkout   
       - run:
           name: Build gridlabd
           command: |
             sudo /usr/bin/influxd run 1>/tmp/influxd.log 2>/tmp/influxd.err &
             sleep 5
-            cd /home/circleci/project/third_party
-            tar xfz armadillo-7.800.1.tar.gz
-            cd armadillo-7.800.1
-            cmake .
-            make
             sudo make install
             cd /home/circleci/project
             autoreconf -isf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,9 @@ jobs:
           command: |
             sudo /usr/bin/influxd run 1>/tmp/influxd.log 2>/tmp/influxd.err &
             sleep 5
-            cd /home/circleci/project/third_party/armadillo-7.800.1
+            cd /home/circleci/project/third_party
+            tar xfz armadillo-7.800.1.tar.gz
+            cd armadillo-7.800.1
             cmake .
             make
             sudo make install

--- a/docs/Developer/Install.md
+++ b/docs/Developer/Install.md
@@ -51,9 +51,9 @@ bash$ git clone https://github.com/slacgismo/gridlabd gridlabd
 bash$ cd gridlabd
 bash$ autoreconf -isf
 bash$ ./configure
-bash$ make install
+bash$ make system
 bash$ export PATH=/usr/local/bin:$PATH
-bash$ export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH
+bash$ export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:-/usr/local/lib}
 bash$ gridlabd validate
 ~~~
 
@@ -68,6 +68,23 @@ or to install a development copy:
 ~~~
 bash$ ./configure --prefix=$PWD/install
 ~~~
+
+### Change branch
+
+When you change the branch in the source, you will have to completely rebuild the installation.  The easiest way to do this is
+
+~~~
+bash$ make reconfigure
+bash$ make system
+~~~
+
+If you want to speed up the installation, you can use the parallel make process, e.g.,
+
+~~~
+bash$ make -j30 system
+~~~
+
+which allows multiple build steps to run in parallel (in this case 30 at a time).
 
 ## Options
 


### PR DESCRIPTION
This PR addresses build problems with docker.

## Current issues
None

## Code changes
- [X] Added armadillo build to docker build in `.circleci/config.yml`

## Documentation changes
- [X] Updated [/Developer/Install](http://docs-dev.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-add-armadillo&folder=/Developer&doc=/Developer/Install.md) to include information about rebuilding.

## Test and Validation Notes
None
