### PR TITLE
Fix csv_data_only option in tape recorders

### DIFF
--- a/tape/autotest/test_recorder_epoch.glm
+++ b/tape/autotest/test_recorder_epoch.glm
@@ -17,7 +17,10 @@ clock {
 //#set minimum_timestep=60;
 //#include "../water_and_setpoint_schedule_v3.glm";
 
-module tape;
+module tape
+{
+     csv_header_type NAME;
+}
 module residential {
      implicit_enduses NONE;
 };

--- a/tape/tape.cpp
+++ b/tape/tape.cpp
@@ -82,24 +82,27 @@ static char1024 tape_gnuplot_path;
 int32 flush_interval = 0;
 int csv_data_only = 0; /* enable this option to suppress addition of lines starting with # in CSV */
 int csv_keep_clean = 0; /* enable this option to keep data flushed at end of line */
-void (*update_csv_data_only)(void)=NULL;
-void (*update_csv_keep_clean)(void)=NULL;
-
-void set_csv_options(void)
-{
-	if (csv_data_only && update_csv_data_only)
-		(*update_csv_data_only)();
-	if (csv_keep_clean && update_csv_keep_clean)
-		(*update_csv_keep_clean)();
-}
 
 typedef int (*OPENFUNC)(void *, char *, char *);
 typedef char *(*READFUNC)(void *, char *, unsigned int);
 typedef int (*WRITEFUNC)(void *, char *, char *);
 typedef int (*REWINDFUNC)(void *);
 typedef void (*CLOSEFUNC)(void *);
-typedef void (*VOIDCALL)(void);
+typedef void *(*SETOPTIONCALL)(const char *name, void *value);
+typedef void *(*GETOPTIONCALL)(const char *name);
 typedef void (*FLUSHFUNC)(void*);
+
+SETOPTIONCALL set_option = NULL;
+GETOPTIONCALL get_option = NULL;
+
+void set_csv_options(void)
+{
+	if (set_option)
+	{
+		set_option("csv_data_only",(void*)&csv_data_only);
+		set_option("csv_keep_clean",(void*)&csv_keep_clean);
+	}
+}
 
 TAPEFUNCS *get_ftable(char *mode){
 	/* check what we've already loaded */
@@ -184,8 +187,8 @@ TAPEFUNCS *get_ftable(char *mode){
 	fptr->next = funcs;
 	funcs = fptr;
 
-	update_csv_data_only = (VOIDCALL)DLSYM(lib,"set_csv_data_only");
-	update_csv_keep_clean = (VOIDCALL)DLSYM(lib,"set_csv_keep_clean");
+	set_option = (SETOPTIONCALL)DLSYM(lib,"set_option");
+	get_option = (GETOPTIONCALL)DLSYM(lib,"get_option");
 	return funcs;
 }
 

--- a/tape_file/tape_file.cpp
+++ b/tape_file/tape_file.cpp
@@ -25,13 +25,39 @@
 
 int csv_data_only = 0; /* enable this option to suppress addition of lines starting with # in CSV */
 int csv_keep_clean = 0; /* enable this option to keep data flushed at end of line */
-EXPORT void set_csv_data_only()
+
+EXPORT void *get_option(const char *name)
 {
-	csv_data_only = 1;
+	struct s_map 
+	{
+		const char *name;
+		void *ptr;
+	} map[] = {
+		{"csv_data_only",(void*)&csv_data_only},
+		{"csv_keep_clean",(void*)&csv_keep_clean},
+	};
+	for ( size_t n = 0 ; n < sizeof(map)/sizeof(map[0]) ; n++ )
+	{
+		if ( strcmp(map[n].name,name) == 0 )
+		{
+			return map[n].ptr;
+		}
+	}
+	return NULL;
 }
-EXPORT void set_csv_keep_clean()
+
+EXPORT void *set_option(const char *name, void *pValue)
 {
-	csv_keep_clean = 1;
+	void *pRef = get_option(name);
+	if ( pRef == (void*)&csv_data_only )
+	{
+		csv_data_only = *(int*)pValue;
+	}
+	else if ( pRef == (void*)&csv_keep_clean )
+	{
+		csv_keep_clean = *(int*)pValue;
+	}
+	return pRef;
 }
 
 /*******************************************************************


### PR DESCRIPTION
This PR fixes issue #704

## Current issues
None

## Code changes
- [x] Change API for `tape_file` options to allow set/get operations for any data type

## Documentation changes
None

## Test and Validation Notes
- [x] Change `tape/autotest/test_recorder_epoch.glm` to use `csv_data_only NAME` option
