### PR TITLE
Update test_version_macro.glm

### DIFF
--- a/gldcore/autotest/test_bare_class.glm
+++ b/gldcore/autotest/test_bare_class.glm
@@ -12,6 +12,6 @@ object test {
 	object assert {
 		target x;
 		relation "==";
-		value 12.4;
+		value "+12.4";
 	};
 }

--- a/gldcore/autotest/test_version_macro.glm
+++ b/gldcore/autotest/test_version_macro.glm
@@ -1,7 +1,7 @@
 #option debug
 #set suppress_repeat_messages=false
 
-#version 4.2.1
+#version ${version.major}.${version.minor}.${version.patch}
 #version -ne 4.1
 #version -gt 4.2.0
 #version -ge 4.2


### PR DESCRIPTION
This PR fix a failing self-test when patch number is not 1.

## Current issues

None

## Code changes

None

## Documentation changes

None

## Test and Validation Notes
- [x] Fix `gldcore/autotest/test_version_macro.glm` to correctly test `major.minor.patch` equality.

