### PR TITLE
Fix info command line option

### DIFF
--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -494,7 +494,7 @@ GLOBAL int global_mainloopstate INIT(MLS_INIT); /**< main loop processing state 
 GLOBAL TIMESTAMP global_mainlooppauseat INIT(TS_NEVER); /**< time at which to pause main loop */
 
 /* Variable:  */
-GLOBAL char global_infourl[1024] INIT("http://gridlab-d.shoutwiki.com/w/index.php?title=Special%3ASearch&fulltext=Search&search="); /**< URL for info calls */
+GLOBAL char global_infourl[1024] INIT("http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&search="); /**< URL for info calls */
 
 /* Variable:  */
 GLOBAL char global_hostname[1024] INIT("localhost"); /**< machine hostname */


### PR DESCRIPTION
This PR addresses issue(s) #599.

## Current issues
1. The search only work if the user is logged into to the docs-browser page. This is a requirement of using GitHub as the document source.
1. The search only looks at the master branch regardless of what branch is current checked out.  This is a requirement of using GitHub as the search engine.

## Code changes
- [x] Changed initialization of `global_infourl`.

## Documentation changes
None

## Test and Validation Notes
None
