### PR TITLE
Fix build on docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,44 +4,17 @@ jobs:
     docker:
       - image: slacgismo/circleci_gridlabd_base:latest
     steps:
+      - checkout   
       - run:
-          name: Install influxdb (TODO add to base image)
+          name: Install needed tools (TODO add to base image)
           command: |
             cd /tmp
             wget -q https://dl.influxdata.com/influxdb/releases/influxdb_1.7.9_amd64.deb
             sudo dpkg -i influxdb_1.7.9_amd64.deb
-      - run:
-          name: Install natural_docs (TODO add to base image)
-          command: |
-            cd /tmp
-            curl https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
-            unzip -qq natural_docs
-            rm -f natural_docs.zip
-            echo '#!/bin/bash' > natural_docs
-            echo 'mono $PWD/Natural\ Docs\/NaturalDocs.exe \$*' >> natural_docs
-            chmod a+x natural_docs
-      - run:
-          name: Install mono (TODO add to base image) 
-          command: |
-            cd /tmp
-            sudo apt-get update
-            sudo apt-get install monodevelop -y
-      - run:
-          name: Install gawk (TODO add to base image)
-          command: |
-            cd /tmp
-            sudo apt-get install gawk -y
-      - run:
-          name: Install python libraries (TODO add to base image)
-          command: |
             sudo pip3 -q install Pillow
-      - checkout   
-      - run:
-          name: Install armadillo
-          command: |
             sudo apt-get install cmake -y
             cd /home/circleci/project/third_party
-            tar xfz armadillo-7.800.1.tar.gz
+            tar xfz armadillo-7.800.1.tar.gz 2>/dev/null
             cd armadillo-7.800.1
             cmake .
             make
@@ -50,7 +23,6 @@ jobs:
           command: |
             sudo /usr/bin/influxd run 1>/tmp/influxd.log 2>/tmp/influxd.err &
             sleep 5
-            sudo make install
             cd /home/circleci/project
             autoreconf -isf
             ./configure

--- a/install.conf-default
+++ b/install.conf-default
@@ -22,7 +22,7 @@ CHECK="yes"
 # Control generation of docs. By default the HTML documents are generated into the "html"
 # folder in the install path. Docs generation is disabled by the "--no-docs" option.
 #
-DOCS="yes"
+DOCS="no"
 
 #
 # Force build in spite of issues like running as root and installing into a non-empty folder.


### PR DESCRIPTION
This PR addresses a new problem with docker hub builds.

## Current issues
It appears that updating a branch from the the GitHub browser does not work as expected.  Don't do it.

## Code changes
- [X] Update `.circleci/config.yml` to restore changes that were lost when updating one of the branches.

## Documentation changes
None

## Test and Validation Notes
The fix should allow docker hub to work again.
