### PR TITLE
Fix the autotest failure due to TMY2 use instead of TMY3

### DIFF
--- a/generators/autotest/test_solar_parent_err.glm
+++ b/generators/autotest/test_solar_parent_err.glm
@@ -23,10 +23,10 @@ module powerflow{
 	default_maximum_voltage_error 1e-9;
 }
 
-
+#weather get WA-Yakima_Air_Terminal.tmy3
 object climate{
 	name MyClimate;
-	tmyfile ../WA-Seattle.tmy2;
+	tmyfile "WA-Yakima_Air_Terminal.tmy3";
 	//reader CsvReader;
 	object recorder {
 		file climate_out.csv;
@@ -74,13 +74,13 @@ object climate{
  object transformer {
 	name substation_transformer;
 	from network_node;
-	to 645;
+	to node_645;
 	phases ABCN;
 	configuration trans_config_to_feeder;
 }; 
 
 object node {     
-	name 645;     
+	name node_645;     
 	phases ABCN;     
 	voltage_A 2401.7771;     
 	voltage_B -1200.8886-2080.000j;     
@@ -93,7 +93,7 @@ object node {
 object transformer {
 	name CTTF_B_645;
 	phases BS;
-	from 645;
+	from node_645;
 	to tn_B_645;
 	configuration SPCT_trans;
 	object solar {


### PR DESCRIPTION
This PR addresses issue(s) of `test_err_solar_parent.glm` failing due to wrong usage of TMY2 file rather the target failure of misuse of parent object with solar object. 

## Current issues
TMY3 fix is in however this test still doesn't differentiate between bad parent error and other errors.

## Code changes
1. `generators/autotests/test_err_solar_parent.glm`

## Documentation changes
- N/A

## Test and Validation Notes
1. Run gridlabd --validate
