### PR TITLE
Fix subcommand template docs

### DIFF
--- a/docs/Subcommand/Template.md
+++ b/docs/Subcommand/Template.md
@@ -5,24 +5,24 @@
 Shell:
 
 ~~~
-bash$ gridlabd help
-bash$ gridlabd index <pattern>
-bash$ gridlabd list <pattern>
-bash$ gridlabd get <pattern>
-bash$ gridlabd submit <file>
-bash$ gridlabd delete <pattern>
-bash$ gridlabd info <pattern>
-bash$ gridlabd copy <name> [<file>]
-bash$ gridlabd clean
-bash$ gridlabd open <local>
-bash$ gridlabd session <local> [<pattern>]
-bash$ gridlabd add <local> <pattern>
-bash$ gridlabd save <local> ["<description>"]
-bash$ gridlabd submit <local>
-bash$ gridlabd config show
-bash$ gridlabd config reset
-bash$ gridlabd config get <name>
-bash$ gridlabd config set <name> <value>
+bash$ gridlabd template help
+bash$ gridlabd template index <pattern>
+bash$ gridlabd template list <pattern>
+bash$ gridlabd template get <pattern>
+bash$ gridlabd template submit <file>
+bash$ gridlabd template delete <pattern>
+bash$ gridlabd template info <pattern>
+bash$ gridlabd template copy <name> [<file>]
+bash$ gridlabd template clean
+bash$ gridlabd template open <local>
+bash$ gridlabd template session <local> [<pattern>]
+bash$ gridlabd template add <local> <pattern>
+bash$ gridlabd template save <local> ["<description>"]
+bash$ gridlabd template submit <local>
+bash$ gridlabd template config show
+bash$ gridlabd template config reset
+bash$ gridlabd template config get <name>
+bash$ gridlabd template config set <name> <value>
 ~~~
 
 # Description
@@ -32,7 +32,7 @@ Use the `template` subcommand to manage GridLAB-D's template files.
 ## `help`
 
 ~~~
-  gridlabd help
+  gridlabd template help
 ~~~
 
 The `template help` subcommand obtains a list of the valid commands.
@@ -74,7 +74,7 @@ Commands:
 The `index` command outputs a list of template files in the archive that match <pattern>.
   
 ~~~
-bash$ gridlabd index wood_pole
+bash$ gridlabd template index wood_pole
 wood_pole.glm
 ~~~
 


### PR DESCRIPTION
This PR fixes issue of typos in template command.

## Current issues
n/a

## Code changes
n/a

## Documentation changes
- [x] [Subcommand/Template](http://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop&folder=/Subcommand&doc=/Subcommand/Template.md)

## Test and Validation Notes
Read the doc