### PR TITLE
Add support for gridlabd.rc file

### DIFF
--- a/docs/Install/Gridlabd_rc.md
+++ b/docs/Install/Gridlabd_rc.md
@@ -1,0 +1,28 @@
+[[/Install/Gridlabd_rc]] - GridLAB-D run control file
+
+# Synopsis
+
+~~~
+/usr/local/share/gridlabd/gridlabd.rc
+$HOME/.gridlabd/gridlabd.rc
+./gridlabd.rc
+~~~
+
+# Description
+
+The `gridlabd.rc` file can be used to execute commands that alter the environment in which gridlabd.bin runs.  There are three locations where this file may be deployed. They will be run this order
+
+1. `/usr/local/share/gridlabd/gridlabd.rc`
+2. `$HOME/.gridlabd/gridlabd.rc`
+3. `./gridlabd.rc`
+
+# Caveat
+
+Some models require the ability to generate and load a dynamic link library at runtime from the local folder.  In such cases it is useful to allow the system
+to load library from the local folder.  This is done using the command
+
+~~~
+export LD_LIBRARY_PATH=.
+~~~
+
+which is placed in the system run control file.  However, this also present a security vulnerability if models can be run using root privileges.  In such cases it is strongly recommended that this line be commented out in the system RC file, and added to the local RC file where the feature is required.

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -354,7 +354,7 @@ elif test "x$1" = "xvalgrind" ; then :
   exit 0
 fi
 
-if text -x "${pkgdatadir}/gridlabd.rc"; then :
+if test -x "${pkgdatadir}/gridlabd.rc"; then :
   source ${pkgdatadir}/gridlabd.rc
 fi
 

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -354,7 +354,7 @@ elif test "x$1" = "xvalgrind" ; then :
   exit 0
 fi
 
-if test -x "${pkgdatadir}/gridlabd.rc"; then :
+if test -f "${pkgdatadir}/gridlabd.rc"; then :
   source ${pkgdatadir}/gridlabd.rc
 fi
 

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -354,6 +354,10 @@ elif test "x$1" = "xvalgrind" ; then :
   exit 0
 fi
 
+if text -x "${pkgdatadir}/gridlabd.rc"; then :
+  source ${pkgdatadir}/gridlabd.rc
+fi
+
 if test -x "${bindir}/gridlabd-$1"; then :
   "${bindir}/gridlabd"-$@
 else

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -97,7 +97,7 @@ elif test "x$1" = "xvalgrind" ; then :
   exit 0
 fi
 
-AS_IF([test -x "${pkgdatadir}/gridlabd.rc"],
+AS_IF([test -f "${pkgdatadir}/gridlabd.rc"],
   [source ${pkgdatadir}/gridlabd.rc],
   [])
 

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -97,6 +97,10 @@ elif test "x$1" = "xvalgrind" ; then :
   exit 0
 fi
 
+AS_IF([text -x "${pkgdatadir}/gridlabd.rc"],
+  [source ${pkgdatadir}/gridlabd.rc],
+  [])
+
 AS_IF([test -x "${bindir}/gridlabd-$1"],
   ["${bindir}/gridlabd"-$@],
   ["$bindir/gridlabd.bin" "$@"])

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -97,7 +97,7 @@ elif test "x$1" = "xvalgrind" ; then :
   exit 0
 fi
 
-AS_IF([text -x "${pkgdatadir}/gridlabd.rc"],
+AS_IF([test -x "${pkgdatadir}/gridlabd.rc"],
   [source ${pkgdatadir}/gridlabd.rc],
   [])
 

--- a/gldcore/rt/Makefile.mk
+++ b/gldcore/rt/Makefile.mk
@@ -10,6 +10,7 @@ dist_pkgdata_DATA += gldcore/rt/gridlabd.htm
 dist_pkgdata_DATA += gldcore/rt/gridlabd.jpg
 dist_pkgdata_DATA += gldcore/rt/gridlabd.js
 dist_pkgdata_DATA += gldcore/rt/gridlabd.syn
+dist_pkgdata_DATA += gldcore/rt/gridlabd.rc
 dist_pkgdata_DATA += gldcore/rt/mingw.conf
 dist_pkgdata_DATA += gldcore/rt/capacitor_b.png
 dist_pkgdata_DATA += gldcore/rt/capacitor_g.png

--- a/gldcore/rt/gridlabd.rc
+++ b/gldcore/rt/gridlabd.rc
@@ -19,7 +19,7 @@
 # runtime libraries and load-time parser hooks are required.
 #
 
-#export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:-/usr/local/lib/gridlabd}
+export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:-/usr/local/lib/gridlabd}
 
 #
 # Run the user's RC file, if found

--- a/gldcore/rt/gridlabd.rc
+++ b/gldcore/rt/gridlabd.rc
@@ -1,0 +1,34 @@
+# gldcore/rt/gridlabd.rc
+#
+# Copyright (C) 2020 Regents of the Leland Stanford Junior University
+#
+# Author: DP Chassin
+#
+# This file can be used to executed commands that alter the environment in
+# which gridlabd.bin runs.  There are three locations where this file
+# may be deployed. They will be run this order
+#   /usr/local/share/gridlabd/gridlabd.rc
+#   $HOME/.gridlabd.rc
+#   ./gridlabd.rc
+#
+
+#
+# Permit dynamic libraries to be loaded from the current folder
+#
+# WARNING: this is a security loophole, but it is necessary if user-defined
+# runtime libraries and load-time parser hooks are required.
+#
+
+#export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:-/usr/local/lib/gridlabd}
+
+#
+# Run the user's RC file, if found
+#
+
+[ -x $HOME/gridlabd.rc ] && source $HOME/gridlabd.rc
+
+#
+# Run the local RC file, if found
+#
+
+[ -x ./gridlabd.rc ] && source ./gridlabd.rc 

--- a/gldcore/rt/gridlabd.rc
+++ b/gldcore/rt/gridlabd.rc
@@ -4,11 +4,11 @@
 #
 # Author: DP Chassin
 #
-# This file can be used to executed commands that alter the environment in
+# This file can be used to execute commands that alter the environment in
 # which gridlabd.bin runs.  There are three locations where this file
 # may be deployed. They will be run this order
 #   /usr/local/share/gridlabd/gridlabd.rc
-#   $HOME/.gridlabd.rc
+#   $HOME/.gridlabd/gridlabd.rc
 #   ./gridlabd.rc
 #
 
@@ -25,7 +25,7 @@ export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:-/usr/local/lib/gridlabd}
 # Run the user's RC file, if found
 #
 
-[ -x $HOME/gridlabd.rc ] && source $HOME/gridlabd.rc
+[ -x $HOME/.gridlabd/gridlabd.rc ] && source $HOME/.gridlabd/gridlabd.rc
 
 #
 # Run the local RC file, if found


### PR DESCRIPTION
This PR fixed issue #630 

## Current issues
None

## Code changes
- [x] Add support to run `gridlabd.rc` in `gridlabd` script.

## Documentation changes
- [X] [/Install/Gridlabd_rc](http://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Install&doc=/Install/Docker_rc)

## Test and Validation Notes
This fix is most noticeable on docker images when validation is run manually without first setting `LD_LIBRARY_PATH`. Two parser load tests in `gldcore` fail. After this fix, this problem should not longer occur.

- [X] Add `/usr/local/share/gridlabd/gridlabd.rc` to enable `LD_LIBRARY_PATH` to set for validation runs. 
