### PR TITLE
Fix multithread validate segfault

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           command: |
             sudo /usr/bin/influxd run 1>/tmp/influxd.out 2>/tmp/influxd.err &
             sleep 5
-            sudo gridlabd -T 0 --validate
+            sudo gridlabd -D keep_progress=TRUE -T 0 --validate
       - run:
            name: Save validation failure data
            command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           command: |
             sudo /usr/bin/influxd run 1>/tmp/influxd.out 2>/tmp/influxd.err &
             sleep 5
-            sudo make validate
+            sudo gridlabd -T 0 --validate
       - run:
            name: Save validation failure data
            command: |

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -99,23 +99,26 @@ public:
 		}
 		else
 		{
+			static LOCKVAR lock = 0;
 			static int len = 0;
-			char blank[1024] = "";
+			::wlock(&lock);
 			if ( len > 0 )
 			{
-				if ( len >= sizeof(blank) )
+				char blank[1024] = "";
+				if ( len >= (int)sizeof(blank) )
 				{
 					len = sizeof(blank)-1;
 				}
 				memset(blank,' ',len);
 				blank[len]='\0';
+				output_raw("%s\r",blank);
 			}
-			output_raw("%s\r",blank);
 			len = output_raw("Processing %s...\r",ptr)-1; 
 			if ( len < 0 )
 			{
 				len = 0;
-			}	
+			}
+			::wunlock(&lock);
 		}
 		wlock(); 
 		n_files++;

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -99,14 +99,23 @@ public:
 		}
 		else
 		{
-			static size_t len = 0;
+			static int len = 0;
 			char blank[1024] = "";
 			if ( len > 0 )
 			{
+				if ( len >= sizeof(blank) )
+				{
+					len = sizeof(blank)-1;
+				}
 				memset(blank,' ',len);
 				blank[len]='\0';
 			}
-			len = output_raw("%s\rProcessing %s...\r",blank,ptr)-len; 
+			output_raw("%s\r",blank);
+			len = output_raw("Processing %s...\r",ptr)-1; 
+			if ( len < 0 )
+			{
+				len = 0;
+			}	
 		}
 		wlock(); 
 		n_files++;

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -100,9 +100,12 @@ public:
 		else
 		{
 			static size_t len = 0;
-			char blank[1024];
-			memset(blank,32,len);
-			blank[len]='\0';
+			char blank[1024] = "";
+			if ( len > 0 )
+			{
+				memset(blank,' ',len);
+				blank[len]='\0';
+			}
 			len = output_raw("%s\rProcessing %s...\r",blank,ptr)-len; 
 		}
 		wlock(); 


### PR DESCRIPTION
This PR addresses issue #208 

## Current issues
None

## Code changes
- [x] Fix validate progress output message handling.

## Documentation changes
None

## Test and Validation Notes

This test requires a large number of processors (e.g., > 32) to be sure it's a good fix. The easiest way to run a 5xlarge AWS EC2 instance.  See [AWS image wiki page](https://github.com/slacgismo/gridlabd/wiki/AWS-images) for details.

The CircleCI validation now uses 2 processors and keep all progress output.