### PR TITLE
Add gldmake script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -329,9 +329,9 @@ $(PREFIX)/docker.img: docker/Dockerfile Makefile
 	docker save $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest -o $(prefix)/docker.img
 
 system: install
-	@echo "Setting $$(./build-aux --install) to the current system version"
+	@echo "Setting $$(./build-aux/version.sh --install) to the current system version"
 	@$(DESTDIR)$(bindir)/gridlabd version set
-	@if [ ! "$$(gridlabd --version=install)" == "$$(./build-aux --install)" ]; then \
+	@if [ ! "$$(gridlabd --version=install)" == "$$(./build-aux/version.sh --install)" ]; then \
 		echo '*** WARNING : build and install versions differ ***'; \
 	fi
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -296,7 +296,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool > /dev/null
 
 install-exec-hook: python-install index
-	cp ${top_srcdir}/{COPYRIGHT,LICENSE} $(prefix)
+	@cp ${top_srcdir}/{COPYRIGHT,LICENSE} $(prefix)
 	@echo ""
 	@echo "Install complete. Here are some useful commands now:"
 	@echo ""
@@ -306,7 +306,7 @@ install-exec-hook: python-install index
 	@echo "To run this version directly without using the command path:"
 	@echo "  $(DESTDIR)$(bindir)/gridlabd"
 	@echo ""
-	@echo "To make this version the default for all user on this system:"
+	@echo "To make this version the default for all users on this system:"
 	@echo "  $(DESTDIR)$(bindir)/gridlabd version set"
 	@echo ""
 
@@ -320,16 +320,20 @@ docker: $(PREFIX)/docker.img
 
 docker-debug: docker/Dockerfile Makefile
 	docker build -f docker/Dockerfile -t $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest --build-arg BRANCH=$(PACKAGE_ORIGIN) --build-arg RUN_VALIDATION=no docker
-	mkdir -p $(prefix)
+	@mkdir -p $(prefix)
 	docker save $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest -o $(prefix)/docker.img
 
 $(PREFIX)/docker.img: docker/Dockerfile Makefile
 	docker build -f docker/Dockerfile -t $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest --build-arg BRANCH=$(PACKAGE_ORIGIN) --build-arg RUN_VALIDATION=yes docker
-	mkdir -p $(prefix)
+	@mkdir -p $(prefix)
 	docker save $(PACKAGE)/$(PACKAGE_VERSION)-$(PACKAGE_BRANCH):latest -o $(prefix)/docker.img
 
 system: install
-	$(DESTDIR)$(bindir)/gridlabd version set
+	@echo "Setting $$(./build-aux --install) to the current system version"
+	@$(DESTDIR)$(bindir)/gridlabd version set
+	@if [ ! "$$(gridlabd --version=install)" == "$$(./build-aux --install)" ]; then \
+		echo '*** WARNING : build and install versions differ ***'; \
+	fi
 
 index: weather library template
 

--- a/gldmake
+++ b/gldmake
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# This script will automatically choose the correct build process 
+# given the status of the source tree.
+#
+# Option 1: new build --> autoreconf -isf && ./configure && make ...
+#
+# Option 2: recent build --> make ...
+#
+# Option 3: old build --> make reconfigure && make ...
+#
+
+SRC_BRANCH=$(./build-aux/version.sh --branch)
+SRC_NUMBER=$(./build-aux/version.sh --number)
+
+DST_BRANCH=$(gridlabd --version=branch)
+DST_NUMBER=$(gridlabd --version=number)
+
+if [ ! -f Makefile ]; then
+	COMMAND='autoreconf -isf && ./configure && make'
+elif [ "$SRC_BRANCH" == "$DST_BRANCH" -a "$SRC_NUMBER" == "$DST_NUMBER" ]; then
+	COMMAND='make'
+else
+	COMMAND='make reconfigure && make'
+fi
+
+echo "$COMMAND $*" | bash

--- a/gldmake
+++ b/gldmake
@@ -17,11 +17,15 @@ DST_BRANCH=$(gridlabd --version=branch)
 DST_NUMBER=$(gridlabd --version=number)
 
 if [ ! -f Makefile ]; then
+	echo "$0: no makefile --> first time build"
 	COMMAND='autoreconf -isf && ./configure && make'
 elif [ "$SRC_BRANCH" == "$DST_BRANCH" -a "$SRC_NUMBER" == "$DST_NUMBER" ]; then
+	echo "$0: build and install versions match --> simple rebuild"
 	COMMAND='make'
 else
+	echo "$0: build and install versions do not match --> full rebuild"
 	COMMAND='make reconfigure && make'
 fi
 
+echo "$COMMAND $*"
 echo "$COMMAND $*" | bash


### PR DESCRIPTION
This PR addresses subtle but annoying `make` problems.

## Current issues
None

## Code changes
- [x] Add `gldmake` script to automatically run the correct build sequence
- [x] Fix `Makefile.am` so it warns if the build and install versions do not match after `system` target is built

## Documentation changes
None

## Test and Validation Notes
There are three possibilities handled by `gldmake`.
1. There is no `Makefile`: this requires a new build
2. The build and install versions are the same: this requires a simple build
3. The build and install versions differ: this requires a full rebuild
