### PR TITLE
Fix deprecated strtok usage is core and modules

### DIFF
--- a/climate/csv_reader.cpp
+++ b/climate/csv_reader.cpp
@@ -357,7 +357,8 @@ int csv_reader::read_line(char *line, int linenum )
 //	OBJECT *my = 0;
 
 	strncpy(buffer, line, 1023);
-	token = strtok(buffer, " ,\t\n\r");
+	char *last;
+	token = strtok_r(buffer, " ,\t\n\r",&last);
 
 	if ( token == 0 ) {
 		return 2; // blank line 
@@ -424,7 +425,7 @@ int csv_reader::read_line(char *line, int linenum )
 		}
 	}
 
-	while ( (token=strtok(NULL, ",\n\r")) != 0 && col < column_ct ) 
+	while ( (token=strtok_r(NULL, ",\n\r",&last)) != 0 && col < column_ct ) 
 	{
 		if ( columns[col]->ptype == PT_double ) 
 		{

--- a/gldcore/convert.cpp
+++ b/gldcore/convert.cpp
@@ -571,7 +571,8 @@ int convert_to_set(const char *buffer, /**< a pointer to the string buffer */
 	else
 	{
 		/* process each keyword in the temporary buffer*/
-		for ( ptr = strtok(temp,SETDELIM) ; ptr != NULL ; ptr = strtok(NULL,SETDELIM) )
+		char *last;
+		for ( ptr = strtok_r(temp,SETDELIM,&last) ; ptr != NULL ; ptr = strtok_r(NULL,SETDELIM,&last) )
 		{
 			bool found = false;
 			KEYWORD *key;

--- a/gldcore/enduse.cpp
+++ b/gldcore/enduse.cpp
@@ -584,7 +584,8 @@ int convert_to_enduse(const char *string, void *data, PROPERTY *prop)
 	strcpy(buffer,string);
 
 	/* parse tuples separate by semicolon*/
-	while ((token=strtok(token==NULL?buffer:NULL,";"))!=NULL)
+	char *last;
+	while ((token=strtok_r(token==NULL?buffer:NULL,";",&last))!=NULL)
 	{
 		/* colon separate tuple parts */
 		char *param = token;

--- a/gldcore/find.cpp
+++ b/gldcore/find.cpp
@@ -1288,7 +1288,8 @@ const char *find_file(const char *name, /**< the name of the file to find */
 	if ( glpath != NULL )
 	{
 		strncpy(envbuf, glpath, sizeof(envbuf));
-		dir = strtok(envbuf, delim);
+		char *last;
+		dir = strtok_r(envbuf, delim,&last);
 		while (dir)
 		{
 			snprintf(filepath, sizeof(filepath), "%s%s%s", dir, pathsep, name);

--- a/gldcore/find.cpp
+++ b/gldcore/find.cpp
@@ -1298,7 +1298,7 @@ const char *find_file(const char *name, /**< the name of the file to find */
 				strncpy(buffer,filepath,len);
 				return buffer;
 			}
-			dir = strtok_r(NULL, delim);
+			dir = strtok_r(NULL, delim, &last);
 		}
 	}
 

--- a/gldcore/find.cpp
+++ b/gldcore/find.cpp
@@ -1298,7 +1298,7 @@ const char *find_file(const char *name, /**< the name of the file to find */
 				strncpy(buffer,filepath,len);
 				return buffer;
 			}
-			dir = strtok(NULL, delim);
+			dir = strtok_r(NULL, delim);
 		}
 	}
 

--- a/gldcore/gui.cpp
+++ b/gldcore/gui.cpp
@@ -785,17 +785,18 @@ void GldGui::output_html_table(GUIENTITY *entity)
 		else 
 		{
 			char *p = NULL;
+			char *last;
 			if ( row++==0 )
 			{
 				html_output(fp,"<tr>");
-				while ( (p=strtok(p?NULL:header,","))!=NULL )
+				while ( (p=strtok_r(p?NULL:header,",",&last))!=NULL )
 					html_output(fp,"<th>%s</th>", p);
 				html_output(fp,"</tr>\n");
 			}
 			if ( entity->height==0 || row<=entity->height )
 			{
 				html_output(fp,"<tr>");
-				while ( (p=strtok(p?NULL:line,","))!=NULL )
+				while ( (p=strtok_r(p?NULL:line,",",&last))!=NULL )
 					html_output(fp,"<td>%s</td>", p);
 				html_output(fp,"</tr>\n");
 			}

--- a/gldcore/instance_slave.cpp
+++ b/gldcore/instance_slave.cpp
@@ -100,7 +100,8 @@ STATUS instance_slave_parse_prop_list(char *line, linkage **root, LINKAGETYPE ty
 
 	IN_MYCONTEXT output_verbose("parser list: \'%s\'", line);
 
-	token = strtok(line, ", \0\n\r");	// @todo should use strtok_r, will change later
+	char *last;
+	token = strtok_r(line, ", \0\n\r", &last);	// @todo should use strtok_r, will change later
 	while(token != 0){
 		tokenct = sscanf(token, "%[A-Za-z0-9_].%[A-Za-z0-9_]", objname, propname);
 		if(2 != tokenct){
@@ -146,7 +147,7 @@ STATUS instance_slave_parse_prop_list(char *line, linkage **root, LINKAGETYPE ty
 		}
 
 		// repeat
-		token = strtok(NULL, ", \0\n\r");
+		token = strtok_r(NULL, ", \0\n\r", &last);
 	}
 	return SUCCESS;
 }

--- a/gldcore/loadshape.cpp
+++ b/gldcore/loadshape.cpp
@@ -1211,7 +1211,8 @@ int convert_to_loadshape(const char *string, void *data, PROPERTY *prop)
 	ls->type = MT_UNKNOWN;
 
 	/* parse tuples separate by semicolon*/
-	while ((token=strtok(token==NULL?buffer:NULL,";"))!=NULL)
+	char *last;
+	while ((token=strtok_r(token==NULL?buffer:NULL,";",&last))!=NULL)
 	{
 		/* colon separate tuple parts */
 		char *param = token;

--- a/gldcore/module.cpp
+++ b/gldcore/module.cpp
@@ -332,10 +332,11 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 
 	/* check for foreign modules */
 	strcpy(buffer,file);
-	fmod = strtok(buffer,"::");
+	char *last;
+	fmod = strtok_r(buffer,"::",&last);
 	if (fmod!=NULL && strcmp(fmod, file) != 0)
 	{
-		char *modname = strtok(NULL,"::");
+		char *modname = strtok_r(NULL,"::",&last);
 		MODULE *parent_mod = module_find(fmod);
 		if(parent_mod == NULL)
 			parent_mod = module_load(fmod, 0, NULL);

--- a/gldcore/unit.cpp
+++ b/gldcore/unit.cpp
@@ -484,7 +484,8 @@ void unit_init(void)
 		char envbuf[1024];
 		const char *dir;
 		strcpy(envbuf, glpath);
-		dir = strtok(envbuf, ";");
+		char *last;
+		dir = strtok_r(envbuf, ";", &last);
 		while(dir != NULL){
 			strcpy(filepath, dir);
 			strcat(filepath, "/unitfile.txt");
@@ -492,7 +493,7 @@ void unit_init(void)
 			if (fp != NULL){
 				break;
 			}
-			dir = strtok(NULL, ";");
+			dir = strtok_r(NULL, ";",&last);
 		}
 	}
 

--- a/residential/house_e.cpp
+++ b/residential/house_e.cpp
@@ -971,7 +971,8 @@ int house_e::create()
 		size_t n_eu=0;
 
 		// extract the implicit_enduse list
-		while ((token=strtok(token?NULL:active_enduses,"|"))!=NULL)
+		char *last;
+		while ((token=strtok_r(token?NULL:active_enduses,"|" ,&last))!=NULL)
 			eulist[n_eu++] = token;
 
 		while (n_eu-->0)

--- a/tape/collector.cpp
+++ b/tape/collector.cpp
@@ -224,8 +224,8 @@ AGGREGATION *link_aggregates(char *aggregate_list, char *group)
 	AGGREGATION *first=NULL, *last=NULL;
 	char1024 list;
 	strcpy(list,aggregate_list); /* avoid destroying orginal list */
-	char *last;
-	for (item=strtok_r(list,",",&last); item!=NULL; item=strtok_r(NULL,",",&last))
+	char *last_token;
+	for (item=strtok_r(list,",",&last_token); item!=NULL; item=strtok_r(NULL,",",&last_token))
 	{
 		AGGREGATION *aggr = gl_create_aggregate(item,group);
 		if (aggr!=NULL)

--- a/tape/collector.cpp
+++ b/tape/collector.cpp
@@ -224,7 +224,8 @@ AGGREGATION *link_aggregates(char *aggregate_list, char *group)
 	AGGREGATION *first=NULL, *last=NULL;
 	char1024 list;
 	strcpy(list,aggregate_list); /* avoid destroying orginal list */
-	for (item=strtok(list,","); item!=NULL; item=strtok(NULL,","))
+	char *last;
+	for (item=strtok_r(list,",",&last); item!=NULL; item=strtok_r(NULL,",",&last))
 	{
 		AGGREGATION *aggr = gl_create_aggregate(item,group);
 		if (aggr!=NULL)

--- a/tape/histogram.cpp
+++ b/tape/histogram.cpp
@@ -202,7 +202,8 @@ void histogram::test_for_complex(char *tprop, char *tpart){
 			gl_error("Unable to resolve complex part for '%s'", property.get_string());
 			return;
 		}
-		strtok(property, "."); /* "quickly" replaces the dot with a space */
+		char *last;
+		strtok_r(property, ".",&last); /* "quickly" replaces the dot with a space */
 	}
 }
 
@@ -330,14 +331,15 @@ int histogram::init(OBJECT *parent)
 		}
 		memset(bin_list, 0, sizeof(BIN) * bin_count);
 		memcpy(bincpy, bins, 1024);
-		cptr = strtok(bincpy, ",\t\r\n\0");
+		char *last;
+		cptr = strtok_r(bincpy, ",\t\r\n\0",&last);
 		if(prop->ptype == PT_complex || prop->ptype == PT_double || prop->ptype == PT_int16 || prop->ptype == PT_int32 || prop->ptype == PT_int64 || prop->ptype == PT_float || prop->ptype == PT_real){
 			for(i = 0; i < bin_count && cptr != NULL; ++i){
 				if(parse_bin_val(cptr, bin_list+i) == 0){
 					gl_error("Histogram unable to parse \'%s\' in %s", cptr, obj->name ? obj->name : "(unnamed histogram)");
 					return 0;
 				}
-				cptr = strtok(NULL, ",\t\r\n\0"); /* minor efficiency gain to use the incremented pointer from parse_bin */
+				cptr = strtok_r(NULL, ",\t\r\n\0",&last); /* minor efficiency gain to use the incremented pointer from parse_bin */
 			}
 		} else if (prop->ptype == PT_enumeration || prop->ptype == PT_set){
 			for(i = 0; i < bin_count && cptr != NULL; ++i){
@@ -345,7 +347,7 @@ int histogram::init(OBJECT *parent)
 					gl_error("Histogram unable to parse \'%s\' in %s", cptr, obj->name ? obj->name : "(unnamed histogram)");
 					return 0;
 				}
-				cptr = strtok(NULL, ",\t\r\n\0"); /* minor efficiency gain to use the incremented pointer from parse_bin */
+				cptr = strtok_r(NULL, ",\t\r\n\0",&last); /* minor efficiency gain to use the incremented pointer from parse_bin */
 			}
 		}
 

--- a/tape/multi_recorder.cpp
+++ b/tape/multi_recorder.cpp
@@ -318,13 +318,14 @@ static int multi_recorder_open(OBJECT *obj)
 		UNIT *unit = 0;
 		int first = 1;
 		OBJECT *myobj = 0;
+		char *last;
 		switch(my->header_units){
 			case HU_DEFAULT:
 				strcpy(my->out_property, my->property);
 				break;
 			case HU_ALL:
 				strcpy(unit_buffer, my->property);
-				for(token = strtok(unit_buffer, ","); token != NULL; token = strtok(NULL, ",")){
+				for(token = strtok_r(unit_buffer, ",", &last); token != NULL; token = strtok_r(NULL, ",",&last)){
 					unit = 0;
 					prop = 0;
 					unitstr[0] = 0;
@@ -423,7 +424,7 @@ static int multi_recorder_open(OBJECT *obj)
 				break;
 			case HU_NONE:
 				strcpy(unit_buffer, my->property);
-				for(token = strtok(unit_buffer, ","); token != NULL; token = strtok(NULL, ",")){
+				for(token = strtok_r(unit_buffer, ",",&last); token != NULL; token = strtok_r(NULL, ",",&last)){
 					if(2 == sscanf(token, "%[A-Za-z0-9_:.][%[^]\n,]]", propstr, unitstr)){
 						; // no logic change
 					}

--- a/tape/player.cpp
+++ b/tape/player.cpp
@@ -64,8 +64,8 @@ PROPERTY *player_link_properties(struct player *player, OBJECT *obj, char *prope
 	int64 cid = -1;
 
 	strcpy(list,property_list); /* avoid destroying orginal list */
-	char *last;
-	for (item=strtok_r(list,",",&last); item!=NULL; item=strtok_r(NULL,",",&last))
+	char *last_token;
+	for (item=strtok_r(list,",",&last_token); item!=NULL; item=strtok_r(NULL,",",&last_token))
 	{
 		prop = NULL;
 		target = NULL;

--- a/tape/player.cpp
+++ b/tape/player.cpp
@@ -64,7 +64,8 @@ PROPERTY *player_link_properties(struct player *player, OBJECT *obj, char *prope
 	int64 cid = -1;
 
 	strcpy(list,property_list); /* avoid destroying orginal list */
-	for (item=strtok(list,","); item!=NULL; item=strtok(NULL,","))
+	char *last;
+	for (item=strtok_r(list,",",&last); item!=NULL; item=strtok_r(NULL,",",&last))
 	{
 		prop = NULL;
 		target = NULL;

--- a/tape/schedule.cpp
+++ b/tape/schedule.cpp
@@ -98,12 +98,13 @@ schedule_list *parse_cron(char *cron_str){
 
 	strcpy(cron_cpy, cron_str);
 
-	mohs = strtok(cron_cpy, " \t\n\r");
-	hods = strtok(NULL, " \t\n\r");
-	doms = strtok(NULL, " \t\n\r");
-	moys = strtok(NULL, " \t\n\r");
-	dows = strtok(NULL, " \t\n\r");
-	vals = strtok(NULL, " \t\n\r");
+	char *last;
+	mohs = strtok_r(cron_cpy, " \t\n\r",&last);
+	hods = strtok_r(NULL, " \t\n\r",&last);
+	doms = strtok_r(NULL, " \t\n\r",&last);
+	moys = strtok_r(NULL, " \t\n\r",&last);
+	dows = strtok_r(NULL, " \t\n\r",&last);
+	vals = strtok_r(NULL, " \t\n\r",&last);
 	
 	if((mohs && hods && doms && moys && dows) == 0){
 		gl_error("Insufficient arguements in cron line \"%s\"", cron_str);
@@ -421,10 +422,11 @@ int schedule::parse_schedule(){
 
 	/* simulate strtok effects, replacing ';' with '\0' and 
 	 *  getting char* to each schedule token. */
-	temp = strtok(sched_buf, ";");
+	char *last;
+	temp = strtok_r(sched_buf, ";",&last);
 	for(i = 0; i < 128 && temp != NULL; ++i){
 		sched_ptr[i] = temp;
-		temp = strtok(NULL, ";");
+		temp = strtok_r(NULL, ";",&last);
 	}
 
 	token_ct = i;

--- a/tape_plot/tape_plot.cpp
+++ b/tape_plot/tape_plot.cpp
@@ -303,7 +303,8 @@ EXPORT void write_default_plot_commands_rec(struct recorder *my, char32 extensio
 		} else {
 			strcpy(list,my->property); /* avoid destroying orginal list */
 			k = 2;
-			for (item=strtok(list,","); item!=NULL; item=strtok(NULL,",")){
+			char *last;
+			for (item=strtok_r(list,",",&last); item!=NULL; item=strtok_r(NULL,",",&last)){
 				if(k == 2){
 					fprintf(my->fp, "plot \'-\' using 1:%i title \'%s\' with lines", k, item);
 					/* only handles one column properly as-is, will be fixed with the tape module update -MH */


### PR DESCRIPTION
This PR fixes issue #276.

## Current issues

None

## Code changes

- [x] Change all instances of `strtok` to `strtok_r`.

## Documentation changes

None

## Test and Validation Notes

None
