### PR TITLE
Delete Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-reconfigure configure:
-	autoreconf -isf && ./configure


### PR DESCRIPTION
This PR undoes the attempt to create a default Makefile to ease first build.  The solution does not work well with `git`.