### PR TITLE
Fix stoptime error check

### DIFF
--- a/gldcore/autotest/test_stoptime_err.glm
+++ b/gldcore/autotest/test_stoptime_err.glm
@@ -1,0 +1,13 @@
+clock {
+    stoptime "2019-01-01 00:00:00";
+    starttime "2020-01-01 00:00:00";
+}
+
+class test
+{
+    double x;
+}
+
+object test {
+    x 10;
+}

--- a/gldcore/exec.cpp
+++ b/gldcore/exec.cpp
@@ -500,18 +500,33 @@ int GldExec::init()
 	IN_MYCONTEXT output_verbose("using %d helper thread(s)", global_threadcount);
 
 	/* setup clocks */
-	if ( global_starttime==0 )
+	if ( global_starttime == 0 )
+	{
 		global_starttime = realtime_now();
+		if ( global_stoptime == 0 )
+		{
+			global_stoptime = TS_NEVER;
+		}
+	}
+
+	/* check the stop time */
+	if ( global_stoptime < TS_NEVER && global_stoptime < global_starttime )
+	{
+		output_error("stop time is before start time");
+		return 0;
+	}
 
 	/* set the start time */
-	//global_clock = global_starttime + local_tzoffset(global_starttime);
 	global_clock = global_starttime;
 
 	/* save locale for simulation */
 	locale_push();
 
-	if (global_init()==FAILED)
+	if ( global_init() == FAILED )
+	{
 		return 0;
+	}
+
 	return 1;
 }
 

--- a/gldcore/exec.cpp
+++ b/gldcore/exec.cpp
@@ -510,7 +510,7 @@ int GldExec::init()
 	}
 
 	/* check the stop time */
-	if ( global_stoptime < TS_NEVER && global_stoptime < global_starttime )
+	if ( global_stoptime < global_starttime )
 	{
 		output_error("stop time is before start time");
 		return 0;

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -2233,7 +2233,14 @@ int GldLoader::clock_properties(PARSER)
 	{
 		if (TERM(time_value(HERE,&tsval)))
 		{
-			global_starttime = tsval;
+			if ( tsval <= global_stoptime )
+			{
+				global_starttime = tsval;
+			}
+			else
+			{
+				syntax_error(filename,linenum,"starttime before stoptime");
+			}
 			ACCEPT;
 			goto Next;
 		}
@@ -2244,7 +2251,14 @@ int GldLoader::clock_properties(PARSER)
 	{
 		if (TERM(time_value(HERE,&tsval)))
 		{
-			global_stoptime = tsval;
+			if ( tsval >= global_starttime )
+			{
+				global_stoptime = tsval;
+			}
+			else
+			{
+				syntax_error(filename,linenum,"stoptime after starttime");
+			}
 			ACCEPT;
 			goto Next;
 		}


### PR DESCRIPTION
This PR addresses a missing check for stop time before start time. Issue #660 

## Current issues

None.

## Code changes

- [x] Block exec init when starttime > stop time
- [x] Raise syntax error in loader when start time > stop time

## Documentation changes

None.

## Test and Validation Notes

- [x] Add `gldcore/autotest/test_stoptime_err.glm`.
