### PR TITLE
Add support for python properties

### DIFF
--- a/docs/GLM/Property/Python.md
+++ b/docs/GLM/Property/Python.md
@@ -1,0 +1,56 @@
+[[/GLM/Property/Python]] -- Python property
+
+# Synopsis
+
+GLM:
+
+~~~
+  class <class-name> {
+    python <property-name>;
+  }
+  object <class-name> {
+    <property-name> <type(<value>);
+  }
+~~~
+  
+# Description
+
+The `python` property type support general python objects.  Although any type of object is supported, only those that implement the python `str` method as useful because GridLAB-D require the `str()` to generate the values for data exchange.
+
+# Examples
+
+~~~
+class test
+{
+	python py_object;
+}
+object test
+{
+	py_object None;
+}
+object test
+{
+	py_object int(1);
+}
+object test
+{
+	py_object float(0.0);
+}
+object test
+{
+	py_object float(1.23);
+}
+object test
+{
+	py_object str('text');
+}
+object test
+{
+	py_object list([1,2,3]);
+}
+object test
+{
+	py_object dict(a=1,b=2,c=3);
+}
+~~~
+

--- a/gldcore/autotest/test_python_property.glm
+++ b/gldcore/autotest/test_python_property.glm
@@ -1,0 +1,56 @@
+
+#set savefile=gridlabd.json
+
+class test
+{
+	python py_object;
+}
+
+object test
+{
+	name "test_none";
+	py_object None;
+}
+
+object test
+{
+	name "test_0";
+	py_object int(0);
+}
+
+object test
+{
+	name "test_1";
+	py_object int(1);
+}
+
+object test
+{
+	name "test_0.0";
+	py_object float(0.0);
+}
+
+object test
+{
+	name "test_1.23";
+	py_object float(1.23);
+}
+
+object test
+{
+	name "test_str";
+	py_object str('text');
+}
+
+object test
+{
+	name "test_list";
+	py_object list([1,2,3]);
+}
+
+object test
+{
+	name "test_dict";
+	py_object dict(a=1,b=2,c=3);
+}
+

--- a/gldcore/property.cpp
+++ b/gldcore/property.cpp
@@ -43,6 +43,7 @@ PROPERTYSPEC property_type[_PT_LAST] = {
 	{"randomvar", "string", NULL, sizeof(randomvar), 24, convert_from_randomvar, convert_to_randomvar, initial_from_randomvar,randomvar_create,NULL,convert_to_double,{TCOPS(double)},random_get_part,random_set_part},
 	{"method","string", NULL, 0, PSZ_DYNAMIC, convert_from_method,convert_to_method,initial_from_method},
 	{"string", "string", "", sizeof(STRING), PSZ_AUTO, convert_from_string, convert_to_string, NULL,string_create,NULL,convert_to_string,{TCOPS(string)},},
+	{"python", "string", "None", sizeof(PyObject**), PSZ_AUTO, convert_from_python, convert_to_python, initial_from_python, python_create,NULL,convert_to_python,{TCNONE},python_get_part,NULL},
 };
 
 PROPERTYTYPE property_getfirst_type(void)

--- a/gldcore/property.h
+++ b/gldcore/property.h
@@ -1079,6 +1079,7 @@ enum e_propertytype {_PT_FIRST=-1,
 	PT_random,
 	PT_method,
 	PT_string,
+	PT_python,
 	/* add new property types here - don't forget to add them also to rt/gridlabd.h and property.c */
 #ifdef USE_TRIPLETS
 	PT_triple,

--- a/gldcore/python_embed.h
+++ b/gldcore/python_embed.h
@@ -20,4 +20,17 @@ bool python_parser(const char *line=NULL, void *context = NULL);
 // forward declarations to gldcore/link/python.c
 MODULE *python_module_load(const char *, int, const char *[]);
 
+// Function: convert_from_double
+DEPRECATED int convert_from_python(char *buffer, int size, void *data, PROPERTY *prop);
+
+// Function: convert_to_double
+DEPRECATED int convert_to_python(const char *buffer, void *data, PROPERTY *prop);
+
+DEPRECATED int initial_from_python(char *buffer, int size, void *data, PROPERTY *prop);
+
+DEPRECATED int python_create(void *ptr);
+
+double python_get_part(void *c, const char *name);
+
+
 #endif

--- a/gldcore/rt/gridlabd.h
+++ b/gldcore/rt/gridlabd.h
@@ -458,6 +458,7 @@ typedef enum {_PT_FIRST=-1,
 	PT_random,		/**< Randomized number */
 	PT_method,		/**< Method interface */
 	PT_string,
+	PT_python,
 #ifdef USE_TRIPLETS
 	PT_triple, /**< triplet of doubles (not supported) */
 	PT_triplex, /**< triplet of complexes (not supported) */


### PR DESCRIPTION
This PR adds support for python properties in GLM files.

## Current issues

* `get_part()` does not work on dictionary float values.

## Code changes

- [x] Add `'python` property to `gldcore/property.{cpp, h}`
- [x] Add `python` property handlers to `gldcore/python_embed.cpp`

## Documentation changes

- [x] [/GLM/Property/Python](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-add-python-property&doc=/GLM/Property/Python.md)

## Test and Validation Notes

- [x] Add `gldcore/autotest/test_python_property.glm`
