### PR TITLE
Fix Amazon EC2 instance setup script

### DIFF
--- a/build-aux/setup-Linux-amzn-2.sh
+++ b/build-aux/setup-Linux-amzn-2.sh
@@ -15,7 +15,7 @@ yum -q install libcurl-devel -y
 # python3 support needed as of 4.2
 yum -q install python37 python3-devel python3-tkinter -y
 [ -f /bin/python3 -a ! -f /usr/local/bin/python3 ] && ln -s /bin/python3 /usr/local/bin/python3
-[ -f /usr/bin/python3-config -a ! -f /usr/local/bin/python3-config ] && ln -s /usr/bin/python3-config /usr/local/bin/python3-config
+[ -f /usr/bin/python3-config -a ! -f /usr/local/bin/python3-config ] && ln -s /bin/python3-config /usr/local/bin/python3-config
 [ ! -f /usr/local/include/python3.7m ] && ln -sf /usr/include/python3.7m /usr/local/include/python3.7m
 /usr/local/bin/python3 -m pip install --quiet --user matplotlib pandas mysql-connector Pillow
 chmod -R a+w /usr/local/lib64/python3.7/site-packages

--- a/build-aux/setup-Linux-amzn-2.sh
+++ b/build-aux/setup-Linux-amzn-2.sh
@@ -15,7 +15,9 @@ yum -q install libcurl-devel -y
 # python3 support needed as of 4.2
 yum -q install python37 python3-devel python3-tkinter -y
 [ -f /bin/python3 -a ! -f /usr/local/bin/python3 ] && ln -s /bin/python3 /usr/local/bin/python3
-[ -f /bin/python3-config -a ! -f /usr/local/bin/python3-config ] && ln -s /bin/python3-config /usr/local/bin/python3-config
+[ -f /bin/python3-config -a ! -f /usr/local/bin/python3-config ] && echo '#!/bin/bash
+/bin/python3-config !$' > /usr/local/bin/python3-config
+chmod +x /usr/local/bin/python3-config
 [ ! -f /usr/local/include/python3.7m ] && ln -sf /usr/include/python3.7m /usr/local/include/python3.7m
 /usr/local/bin/python3 -m pip install --quiet --user matplotlib pandas mysql-connector Pillow
 chmod -R a+w /usr/local/lib64/python3.7/site-packages

--- a/build-aux/setup-Linux-amzn-2.sh
+++ b/build-aux/setup-Linux-amzn-2.sh
@@ -15,7 +15,9 @@ yum -q install libcurl-devel -y
 # python3 support needed as of 4.2
 yum -q install python37 python3-devel python3-tkinter -y
 [ -f /bin/python3 -a ! -f /usr/local/bin/python3 ] && ln -s /bin/python3 /usr/local/bin/python3
-pip3 --quiet --user install matplotlib pandas mysql-connector Pillow
+[ -f /usr/bin/python3-config -a ! -f /usr/local/bin/python3-config ] && ln -s /usr/bin/python3-config /usr/local/bin/python3-config
+[ ! -f /usr/local/include/python3.7m ] && ln -sf /usr/include/python3.7m /usr/local/include/python3.7m
+/usr/local/bin/python3 -m pip install --quiet --user matplotlib pandas mysql-connector Pillow
 chmod -R a+w /usr/local/lib64/python3.7/site-packages
 
 # mono
@@ -38,8 +40,8 @@ mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
 fi
 
 # converter support
-pip3 install networkx
-cd /tmp
-curl http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/m/mdbtools-0.7.1-3.el7.x86_64.rpm > mdbtools-0.7.1-3.el7.x86_64.rpm
-rpm -Uvh mdbtools-0.7.1-3.el7.x86_64.rpm
-yum -q install mdbtools -y
+/usr/local/bin/python3 -m pip install --quiet --user networkx 
+# cd /tmp
+# curl http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/m/mdbtools-0.7.1-3.el7.x86_64.rpm > mdbtools-0.7.1-3.el7.x86_64.rpm
+# rpm -Uvh mdbtools-0.7.1-3.el7.x86_64.rpm
+# yum -q install mdbtools -y

--- a/build-aux/setup-Linux-amzn-2.sh
+++ b/build-aux/setup-Linux-amzn-2.sh
@@ -16,7 +16,7 @@ yum -q install libcurl-devel -y
 yum -q install python37 python3-devel python3-tkinter -y
 [ -f /bin/python3 -a ! -f /usr/local/bin/python3 ] && ln -s /bin/python3 /usr/local/bin/python3
 [ -f /bin/python3-config -a ! -f /usr/local/bin/python3-config ] && echo '#!/bin/bash
-/bin/python3-config !$' > /usr/local/bin/python3-config
+/bin/python3-config $*' > /usr/local/bin/python3-config
 chmod +x /usr/local/bin/python3-config
 [ ! -f /usr/local/include/python3.7m ] && ln -sf /usr/include/python3.7m /usr/local/include/python3.7m
 /usr/local/bin/python3 -m pip install --quiet --user matplotlib pandas mysql-connector Pillow

--- a/build-aux/setup-Linux-amzn-2.sh
+++ b/build-aux/setup-Linux-amzn-2.sh
@@ -15,7 +15,7 @@ yum -q install libcurl-devel -y
 # python3 support needed as of 4.2
 yum -q install python37 python3-devel python3-tkinter -y
 [ -f /bin/python3 -a ! -f /usr/local/bin/python3 ] && ln -s /bin/python3 /usr/local/bin/python3
