### PR TITLE
Anchoring master to a tagged base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: slacgismo/circleci_gridlabd_base:latest
+      - image: slacgismo/circleci_gridlabd_base:200107
     steps:
       - checkout    
       - run:

--- a/.gitattributes
+++ b/.gitattributes
@@ -44,3 +44,4 @@
 *.doc binary
 *.xls binary
 *.xlsx binary
+.circleci/config.yml merge=ours


### PR DESCRIPTION
This PR addresses issue(s):
- Currently both master and develop are working off of the same base image (`slacgismo/circleci_gridlabd_base:latest`). To avoid disruption to master when working on the base image code, I've tagged the base image (`slacgismo/circleci_gridlabd_base:200107`) which will now be the base image for master, and develop will be using latest.

NOTE: This change can't be brought into develop when merging other changes into develop that were patched into master. 

`git config --global merge.ours.driver true` before merging master into develop

## Current issues
NONE

## Code changes
1. .circleci/config.yml

## Documentation changes
-none

## Test and Validation Notes
1. Check circleci validation
