### PR TITLE
Fix exit code handlers

### DIFF
--- a/docs/GLM/Macro/On_exit.md
+++ b/docs/GLM/Macro/On_exit.md
@@ -8,7 +8,9 @@
 
 # Description
 
-When this macro is encountered, an exit handler is added when the simulation exits with `exitcode`.  Exit handlers are run only when the simulation has completed all post simulation processing and is about to exit.  The exit process is suspended until the result of the exit handler(s) are obtained.
+When this macro is encountered, an exit handler is added when the simulation exits with `exitcode`.  Exit handlers are run only when the simulation has completed all post simulation processing and is about to exit.  The exit process is suspended until the result of the exit handler(s) are obtained. The exit code of the exit handler is then used as the exit code of the simulation.  
+
+If multiple exit handlers are specified, they will be called in the order in which they are listed. If an exit handler returns a non-zero exit code, the exit handling sequence is abandoned and the exit code of the simulation is the exit code of the failed handler.  If no errors are encountered, the exit code 0 is used. 
 
 When the value `-1` is used for the `exitcode`, any non-zero exit condition will trigger the exit handler.
 

--- a/gldcore/autotest/test_on_exit_0_err.glm
+++ b/gldcore/autotest/test_on_exit_0_err.glm
@@ -1,0 +1,5 @@
+// this causes the error to be ignored
+#on_exit 0 exit 0
+
+//#option verbose
+#error this causes an error that is not ignored

--- a/gldcore/autotest/test_on_exit_1.glm
+++ b/gldcore/autotest/test_on_exit_1.glm
@@ -1,0 +1,3 @@
+// this causes the error to be ignored
+#on_exit -1 exit 0
+#error this causes an error that should be ignored

--- a/gldcore/autotest/test_on_exit_5.glm
+++ b/gldcore/autotest/test_on_exit_5.glm
@@ -1,0 +1,3 @@
+// this causes the error to be ignored
+#on_exit 5 exit 0
+#error this causes an error that should be ignored

--- a/gldcore/autotest/test_on_exit_err.glm
+++ b/gldcore/autotest/test_on_exit_err.glm
@@ -1,0 +1,2 @@
+// this causes an error when no error has been detected
+#on_exit 0 exit 5

--- a/gldcore/main.h
+++ b/gldcore/main.h
@@ -144,7 +144,7 @@ public:
 
 		Returns: exit code of first failed call, or 0 if all calls succeeded
 	 */
-	int run_on_exit();
+	int run_on_exit(int return_code = 0);
 
 private:	// private methods
 	void set_global_browser(const char *path = NULL);

--- a/gldcore/scripts/gridlabd-weather
+++ b/gldcore/scripts/gridlabd-weather
@@ -13,7 +13,6 @@ COUNTRY="US"
 GITUSER=slacgismo
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
-SVNLSOPTIONS="--config-option=servers:global:http-timeout=60 --non-interactive -r1"
 DATADIR="$GLD_ETC/weather/$COUNTRY"
 
 # load the configuration (if any)
@@ -33,7 +32,6 @@ function config()
 		echo "GITBRANCH=\"$GITBRANCH\""
 		echo "CACHEDIR=\"$CACHEDIR\""
 		echo "DATADIR=\"$DATADIR\""
-		echo "SVNLSOPTIONS=\"$SVNLSOPTIONS\""
 	elif [ "$1" == "reset" ]; then
 		rm -f $CONFIGFILE || (echo "ERROR: unable to reset $CONFIGFILE" > /dev/stderr; exit 1)
 	elif [ "$1" == "set" -a $# == 3 ]; then
@@ -71,7 +69,8 @@ function fetch_index()
 	fi
 	if [ ! -f $INDEX -o -z $INDEX ]; then
 		echo -n "Downloading ${GITBRANCH} index of $COUNTRY weather archive from ${GITPROJ}... "
-		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX || rm -f $INDEX
+#		svn $SVNLSOPTIONS ls $GITPROJ/branches/$GITBRANCH/$COUNTRY | grep '.tmy3$' > $INDEX || rm -f $INDEX
+		curl -s $GITHUBUSERCONTENT/$GITUSER/$GITREPO/$GITBRANCH/$COUNTRY/.index >$INDEX
 		echo $(wc -l $INDEX | sed -e 's/ \+/ /g;s/^ //' | cut -f1 -d' ') "weather files found"
 	fi
 	if [ ! -f $INDEX ]; then


### PR DESCRIPTION
This PR fixes issue #611.

## Current issues
None

## Code changes
1. Change `on_exit` handler implementation in `gldcore/main.cpp` and `gldcore/main.h`.
2. Change how weather index is downloaded so it doesn't cause errors when `svn ls` fails.

## Documentation changes
- [/GLM/Macro/On_exit](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-fix-exit-codes&folder=/GLM/Macro&doc=/GLM/Macro/On_exit.md)

## Test and Validation Notes
1. Add four `on_exit` tests to `gldcore/autotest` 
