### PR TITLE
Add FINDFILE pseudo global

### DIFF
--- a/docs/GLM/Global/Findfile.md
+++ b/docs/GLM/Global/Findfile.md
@@ -1,0 +1,27 @@
+[[/GLM/Global/Findfile]] -- Find a file in GLPATH
+
+# Synopsis
+
+GLM:
+
+~~~
+${FINDFILE filename}
+~~~
+
+# Description
+
+The full pathname is inserted into the GLM file at the location of the global expansion.
+
+# Example
+
+The following example prints the full path name of a downloaded weather file:
+
+~~~
+#weather get Seattle
+#setenv GLPATH=${GLPATH}:${GLPATH}/weather/US
+#print ${FINDFILE WA-Seattle_Seattletacoma_Intl_A.tmy3}
+~~~
+
+# See also
+
+* [[/GLM/Global/Shell]]

--- a/docs/GLM/Global/Range.md
+++ b/docs/GLM/Global/Range.md
@@ -1,0 +1,25 @@
+[[/GLM/Global/Range]] -- Generate a range of values
+
+# Synopsis
+
+GLM:
+
+~~~
+${RANGE<delimiter><start>,<stop>,<increment>}
+~~~
+
+# Description
+
+The `RANGE` pseudoglobal generates a range of value from `<start>` to `<stop>` stepping by `<increment>` separated by `<delimiter>`. The only allowed delimiters are a single space, a single comma, a single semicolon, or a single colon.
+
+# Example
+
+The following example prints the numbers from 1 to 10 delimited by colons:
+
+~~~
+#print ${RANGE:1,10}
+~~~
+
+# See also
+
+* [[/GLM/Global/Shell]]

--- a/gldcore/autotest/test_findfile.glm
+++ b/gldcore/autotest/test_findfile.glm
@@ -1,2 +1,9 @@
+#weather get Seattle
 
-#print ${SHELL ls}
+#setenv GLPATH=${GLPATH}:${GLPATH}/weather/US
+#define file=${FINDFILE WA-Seattle_Boeing_Field_Isis.tmy3}
+#ifexist ${file}
+#print ${file} found
+#else
+#error weather file not found
+#endif

--- a/gldcore/autotest/test_findfile.glm
+++ b/gldcore/autotest/test_findfile.glm
@@ -1,0 +1,2 @@
+
+#print ${SHELL ls}

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -938,7 +938,7 @@ DEPRECATED const char *global_shell(char *buffer, int size, const char *command)
 {
 	char line[1024];
 	FILE *fp = NULL, *err = NULL;
-	if ( popens(command, &fp, &err) ) 
+	if ( popens(command, &fp, &err) < 0 ) 
 	{
 		if ( err == NULL )
 		{
@@ -952,7 +952,6 @@ DEPRECATED const char *global_shell(char *buffer, int size, const char *command)
 			}
 			pcloses(fp);
 		}
-		return NULL;
 	}
 	int pos = 0;
 	strcpy(buffer,"");
@@ -961,11 +960,13 @@ DEPRECATED const char *global_shell(char *buffer, int size, const char *command)
 		int len = strlen(line);
 		if ( pos+len >= size )
 		{
-			output_error("global_shell(buffer=0x%x,size=%d,command='%s'): result too large",buffer,size,command);
-			pclose(fp);
-			return strcpy(buffer,"");
+			output_warning("global_shell(buffer=0x%x,size=%d,command='%s'): result too large, truncating",buffer,size,command);
+			break;
 		}
-		strcpy(buffer+pos,line);
+		else
+		{
+			strcpy(buffer+pos,line);
+		}
 		pos += len;
 		if ( buffer[pos-1] == '\n' )
 			buffer[pos-1] = ' ';
@@ -981,7 +982,7 @@ DEPRECATED const char *global_range(char *buffer, int size, const char *name)
 	double step = 1.0;
 	char delim = ' ';
 	sscanf(name,"RANGE%c%lg,%lg,%lg",&delim,&start,&stop,&step);
-	if ( strchr(" ;,",delim) == NULL )
+	if ( strchr(" ;,:",delim) == NULL )
 	{
 		output_error("global_range(buffer=%x,size=%d,name='%s'): delimiter '%s' is not supported, using space",buffer,size,name,delim);
 		delim = ' ';


### PR DESCRIPTION
This PR addresses the inability to locate a file in GLPATH while loading a GLM.

## Current issues
None

## Code changes
- [x] Add `FINDFILE` pseudo global to `gldcore/globals.cpp`.
- [x] Fix asynchronous subcommand output processing.

## Documentation changes
- [x] [/GLM/Global/Findfile](http://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-add-findfile-pseudoglobal&folder=/GLM/Global&doc=/GLM/Global/Findfile.md)
- [x] [/GLM/Global/Range](http://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-add-findfile-pseudoglobal&folder=/GLM/Global&doc=/GLM/Global/Range.md)

## Test and Validation Notes
- [x] Add `gldcore/autotest/test_findfile.glm`
