### PR TITLE
Add make docker target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -316,6 +316,13 @@ reconfigure: distclean
 reconfigure-debug: distclean
 	autoreconf -isf && ./configure 'CXXFLAGS=-O0 -g'
 
+docker: $(PREFIX)/docker.img
+
+$(PREFIX)/docker.img: docker/Dockerfile Makefile
+	docker build -f docker/Dockerfile -t $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest --build-arg BRANCH=$(PACKAGE_BRANCH) docker
+	mkdir -p $(PREFIX)
+	docker save -o $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest $(PREFIX)/docker.img
+
 system: install
 	$(DESTDIR)$(bindir)/gridlabd version set
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -321,7 +321,7 @@ docker: $(PREFIX)/docker.img
 $(PREFIX)/docker.img: docker/Dockerfile Makefile
 	docker build -f docker/Dockerfile -t $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest --build-arg BRANCH=$(PACKAGE_ORIGIN) docker
 	mkdir -p $(prefix)
-	docker save -o $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest $(prefix)/docker.img
+	docker save $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest -o $(prefix)/docker.img
 
 system: install
 	$(DESTDIR)$(bindir)/gridlabd version set

--- a/Makefile.am
+++ b/Makefile.am
@@ -319,9 +319,9 @@ reconfigure-debug: distclean
 docker: $(PREFIX)/docker.img
 
 $(PREFIX)/docker.img: docker/Dockerfile Makefile
-	docker build -f docker/Dockerfile -t $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest --build-arg BRANCH=$(PACKAGE_BRANCH) docker
-	mkdir -p $(PREFIX)
-	docker save -o $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest $(PREFIX)/docker.img
+	docker build -f docker/Dockerfile -t $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest --build-arg BRANCH=$(PACKAGE_ORIGIN) docker
+	mkdir -p $(prefix)
+	docker save -o $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest $(prefix)/docker.img
 
 system: install
 	$(DESTDIR)$(bindir)/gridlabd version set

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ m4_define([pkgbranch],  sbuild_m4_esyscmd_s([build-aux/version.sh --branch]))
 m4_define([gitversion], sbuild_m4_esyscmd_s([build-aux/version.sh --git]))
 m4_define([versionname], sbuild_m4_esyscmd_s([build-aux/version.sh --name]))
 m4_define([pkginstall], sbuild_m4_esyscmd_s([build-aux/version.sh --install]))
+m4_define([pkgorigin],sbuild_m4_esyscmd_s([git rev-parse --abbrev-ref HEAD]))
 
 AC_PREREQ([2.63])
 AC_INIT(pkgname, pkgversion, [gridlabd@gmail.com], pkg)
@@ -69,6 +70,7 @@ AC_CANONICAL_HOST
 # Export version info as autoconf variables
 AC_SUBST(PACKAGE_BASEVERSION, pkgversion)
 AC_SUBST(PACKAGE_BRANCH, pkgbranch)
+AC_SUBST(PACKAGE_ORIGIN, pkgorigin)
 AC_SUBST(PACKAGE_REVISION, gitversion)
 
 AC_PREFIX_DEFAULT(pkginstall)
@@ -574,7 +576,7 @@ AC_MSG_RESULT([
 
     Package: .................... $PACKAGE 
     Version: .................... $VERSION
-    Branch: ..................... $BRANCHNAME
+    Branch: ..................... $PACKAGE_ORIGIN
     Install prefix: ............. ${DSTDIR/^$PWD/.}
 
   Dependencies:


### PR DESCRIPTION
This PR adds a new target to make the docker image.

## Current issues
None

## Code changes
- [x] Add new targets for docker images.

## Documentation changes
None

## Test and Validation Notes
Use `make docker` to build the docker image on the local system. The image name is `gridlabd/<version>-<branch>:latest`.  Use `gridlabd --docker enable gridlabd/<version>-<branch>:latest` to switch from local install to docker image.
