### PR TITLE
Fixes for Python 3.7.7 upgrade in docker

### DIFF
--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -75,7 +75,7 @@ GLD_SOURCES_EXTRA_PLACE_HOLDER += gldcore/xcore.cpp gldcore/xcore.h
 
 bin_PROGRAMS += gridlabd.bin
 
-gridlabd_bin_CPPFLAGS = -DMAIN_PYTHON
+gridlabd_bin_CPPFLAGS = -DMAIN_PYTHON -fPIC
 gridlabd_bin_CPPFLAGS += $(XERCES_CPPFLAGS)
 gridlabd_bin_CPPFLAGS += $(AM_CPPFLAGS)
 

--- a/gldcore/link/python/setup.py
+++ b/gldcore/link/python/setup.py
@@ -42,7 +42,7 @@ except:
 		compile_options = None
 if not compile_options :
 	compile_options=['-Wall','-O3','-g']
-compile_options.extend(['-I%s/gldcore'%srcdir,'-Igldcore','-Igldcore/rt',"-DHAVE_CONFIG_H","-DHAVE_PYTHON"])
+compile_options.extend(['-I%s/gldcore'%srcdir,'-Igldcore','-Igldcore/rt',"-fPIC","-DHAVE_CONFIG_H","-DHAVE_PYTHON"])
 
 from distutils.core import setup, Extension
 gridlabd = Extension('gridlabd', 

--- a/gldcore/module.cpp
+++ b/gldcore/module.cpp
@@ -1429,7 +1429,7 @@ int module_compile(const char *name,	/**< name of library */
 	fclose(fp);
 
 	/* compile the code */
-	if ( (rc=execf("%s %s %s -c \"%s\" -o \"%s\" ", cc, mopt, ccflags, cfile, ofile))!=0 )
+	if ( (rc=execf("%s %s %s -fPIC -c \"%s\" -o \"%s\" ", cc, mopt, ccflags, cfile, ofile))!=0 )
 		return rc;
 
 	/* create needed DLL files on windows */


### PR DESCRIPTION
This PR addresses issue(s) DockerHub unable to build gridlabd

## Current issues
1. Timezone fix for python 3.7.7

## Code changes
1. gldcore/Makefile.mk
1. gldcore/link/python/setup.py
1. gldcore/module.cpp
Note, adding -fPIC to every compiler

## Test and Validation Notes
1. Check that Dockerhub builds gridlabd image. 

Note, the base image for gridlabd_docker_base was updated in addition to this patch.
