### PR TITLE
Fix format of schedule skew values in json output

### DIFF
--- a/build-aux/setup-Darwin-19.sh
+++ b/build-aux/setup-Darwin-19.sh
@@ -22,3 +22,6 @@ pip3 install matplotlib pandas numpy Pillow
 # influxdb
 brew install influxdb
 brew services start influxdb
+
+# subversion cli
+brew install svn

--- a/gldcore/autotest/test_config.glm
+++ b/gldcore/autotest/test_config.glm
@@ -7,11 +7,11 @@
 #if ${TEST1:-X} == A
 #print ok
 #else
-#error TEST1 failed
+#error TEST1==${TEST1:-X} failed
 #endif
 
 #if ${TEST2:-X} == B
 #print ok
 #else
-#error TEST2 failed
+#error TEST2==${TEST2:-X} failed
 #endif

--- a/gldcore/autotest/test_config_prefix.glm
+++ b/gldcore/autotest/test_config_prefix.glm
@@ -7,11 +7,11 @@
 #if ${MY_TEST1:-X} == A
 #print ok
 #else
-#error MY_TEST1 failed
+#error MY_TEST1==${MY_TEST1:-X} failed
 #endif
 
 #if ${MY_TEST2:-X} == B
 #print ok
 #else
-#error MY_TEST2 failed
+#error MY_TEST2==${MY_TEST2:-X} failed
 #endif

--- a/gldcore/autotest/test_config_relax.glm
+++ b/gldcore/autotest/test_config_relax.glm
@@ -8,11 +8,11 @@
 #if ${TEST1:-X} == A
 #print ok
 #else
-#error TEST1 failed
+#error TEST1==${TEST1:-X} failed
 #endif
 
 #if ${TEST2:-X} == B
 #print ok
 #else
-#error TEST2 failed
+#error TEST2==${TEST2:-X} failed
 #endif

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -446,7 +446,7 @@ int GldJsonWriter::write_objects(FILE *fp)
 		if ( convert_from_timestamp(obj->clock,buffer,buffer_size) )
 			TUPLE("clock","%s",buffer);
 		if ( obj->valid_to > TS_ZERO && obj->valid_to < TS_NEVER ) TUPLE("valid_to","%llu",(int64)(obj->valid_to));
-		if ( obj->schedule_skew != 0 ) TUPLE("schedule_skew","%llu",obj->schedule_skew);
+		if ( obj->schedule_skew != 0 ) TUPLE("schedule_skew","%lld",obj->schedule_skew);
 		if ( obj->in_svc > TS_ZERO && obj->in_svc < TS_NEVER ) TUPLE("in","%llu",(int64)(obj->in_svc));
 		if ( obj->out_svc > TS_ZERO && obj->out_svc < TS_NEVER ) TUPLE("out","%llu",(int64)(obj->out_svc));
 		TUPLE("rng_state","%llu",(int64)(obj->rng_state));


### PR DESCRIPTION
This PR addresses issue #690 

## Current issues

None

## Code changes

- [x] Change JSON format of schedule skew from `%llu` to `%lld` in `gldcore/json.cpp`

## Documentation changes

None

## Test and Validation Notes

None
