### PR TITLE
Fix heat index calculation

### DIFF
--- a/climate/climate.cpp
+++ b/climate/climate.cpp
@@ -2313,7 +2313,7 @@ void climate::update_heatindex(void)
 	double RH = humidity * 100;
 
 	// see https://www.wpc.ncep.noaa.gov/html/heatindex_equation.shtml for details
-	if ( heat_index < 80 )
+	if ( T < 80 )
 	{
 		heat_index = 0.75*T + 0.25*( 61.0+1.2*(T-68.0)+0.094*RH);
 	}


### PR DESCRIPTION
This PR fixed issues #571.

## Current issues
None

## Code changes
1. change variable used in heat index calculation test to conform to NOAA specifications

## Documentation changes
None

## Test and Validation Notes
- [x] the heat index calculation needs a proper self-test, e.g., `climate/autotest/test_heat_index.glm`
