### PR TITLE
Change voltdump and currdump format

### DIFF
--- a/docs/Module/Powerflow/Currdump.md
+++ b/docs/Module/Powerflow/Currdump.md
@@ -14,6 +14,7 @@ GLM:
     interval "+0 s";
     filemode "w";
     mode "RECT";
+    version "2";
   }
 ~~~
 
@@ -86,6 +87,13 @@ Sets the file write mode. Use `w` to write a new file each dump. Use `a` to appe
 ~~~
 
 Specify whether to dump complex numbers in polar or rectangular form.
+
+### `version`
+~~~
+  int32 version;
+~~~
+
+Specifies the format version to output. The default is version 2, which omits the comment row when a new timestamp is seen, and adds a `datetime` column to the output.
 
 # Example
 

--- a/docs/Module/Powerflow/Voltdump.md
+++ b/docs/Module/Powerflow/Voltdump.md
@@ -15,6 +15,7 @@ GLM:
     mode "{polar,rect}";
     filemode "<string>";
     interval "<decimal> s";
+    version "2";
   }
 ~~~
 
@@ -95,6 +96,13 @@ Sets the file write mode
 ~~~
 
 Interval at which voltdump runs
+
+### `version`
+~~~
+  int32 version;
+~~~
+
+Specifies the format version to output. The default is version 2, which omits the comment row when a new timestamp is seen, and adds a `datetime` column to the output.
 
 # Example
 

--- a/docs/Module/Powerflow/Voltdump.md
+++ b/docs/Module/Powerflow/Voltdump.md
@@ -87,7 +87,7 @@ Dumps the voltages in either polar or rectangular notation
   char8 filemode;
 ~~~
 
-Sets the file write mode
+Sets the file write mode. Use w to write a new file each dump. Use a to append each dump to the end of file when a new timestamp is generated.
 
 ### `interval`
 

--- a/gldcore/scripts/gridlabd-weather
+++ b/gldcore/scripts/gridlabd-weather
@@ -10,7 +10,7 @@ fi
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 COUNTRY="US"
-GITUSER=dchassin
+GITUSER=slacgismo
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
 SVNLSOPTIONS="--config-option=servers:global:http-timeout=60 --non-interactive -r1"

--- a/powerflow/currdump.h
+++ b/powerflow/currdump.h
@@ -24,6 +24,7 @@ public:
 	double interval;
 	int32 maxcount;
 	char8 filemode;
+	int32 version;
 public:
 	static CLASS *oclass;
 public:

--- a/powerflow/voltdump.cpp
+++ b/powerflow/voltdump.cpp
@@ -55,6 +55,7 @@ int voltdump::create(void)
 	mode = VDM_RECT;
 	strcpy(filemode,"");
 	interval = 0;
+	version = 0;
 	return 1;
 }
 

--- a/powerflow/voltdump.cpp
+++ b/powerflow/voltdump.cpp
@@ -38,6 +38,7 @@ voltdump::voltdump(MODULE *mod)
 				PT_KEYWORD, "rect", (enumeration)VDM_RECT,
 				PT_KEYWORD, "polar", (enumeration)VDM_POLAR,
 			PT_char8, "filemode", PADDR(filemode), PT_DESCRIPTION,"sets the file write mode",
+			PT_int32, "version", PADDR(version), PT_DESCRIPTION, "dump format version",
 			PT_double, "interval[s]", PADDR(interval), PT_DESCRIPTION, "interval at which voltdump runs",
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		
@@ -88,6 +89,14 @@ int voltdump::init(OBJECT *parent)
 			strcpy(filemode,"w");
 		}
 	}
+	if ( version < 0 || version > 2 )
+	{
+		gl_error("format version %d is invalid", version);
+	}
+	else if ( version == 0 )
+	{
+		version = 2;
+	}
 	return 1;
 }
 
@@ -96,23 +105,25 @@ int voltdump::isa(CLASSNAME classname)
 	return strcmp(classname,"voltdump")==0;
 }
 
