### PR TITLE
Fix object iterator initialization bug

### DIFF
--- a/gldcore/object.cpp
+++ b/gldcore/object.cpp
@@ -3258,16 +3258,14 @@ PROPERTY *object_get_property_by_addr(OBJECT *obj, void *addr, bool full)
 
 PROPERTY *object_get_first_property(OBJECT *obj, bool full)
 {
-	for ( CLASS *oclass = obj->oclass ; 
-		oclass != NULL ; 
-		oclass = ( full == true ? oclass->parent : NULL ) )
-	{	
-		if ( oclass->pmap != NULL )
-		{
-			return obj->oclass->pmap;
-		}
+	CLASS *oclass = obj->oclass;
+	PROPERTY *prop = oclass->pmap;
+	while ( prop == NULL && full && oclass->parent != NULL )
+	{
+		oclass = oclass->parent;
+		prop = oclass->pmap;
 	}
-	return NULL;
+	return prop;
 }
 
 PROPERTY *object_get_next_property(PROPERTY *prop, bool full)


### PR DESCRIPTION
This PR fixed issue #606.

## Current issues
None

## Code changes
- [x] Rewrite `gldcore/object.cpp:object_get_first_property()` so it iterates correctly through parent classes.

## Documentation changes
None

## Test and Validation Notes
This is a very serious bug and it's surprising it was not noticed earlier. Evidently there is no validation test that verifies how the object iterator works when `full=true`.
