### PR TITLE
Fix make clean

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,7 +261,7 @@ clean-local: python-clean
 	@(cd $(top_srcdir) ; build-aux/clean_dirs.sh)
 
 distclean-local: python-clean
-	@(cd $(top_srcdir) ; build-aux/clean_dirs.sh)
+	@(cd $(top_srcdir) ; build-aux/clean_dirs.sh --depends)
 	@rm -rf $(top_srcdir)/autom4te.cache
 	@rm -f $(top_srcdir)/aclocal.m4 
 	@rm -f $(top_srcdir)/autoscan.log

--- a/build-aux/clean_dirs.sh
+++ b/build-aux/clean_dirs.sh
@@ -8,10 +8,12 @@ for i in `find . -type d -name autotest -print`; do
 	done
 done
 
-for f in `find . -type d -name '.deps' -print`; do
-	rm -rf $f
-done
-
 for f in `find . -type d -name '.libs' -print`; do
 	rm -rf $f
 done
+
+if [ "$1" == "--depends" ]; then
+	for f in `find . -type d -name '.deps' -print`; do
+		rm -rf $f
+	done
+fi


### PR DESCRIPTION
This PR addresses issue(s) #456.

## Current issues
None

## Code changes
1. Fixed `makefile` and `build_aux/clean_dirs.sh`

## Documentation changes
None

## Test and Validation Notes
None
