### PR TITLE
Add support for ZIP input and output

### DIFF
--- a/docs/Command/Automatic export conversion.md
+++ b/docs/Command/Automatic export conversion.md
@@ -14,6 +14,12 @@ The GridLAB-D GLM save routines will automatically save output to files that hav
 
 The data saved in the file may be controlled using [[/Global/Filesave_options]].
 
+## Supported File Formats
+
+### ZIP
+
+ZIP files are exported using the `-o filename.zip` command line option.  When output to ZIP is used, all the files in the folder in which contains the JSON output file will be stored in the resulting ZIP file. If the ZIP file is already present, it will be overwritten.
+
 ## Converter Implementation
 
 Converters use the following calling syntax:

--- a/docs/Command/Automatic export conversion.md
+++ b/docs/Command/Automatic export conversion.md
@@ -30,6 +30,14 @@ bash$ python3 json2<ext>.py -i filename.glm -o filename.<ext>
 
 where `<ext>` is the extension that is supported.
 
+# Examples
+
+Run `my-model.glm` and store all files in `my-model.zip`
+
+~~~
+bash$ gridlabd my-model.glm -o my-model.zip
+~~~
+
 # Caveats
 
 When a converter is run, the output file is stored in JSON file by the same name, but with the `.json` extension instead.  If the JSON file already exists, **the existing JSON file may be overwritten**.

--- a/docs/Command/Automatic import conversion.md
+++ b/docs/Command/Automatic import conversion.md
@@ -10,6 +10,12 @@ bash$ gridlabd <filename>.<ext>
 
 The GridLAB-D GLM loader will automatically convert to GLM format all input files that have "known" extensions.  A known extension is one for which a Python converter exists in GLPATH. Python converters use the naming convention `<ext>2glm.py` and are normally stored in the GridLAB-D `shared` folder.
 
+## Support File Formats
+
+### ZIP
+
+When a ZIP file is specified as an input file, the contents of the archive are extracted into the same folder as the ZIP file, and the corresponding GLM file is run. If the GLM file is already present, it will be overwritten.
+
 ## Converter Development
 
 Converters use the following calling syntax:

--- a/docs/Command/Automatic import conversion.md
+++ b/docs/Command/Automatic import conversion.md
@@ -26,6 +26,14 @@ bash$ python3 <ext>2glm.py -i filename.<ext> -o filename.glm
 
 where `<ext>` is the extension that is supported.
 
+# Examples
+
+Extract files in `my-model.zip` and run `my-model.glm`:
+
+~~~
+bash$ gridlabd my-model.zip
+~~~
+
 # Caveats
 
 When a converter is run, the input file is converted in stored in a GLM file by the same name, but with the `.glm` extension instead.  If the GLM file already exists, **the existing GLM file may be overwritten**.

--- a/gldcore/converters/Makefile.mk
+++ b/gldcore/converters/Makefile.mk
@@ -9,3 +9,5 @@ dist_pkgdata_DATA += gldcore/converters/csv-ami2glm-ceus.py
 dist_pkgdata_DATA += gldcore/converters/csv-scada2glm-rbsa.py
 dist_pkgdata_DATA += gldcore/converters/csv-scada2glm-ceus.py
 dist_pkgdata_DATA += gldcore/converters/csv-ica2glm-ica.py
+dist_pkgdata_DATA += gldcore/converters/zip2glm.py
+dist_pkgdata_DATA += gldcore/converters/json2zip.py

