### PR TITLE
Add percent done to progress output

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -158,7 +158,7 @@ clean-wc:
 	. utilities/cleanwc
 
 install-validate: install
-	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd --validate || (tar cfz validate-output.tar.gz */autotest/test_*/*;exit 1))
+	@(export LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH:-${libdir}}; ${bindir}/gridlabd -D keep_progress=TRUE --validate -D keep_progress=TRUE || (tar cfz validate-output.tar.gz */autotest/test_*/*;exit 1))
 
 check-local validate: 
 	gridlabd --validate

--- a/docs/Global/Keep_progress.md
+++ b/docs/Global/Keep_progress.md
@@ -1,0 +1,27 @@
+[[/Global/Keep_progress]] -- Keep progress enable flag
+
+# Synopsis
+
+GLM:
+
+~~~
+#set keep_progress=TRUE
+~~~
+
+Shell:
+
+~~~
+bash$ gridlabd -D keep_progress=TRUE
+bash$ gridlabd --define keep_progress=TRUE
+~~~
+
+# Description
+
+Keep progress enable flag. By default this is `FALSE`, which indicates that only `CR` is output between progress 
+reports.  If `TRUE`, then `CRLF` is output.
+
+# Example
+
+~~~
+#set keep_progress=TRUE
+~~~

--- a/docs/Global/Keep_progress.md
+++ b/docs/Global/Keep_progress.md
@@ -18,10 +18,17 @@ bash$ gridlabd --define keep_progress=TRUE
 # Description
 
 Keep progress enable flag. By default this is `FALSE`, which indicates that only `CR` is output between progress 
-reports.  If `TRUE`, then `CRLF` is output.
+reports.  If `TRUE`, then `CRLF` is output. Note, disabling the `supress_repeat_messages` flag allows the display of every line of progress.
 
 # Example
 
 ~~~
+#set supress_repeat_messages=FALSE
 #set keep_progress=TRUE
 ~~~
+
+# See also
+
+* [[/Global/Suppress_repeat_messages]]
+
+

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -322,6 +322,7 @@ DEPRECATED static struct s_varmap {
 	{"glm_save_options", PT_set, &global_glm_save_options, PA_PUBLIC, "options to control GLM file save format", gso_keys},
 	{"filesave_options", PT_set, &global_filesave_options, PA_PUBLIC, "control elements saved on output", fso_keys},
 	{"ignore_errors", PT_bool, &global_ignore_errors, PA_PUBLIC, "disable exit on error behavior"},
+	{"keep_progress", PT_bool, &global_keep_progress, PA_PUBLIC, "keep each progress line"},
 	/* add new global variables here */
 };
 

--- a/gldcore/output.cpp
+++ b/gldcore/output.cpp
@@ -760,7 +760,7 @@ int output_progress()
 	}
 	else if ( global_keep_progress )
 	{
-		res = output_message("%sProcessing %s (%.1f%% done)...", prefix, ts, fractional_progress*100);
+		res = output_raw("%sProcessing %s (%.1f%% done)...\n", prefix, ts, fractional_progress*100);
 	}
 	else if ( global_show_progress )
 	{

--- a/gldcore/output.cpp
+++ b/gldcore/output.cpp
@@ -755,7 +755,7 @@ int output_progress()
 
 	if ( redirect.progress )
 	{
-		res = fprintf(redirect.progress,"%s\n",ts);
+		res = fprintf(redirect.progress,"%s,%.3f\n",ts,fractional_progress);
 		fflush(redirect.progress);
 	}
 	else if ( global_keep_progress )

--- a/gldcore/scripts/gridlabd-weather
+++ b/gldcore/scripts/gridlabd-weather
@@ -10,7 +10,7 @@ fi
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 COUNTRY="US"
-GITUSER=dchassin
+GITUSER=slacgismo
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
 SVNLSOPTIONS="--config-option=servers:global:http-timeout=60 --non-interactive -r1"

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -93,20 +93,17 @@ public:
 		{
 			IN_MYCONTEXT output_debug("processing %s", ptr);
 		}
+		else if ( global_keep_progress )
+		{
+			output_message("Processing %s...",ptr); 
+		}
 		else
 		{
 			static size_t len = 0;
 			char blank[1024];
 			memset(blank,32,len);
 			blank[len]='\0';
-			if ( global_keep_progress )
-			{
-				len = output_raw("Processing %s...\n",ptr)-len; 
-			}
-			else
-			{
-				len = output_raw("%s\rProcessing %s...\r",blank,ptr)-len; 
-			}
+			len = output_raw("%s\rProcessing %s...\r",blank,ptr)-len; 
 		}
 		wlock(); 
 		n_files++;

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -99,7 +99,14 @@ public:
 			char blank[1024];
 			memset(blank,32,len);
 			blank[len]='\0';
-			len = output_raw("%s\rProcessing %s...\r",blank,ptr)-len; 
+			if ( global_keep_progress )
+			{
+				len = output_raw("Processing %s...\n",ptr)-len; 
+			}
+			else
+			{
+				len = output_raw("%s\rProcessing %s...\r",blank,ptr)-len; 
+			}
 		}
 		wlock(); 
 		n_files++;


### PR DESCRIPTION
This PR fixes issue #569.

## Current issues
None

## Code changes
- [X] Add percent done to progress report output
- [X] Add validate `keep_progress` usage
- [X] Add access to `keep_progress` global

## Documentation changes
- [X] Document `keep_progress` global

## Test and Validation Notes
Both running progress and validate output now support `-D keep_progress=TRUE`.
