### PR TITLE
Fix double unit string output

### DIFF
--- a/gldcore/class.cpp
+++ b/gldcore/class.cpp
@@ -462,14 +462,7 @@ int class_property_to_string(PROPERTY *prop, /**< the property type */
 	}
 	else if ( prop->ptype > _PT_FIRST && prop->ptype < _PT_LAST )
 	{
-		int rv = property_write(prop,addr,value,size);
-		if ( rv > 0 && prop->unit != 0 )
-		{
-			strcat(value+rv," ");
-			strcat(value+rv+1,prop->unit->name);
-			rv += (int)(1+strlen(prop->unit->name));
-		}
-		return rv;
+		return property_write(prop,addr,value,size);
 	}
 	else
 	{

--- a/gldcore/convert.cpp
+++ b/gldcore/convert.cpp
@@ -260,6 +260,12 @@ int convert_from_complex(char *buffer, /**< pointer to the string buffer */
 	{
 		count = sprintf(temp,global_complex_format,v->Re()*scale,v->Im()*scale,v->Notation()?v->Notation():'i');
 	}
+
+	if ( prop->unit )
+	{
+		count += sprintf(temp+count," %s",prop->unit->name);
+	}
+
 	if ( count < size - 1 )
 	{
 		memcpy(buffer, temp, count);


### PR DESCRIPTION
This PR fixed issue #627 

## Current issues
None

## Code changes
- [x] Removed unneeded unit copy from general property conversion
- [x] Added missing unit copy to complex property conversion

## Documentation changes
None

## Test and Validation Notes
None
