### PR TITLE
Update multi_recorder.cpp

### DIFF
--- a/tape/multi_recorder.cpp
+++ b/tape/multi_recorder.cpp
@@ -576,6 +576,7 @@ EXPORT int method_multi_recorder_property(OBJECT *obj, char *value, size_t size)
 		if ( my->property_len < len )
 		{
 			my->property_len = ((my->property_len+len+1)/BLOCKSIZE+1)*BLOCKSIZE;
+			char *old_value = my->property;
 			my->property = (char*)realloc(my->property,my->property_len);
 			if ( my->property == NULL )
 			{
@@ -583,7 +584,15 @@ EXPORT int method_multi_recorder_property(OBJECT *obj, char *value, size_t size)
 				my->property_len = 0;
 				return 0;
 			}
-			strcpy(my->property,value);
+			if ( old_value )
+			{
+				strcat(my->property,",");
+				strcat(my->property,value);
+			}
+			else
+			{
+				strcpy(my->property,value);
+			}
 		}	
 		else
 		{


### PR DESCRIPTION
This PR fixes a GRIP multi-recorder error #762 

## Current issues

None

## Code changes

- [x] Fix `tape/collector.cpp/method_collector_property()` so it handles multiple property lists correctly.
- [x] Fix `tape/recorder.cpp/method_recorder_property()` so it handles multiple property lists correctly.
- [x] Fix `tape/multi_recorder.cpp/method_multi_recorder_property()` so it handles multiple property lists correctly.

## Documentation changes

None

## Test and Validation Notes

Note: the error affect the Hinesburg model, which contains NDA data and cannot be posted.