--- a/gldcore/converters/json2zip.py
+++ b/gldcore/converters/json2zip.py
@@ -1,0 +1,62 @@
+import json 
+import os 
+import sys, getopt
+import zipfile as zipf
+
+config = {"input":"json","output":"zip"}
+
+method = zipf.ZIP_STORED
+# options:
+# ZIP_STORED (default)
+# ZIP_DEFLATED (requires zlib)
+# ZIP_BZIP2 (requires bz2)
+# ZIP_LZMA (requires lzma)
+
+def help():
+	return """json2zip.py -i <input-file> -o <output-file>
+    -c|--config              output converter configuration data
+    -h|--help                output this help
+    -i|--ifile <filename>    [REQUIRED] JSON input file
+    -o|--ofile <filename>    [OPTIONAL] ZIP output file name
+"""
+
+def main():
+	input_name = None
+	output_name = None
+	try : 
+		opts, args = getopt.getopt(sys.argv[1:],"chi:o:",["config","help","ifile=","ofile="])
+	except getopt.GetoptError:
+		sys.exit(2)
+	if not opts : 
+		print('Missing command arguments')
+		sys.exit(2)
+	for opt, arg in opts:
+		if opt in ("-c","--config"):
+			print(config)
+			sys.exit(0)
+		elif opt in ("-h","--help"):
+			print(help())
+			sys.exit(0)
+		elif opt in ("-i", "--ifile"):
+			input_name = arg
+		elif opt in ("-o", "--ofile"):
+			output_name = arg
+		else:
+			raise Exception("option '{opt}={arg}' is not valid");
+
+	if input_name == None:
+		raise Exception("input filename not specified")
+	if input_name[-5:] != ".json":
+		raise Exception(f"input file '{input_name}' is not a JSON file")
+	output_name = input_name[0:-5] + ".zip"
+	path = os.path.dirname(os.path.abspath(input_name))
+	os.chdir(path)
+	dirs = os.listdir(".")
+	if dirs:
+		zip = zipf.ZipFile(output_name,"w")
+		for file in dirs:
+			if file != output_name:
+				zip.write(file)
+	
+if __name__ == '__main__':
+	main()

--- a/gldcore/converters/zip2glm.py
+++ b/gldcore/converters/zip2glm.py
@@ -1,0 +1,52 @@
+import json 
+import os 
+import sys, getopt
+import zipfile as zipf
+
+config = {"input":"zip","output":"glm"}
+
+def help():
+	return """zip2glm.py -i <input-file> -o <output-file>
+    -c|--config              output converter configuration data
+    -h|--help                output this help
+    -i|--ifile <filename>    [REQUIRED] ZIP input file
+    -o|--ofile <filename>    [OPTIONAL] GLM output file name
+"""
+
+def main():
+	input_name = None
+	output_name = None
+	try : 
+		opts, args = getopt.getopt(sys.argv[1:],"chi:o:",["config","help","ifile=","ofile="])
+	except getopt.GetoptError:
+		sys.exit(2)
+	if not opts : 
+		print('Missing command arguments')
+		sys.exit(2)
+	for opt, arg in opts:
+		if opt in ("-c","--config"):
+			print(config)
+			sys.exit(0)
+		elif opt in ("-h","--help"):
+			print(help())
+			sys.exit(0)
+		elif opt in ("-i", "--ifile"):
+			input_name = arg
+		elif opt in ("-o", "--ofile"):
+			output_name = arg
+		else:
+			raise Exception("option '{opt}={arg}' is not valid");
+
+	if input_name == None:
+		raise Exception("input filename not specified")
+	zip = zipf.ZipFile(input_name,mode="r");
+	if output_name == None:
+		output_name = input_name[0:-4] + ".glm"
+	print(output_name)
+	print(zip.namelist())
+	if not output_name in zip.namelist():
+		raise Exception(f"output filename '{output_name}' not in '{input_name}'")
+	zip.extractall(path=".")
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
This PR adds support for ZIP input and output converters.

## Current issues
None

## Code changes
- [x] Add `gldcore/converters/zip2glm.py` for input automatic conversion
- [x] Add `gldcore/converters/json2zip.py` for output automatic conversion
- [x] Add new converters to `gldcore/converters/Makefile.mk`

## Documentation changes
None, but maybe it's time to think about how to document all the various input and output formats now supported by the automatic converters.

## Test and Validation Notes
1. Choose a folder with a GLM and support files.  Run `gridlabd file.glm -o file.zip`.  After the run is complete, the ZIP file should be created.
2. Move the ZIP to a new folder. Run `gridlabd file.zip`.  This should repeat the run.
