### PR TITLE
Fix invariant aggregate failure with groupid

### DIFF
--- a/gldcore/aggregate.cpp
+++ b/gldcore/aggregate.cpp
@@ -187,7 +187,7 @@ GldAggregator::GldAggregator(const char *aggregator, /**< aggregator (min,max,av
 			PGMCONSTFLAGS flags = find_pgmconstants(pgm); 
 			
 			/* the search must be over the same class so that the property offset is known in advance */
-			if ((flags&CF_CLASS)!=CF_CLASS)
+			if ( ! global_allow_variant_aggregates && ! (flags&CF_CONSTANT) )
 			{
 				output_error("aggregate group expression '%s' does not result in a set with a fixed class", group_expression);
 				/* TROUBLESHOOT

--- a/gldcore/autotest/test_groupid_noclass.glm
+++ b/gldcore/autotest/test_groupid_noclass.glm
@@ -1,0 +1,31 @@
+// $Id: test_groupid.glm 4738 2014-07-03 00:55:39Z dchassin $
+// 
+// Test groupid function
+
+clock {
+	timezone PST+8PDT;
+	starttime '2000-01-01 0:00:00 PST';
+	stoptime '2000-01-02 0:00:00 PST';
+}
+
+module residential {
+	implicit_enduses NONE;
+}
+
+object house:..10 {
+	groupid A;
+}
+
+object house:..12 {
+	groupid B;
+}
+
+module tape;
+
+object collector {
+	group "groupid=A";
+	property "count(floor_area)";
+	limit 10;
+	interval 3600;
+	file output.csv;
+}

--- a/gldcore/find.cpp
+++ b/gldcore/find.cpp
@@ -984,7 +984,7 @@ int expression(PARSER, FINDPGM **pgm)
 			strcpy(v.string, pvalue);
 			//printf("find(): v.string=\"%s\", pvalue=\"%s\"\n", v.string, pvalue);
 			add_pgm(pgm, comparemap[op%7].string, OFFSET(groupid), v, NULL, findlist_del);
-			(*pgm)->constflags = PGMCONSTFLAGS((*pgm)->constflags|CF_NAME);
+			(*pgm)->constflags = PGMCONSTFLAGS((*pgm)->constflags|CF_GROUPID);
 			ACCEPT;
 			DONE;
 		}

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -321,6 +321,7 @@ DEPRECATED static struct s_varmap {
 	{"glm_save_options", PT_set, &global_glm_save_options, PA_PUBLIC, "options to control GLM file save format", gso_keys},
 	{"filesave_options", PT_set, &global_filesave_options, PA_PUBLIC, "control elements saved on output", fso_keys},
 	{"ignore_errors", PT_bool, &global_ignore_errors, PA_PUBLIC, "disable exit on error behavior"},
+	{"allow_variant_aggregates", PT_bool, &global_allow_variant_aggregates, PA_PUBLIC, "permits aggregates to include time-varying criteria"},
 	/* add new global variables here */
 };
 

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -654,6 +654,8 @@ GLOBAL bool global_relax_undefined_if INIT(false); /**< allow #if macro to handl
 GLOBAL bool global_literal_if INIT(false); /**< do not interpret lhs of #if as a variable name */
 
 /* Variable:  */
+GLOBAL bool global_allow_variant_aggregates INIT(false); /* allow aggregates to include time varying results */
+/* Variable:  */
 GLOBAL char1024 global_daemon_configfile INIT("gridlabd.cnf"); /**< name of daemon configuration file */
 typedef enum {
 	DMC_MAIN		= 0x0000000000000001,


### PR DESCRIPTION
This PR addresses issue(s) #561 

## Current issues
There are several problems:

Invariance is only based on the first criterion. If any subsequent criteria are variant, the invariant violation is not detected. No suggested fix for this yet.

Groupid does not set it's invariance flag. Easy fix.

The aggregate test only check class, not all constants. Easy fix.

There is no global to override the invariance test if desired. Easy fix.

## Code changes
1. Addition of global `allow_variant_aggregates`.
2. Addition of an autotest `test_groupid_noclass.glm`

## Documentation changes
- none

## Test and Validation Notes
1. Run `groupid` in a collector as the only identifier