-void voltdump::dump(TIMESTAMP t){
-	char namestr[64];
+void voltdump::dump(TIMESTAMP t)
+{
 	char timestr[64];
 	FINDLIST *nodes = NULL;
 	OBJECT *obj = NULL;
 	FILE *outfile = NULL;
 	node *pnode;
-//	CLASS *nodeclass = NULL;
-//	PROPERTY *vA, *vB, *vC;
 
-	if(group[0] == 0){
+	if ( group[0] == 0 )
+	{
 		nodes = gl_find_objects(FL_NEW,FT_MODULE,SAME,"powerflow",FT_END);
-	} else {
+	} 
+	else 
+	{
 		nodes = gl_find_objects(FL_NEW,FT_MODULE,SAME,"powerflow",AND,FT_GROUPID,SAME,group.get_string(),FT_END);
 	}
 
-	if(nodes == NULL){
+	if ( nodes == NULL )
+	{
 		gl_warning("no nodes were found to dump");
 		return;
 	}
@@ -122,41 +133,59 @@ void voltdump::dump(TIMESTAMP t){
 		gl_verbose("voltdump is appending data to %s",filename.get_string());
 	}
 	outfile = fopen(filename, filemode);
-	if(outfile == NULL){
+	if ( outfile == NULL ) 
+	{
 		gl_error("voltdump unable to open %s for output", filename.get_string());
 		return;
 	}
 
-	//nodeclass = node::oclass;
-	//vA=gl_find_property(nodeclass, "
-
 	int node_count = 0;
 	while ( (obj=gl_find_next(nodes,obj)) )
 	{
-		if(gl_object_isa(obj, "node", "powerflow")){
+		if ( gl_object_isa(obj, "node", "powerflow") )
+		{
 			node_count += 1;
 		}
 	}
 	/* print column names */
 	gl_printtime(t, timestr, 64);
-	fprintf(outfile,"# %s run at %s on %i nodes\n", filename.get_string(), timestr, node_count);
+	if ( version < 2 )
+	{
+		fprintf(outfile,"# %s run at %s on %i nodes\nnode_name,", filename.get_string(), timestr, node_count);
+	}
+	else
+	{
+		fprintf(outfile,"node_name,datetime,");
+	}
 	if (mode == VDM_RECT)
-		fprintf(outfile,"node_name,voltA_real,voltA_imag,voltB_real,voltB_imag,voltC_real,voltC_imag\n");
+		fprintf(outfile,"voltA_real,voltA_imag,voltB_real,voltB_imag,voltC_real,voltC_imag\n");
 	else if (mode == VDM_POLAR)
-		fprintf(outfile,"node_name,voltA_mag,voltA_angle,voltB_mag,voltB_angle,voltC_mag,voltC_angle\n");
-	
+		fprintf(outfile,"voltA_mag,voltA_angle,voltB_mag,voltB_angle,voltC_mag,voltC_angle\n");
 	obj = 0;
 	while ( (obj=gl_find_next(nodes,obj)) )
 	{
-		if(gl_object_isa(obj, "node", "powerflow")){
+		if ( gl_object_isa(obj, "node", "powerflow") )
+		{
 			pnode = OBJECTDATA(obj,node);
-			if(obj->name == NULL){
-				sprintf(namestr, "%s:%i", obj->oclass->name, obj->id);
+			if ( obj->name == NULL ) 
+			{
+				fprintf(outfile, "%s:%i,", obj->oclass->name, obj->id);
 			}
-			if(mode == VDM_RECT){
-				fprintf(outfile,"%s,%f,%f,%f,%f,%f,%f\n",(obj->name ? obj->name : namestr),pnode->voltage[0].Re(),pnode->voltage[0].Im(),pnode->voltage[1].Re(),pnode->voltage[1].Im(),pnode->voltage[2].Re(),pnode->voltage[2].Im());
-			} else if(mode == VDM_POLAR){
-				fprintf(outfile,"%s,%f,%f,%f,%f,%f,%f\n",(obj->name ? obj->name : namestr),pnode->voltage[0].Mag(),pnode->voltage[0].Arg(),pnode->voltage[1].Mag(),pnode->voltage[1].Arg(),pnode->voltage[2].Mag(),pnode->voltage[2].Arg());
+			else
+			{
+				fprintf(outfile, "%s,", obj->name);				
+			}
+			if ( version > 1 )
+			{
+				fprintf(outfile,"%s,",timestr);
+			}
+			if ( mode == VDM_RECT )
+			{
+				fprintf(outfile,"%f,%f,%f,%f,%f,%f\n",pnode->voltage[0].Re(),pnode->voltage[0].Im(),pnode->voltage[1].Re(),pnode->voltage[1].Im(),pnode->voltage[2].Re(),pnode->voltage[2].Im());
+			} 
+			else if ( mode == VDM_POLAR )
+			{
+				fprintf(outfile,"%f,%f,%f,%f,%f,%f\n",pnode->voltage[0].Mag(),pnode->voltage[0].Arg(),pnode->voltage[1].Mag(),pnode->voltage[1].Arg(),pnode->voltage[2].Mag(),pnode->voltage[2].Arg());
 			}
 		}
 	}

--- a/powerflow/voltdump.h
+++ b/powerflow/voltdump.h
@@ -24,6 +24,7 @@ public:
 	enumeration mode;		///< dumps the voltages in either polar or rectangular notation
 	char8 filemode;
 	double interval;
+	int32 version;
 public:
 	static CLASS *oclass;
 public:


### PR DESCRIPTION
This PR fixed issue #566 

## Current issues
Version 2 dump is now the default.  This may affect old models that depend on version 1 dumps and don't read the CSV column headers. That is unfortunate, but one should always read CSV column headers if present.

## Code changes
- [X] Add `version 2` support for `currdump` object in `powerflow` module
- [X] Add `version 2` support for `voltdump` object in `powerflow` module

## Documentation changes
- [X] Update [/Module/Powerflow/Voltdump](http://docs-dev.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-change-voltcurdump-format&folder=/Module/Powerflow&doc=/Module/Powerflow/Voltdump.md)
- [X] Update [/Module/Powerflow/Currdump](http://docs-dev.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-change-voltcurdump-format&folder=/Module/Powerflow&doc=/Module/Powerflow/Currdump.md)

## Test and Validation Notes
- [X] Enable volt and current dump output to `powerflow/autotest/test_reversed_lines_NR.glm`