-[ -f /usr/bin/python3-config -a ! -f /usr/local/bin/python3-config ] && ln -s /bin/python3-config /usr/local/bin/python3-config
+[ -f /bin/python3-config -a ! -f /usr/local/bin/python3-config ] && ln -s /bin/python3-config /usr/local/bin/python3-config
 [ ! -f /usr/local/include/python3.7m ] && ln -sf /usr/include/python3.7m /usr/local/include/python3.7m
 /usr/local/bin/python3 -m pip install --quiet --user matplotlib pandas mysql-connector Pillow
 chmod -R a+w /usr/local/lib64/python3.7/site-packages

--- a/climate/climate.h
+++ b/climate/climate.h
@@ -19,7 +19,7 @@
 #include "weather.h"
 #include "weather_reader.h"
 
-extern char1024 climate_library_path;
+extern char climate_library_path[sizeof(char1024)];
 
 typedef enum e_compass_ptr {
 	CP_H    = 0,

--- a/climate/init.cpp
+++ b/climate/init.cpp
@@ -4,7 +4,7 @@
 
 #include "climate.h"
 
-char1024 climate_library_path = "/usr/local/share/gridlabd/weather/US";
+char climate_library_path[sizeof(char1024)] = "/usr/local/share/gridlabd/weather/US";
 
 EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
 {
@@ -20,7 +20,11 @@ EXPORT CLASS *init(CALLBACKS *fntable, MODULE *module, int argc, char *argv[])
 	new weather(module);
 	new csv_reader(module);
 
-	gl_global_create("climate::library_path",PT_char1024,&climate_library_path,NULL);
+	if ( gl_global_getvar("datadir",climate_library_path,sizeof(climate_library_path)) )
+	{
+		strcat(climate_library_path,"/weather/US");
+	}
+	gl_global_create("climate::library_path",PT_char1024,climate_library_path,NULL);
 
 	/* always return the first class registered */
 	return climate::oclass;

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -333,6 +333,7 @@ DEPRECATED static struct s_varmap {
 	{"progress", PT_double, &global_progress, PA_REFERENCE, "computed progress based on clock, start, and stop times"},
 	{"server_keepalive", PT_bool, &global_server_keepalive, PA_PUBLIC, "flag to keep server alive after simulation is complete"},
 	{"pythonpath",PT_char1024,&global_pythonpath,PA_PUBLIC,"folder to append to python module search path"},
+	{"datadir",PT_char1024,&global_datadir,PA_PUBLIC,"folder in which share data is stored"},
 	/* add new global variables here */
 };
 

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -326,7 +326,7 @@ export CCFLAGS="${INCLUDE} ${PYCCFLAGS} ${CCFLAGS}"
 export CPPFLAGS="${INCLUDE} ${PYCCFLAGS} ${CPPFLAGS}"
 export CXXFLAGS="${INCLUDE} ${PYCCFLAGS} ${CXXFLAGS}"
 export PYLDFLAGS="$(/usr/local/bin/python3-config --ldflags)"
-export LIB="-L/usr/local/lib/gridlabd -L/usr/local/lib -L/usr/lib"
+export LIB="-L$libdir -L/usr/local/lib -L/usr/lib"
 export LDFLAGS="${LIB} ${PYLDFLAGS} ${LDFLAGS}"
 export PYTHONPATH=.:${GLD_ETC}${PYTHONPATH:+:}${PYTHONPATH}
 

--- a/gldcore/gridlabd.m4sh
+++ b/gldcore/gridlabd.m4sh
@@ -71,7 +71,7 @@ export CCFLAGS="${INCLUDE} ${PYCCFLAGS} ${CCFLAGS}"
 export CPPFLAGS="${INCLUDE} ${PYCCFLAGS} ${CPPFLAGS}"
 export CXXFLAGS="${INCLUDE} ${PYCCFLAGS} ${CXXFLAGS}"
 export PYLDFLAGS="$(/usr/local/bin/python3-config --ldflags)"
-export LIB="-L/usr/local/lib/gridlabd -L/usr/local/lib -L/usr/lib"
+export LIB="-L$libdir -L/usr/local/lib -L/usr/lib"
 export LDFLAGS="${LIB} ${PYLDFLAGS} ${LDFLAGS}"
 export PYTHONPATH=.:${GLD_ETC}${PYTHONPATH:+:}${PYTHONPATH}
 

--- a/install.sh
+++ b/install.sh
@@ -337,6 +337,7 @@ if [ "$INDEX" == "yes" ]; then
 fi
 if [ "$TEST" == "yes" ]; then
 	export PATH=$INSTALL/bin:$PATH
+	export GLPATH=$INSTALL/share/gridlabd/weather/US
 	export LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH:-.}
 	run $INSTALL/bin/gridlabd -T $NPROC --validate
 fi


### PR DESCRIPTION
This PR fixes issue #374.

## Current issues
1. Warnings are still generated by `gldcore/{debug,gui,local,module,validate}`.
1. Warnings are still generated by `assert` and `tape` modules.
1. Warnings are still generated by `python` build.

## Code changes
- [x] Change default value of `climate::library_path`
- [x] Public `datadir` global variable.

## Documentation changes
None

## Test and Validation Notes
None
