### PR TITLE
Upgrades to support python3.7 through python3.9

### DIFF
--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -12,13 +12,17 @@ yum -q install which -y
 yum -q install svn -y
 
 # python3 support needed as of 4.2
-yum -q install python3 python36-devel python3-pip python3-tkinter -y
-test -l /usr/local/bin/python3 || ln -sf /usr/bin/python3 /usr/local/bin/python3
-pip3 --quiet install --upgrade pip
-echo '#/bin/bash' > /usr/local/bin/python3-config
-echo '/usr/bin/python3-config $*' >> /usr/local/bin/python3-config
-chmod +x /usr/local/bin/python3-config
-/usr/local/bin/python3 -m pip --quiet install matplotlib pandas mysql-connector Pillow
+cd /usr/local/src
+curl https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz | tar xz
+cd Python-3.9.0
+./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
+make -j $(nproc)
+make altinstall
+ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
+ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
+ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
+ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
+ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 
 # latex
 if [ ! -x /usr/bin/tex ]; then

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -12,27 +12,31 @@ yum -q install which -y
 yum -q install svn -y
 
 # python3 support needed as of 4.2
-cd /usr/local/src
-curl https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz | tar xz
-cd Python-3.9.0
-./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
-make -j $(nproc)
-make altinstall
-ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
-ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
-ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
-ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
-ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
+if [ ! -x /usr/local/bin/python3 -o $(/usr/local/bin/python3 --version) != "Python 3.9.0" ]; then
+	yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
+	cd /usr/local/src
+	curl https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz | tar xz
+	cd Python-3.9.0
+	./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
+	make -j $(nproc)
+	make altinstall
+	ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
+	ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
+	ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
+	ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
+	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
+	/usr/local/bin/python3 pip -m install mysql-connector matplotlib numpy pandas Pillow
+fi
 
 # latex
 if [ ! -x /usr/bin/tex ]; then
-	yum install tex
+	yum -q install tex -y
 fi
 
 # doxygen
 if [ ! -x /usr/bin/doxygen ]; then
 	if [ ! -d /usr/local/src/doxygen ]; then
-		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen
+		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
 	fi
 	if [ ! -d /usr/local/src/doxygen/build ]; then
 		mkdir /usr/local/src/doxygen/build

--- a/configure.ac
+++ b/configure.ac
@@ -514,6 +514,7 @@ AM_CONDITIONAL([HAVE_MYSQL], [test ! "x$HAVE_MYSQL" = "xno"])
 # Verify python version
 AM_PATH_PYTHON(3.7)
 HAVE_PYTHON="$(python3 --version | cut -f2 -d' ')"
+PYTHON_EXEC="$(python3 -c "import os; print(os.path.realpath('$(which python3)'))")"
 PYTHON_VER=$(echo $HAVE_PYTHON | cut -f1-2 -d.)
 AM_CONDITIONAL([HAVE_PYTHON], [test ! "x$HAVE_PYTHON" = "xno"])
 AS_IF([test "x$HAVE_PYTHON" != "xno" -a "$(uname)" == "Darwin" ],
@@ -638,7 +639,7 @@ AC_MSG_RESULT([
 -----------------------------------------------------------------------
 ])
 
-CXXFLAGS="$(python3-config --cflags) $CXXFLAGS "
+CXXFLAGS="$(python3-config --cflags) $CXXFLAGS -D PYTHON_EXEC='\"$PYTHON_EXEC\"'"
 LDFLAGS="$(python3-config --ldflags) $PYTHON_LIB $LDFLAGS "
 
 AC_CONFIG_FILES([Makefile])

--- a/configure.ac
+++ b/configure.ac
@@ -519,7 +519,7 @@ PYTHON_VER=$(echo $HAVE_PYTHON | cut -f1-2 -d.)
 AM_CONDITIONAL([HAVE_PYTHON], [test ! "x$HAVE_PYTHON" = "xno"])
 AS_IF([test "x$HAVE_PYTHON" != "xno" -a "$(uname)" == "Darwin" ],
     [PYTHON_LIB="-lpython${PYTHON_VER/3.7/3.7m} -shared -Wl-undefined,dynamic_lookup"],
-    [PYTHON_LIB=""])
+    [PYTHON_LIB="-lpython${PYTHON_VER/3.7/3.7m}"])
 
 # check for mono
 AS_IF([test -z "$(which mono)" ],

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -340,6 +340,7 @@ DEPRECATED static struct s_varmap {
 	{"progress", PT_double, &global_progress, PA_REFERENCE, "computed progress based on clock, start, and stop times"},
 	{"server_keepalive", PT_bool, &global_server_keepalive, PA_PUBLIC, "flag to keep server alive after simulation is complete"},
 	{"pythonpath",PT_char1024,&global_pythonpath,PA_PUBLIC,"folder to append to python module search path"},
+	{"pythonexec",PT_char1024,&global_pythonexec,PA_REFERENCE,"python executable used to build gridlabd"},
 	{"datadir",PT_char1024,&global_datadir,PA_PUBLIC,"folder in which share data is stored"},
 	{"json_complex_format",PT_set,&global_json_complex_format,PA_PUBLIC,"JSON complex number format",jcf_keys},
 	{"rusage_file",PT_char1024,&global_rusage_file,PA_PUBLIC,"file in which resource usage data is collected"},

--- a/gldcore/globals.h
+++ b/gldcore/globals.h
@@ -799,6 +799,9 @@ GLOBAL char1024 global_datadir INIT("");
 /* Variable: global_pythonpath */
 GLOBAL char1024 global_pythonpath INIT(".");
 
+/* Variable: global_pythonexec */
+GLOBAL char1024 global_pythonexec INIT(PYTHON_EXEC);
+
 /* Variable: global_rusage_rate */
 GLOBAL int64 global_rusage_rate INIT(0);
 

--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -711,7 +711,6 @@ static PyObject *gridlabd_start(PyObject *self, PyObject *args)
 #ifdef MAIN_PYTHON
         return gridlabd_exception("unable to start gridlabd in this module instance");
 #else
-        PyEval_InitThreads();
         save_environ();
         exec_mls_create();
         gridlabd_module_status = GMS_STARTED;
@@ -1657,7 +1656,7 @@ extern "C" bool on_init(void)
         if ( PyCallable_Check(call) )
         {
             PyObject *arg = Py_BuildValue("(i)",global_clock);
-            PyObject *result = PyEval_CallObject(call,arg);
+            PyObject *result = PyObject_Call(call,arg,NULL);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1694,7 +1693,7 @@ extern "C" TIMESTAMP on_precommit(TIMESTAMP t0)
         if ( call && PyCallable_Check(call) )
         {
             PyObject *arg = Py_BuildValue("(i)",t0);
-            PyObject *result = PyEval_CallObject(call,arg);
+            PyObject *result = PyObject_Call(call,arg,NULL);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1741,7 +1740,7 @@ extern "C" TIMESTAMP on_presync(TIMESTAMP t0)
         if ( call && PyCallable_Check(call) )
         {
             PyObject *arg = Py_BuildValue("(i)",t0);
-            PyObject *result = PyEval_CallObject(call,arg);
+            PyObject *result = PyObject_Call(call,arg,NULL);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1787,7 +1786,7 @@ extern "C" TIMESTAMP on_sync(TIMESTAMP t0)
         if ( call && PyCallable_Check(call) )
         {
             PyObject *arg = Py_BuildValue("(i)",t0);
-            PyObject *result = PyEval_CallObject(call,arg);
+            PyObject *result = PyObject_Call(call,arg,NULL);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1833,7 +1832,7 @@ extern "C" TIMESTAMP on_postsync(TIMESTAMP t0)
         if ( call && PyCallable_Check(call) )
         {
             PyObject *arg = Py_BuildValue("(i)",t0);
-            PyObject *result = PyEval_CallObject(call,arg);
+            PyObject *result = PyObject_Call(call,arg,NULL);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1878,7 +1877,7 @@ extern "C" bool on_commit(TIMESTAMP t)
         if ( call && PyCallable_Check(call) )
         {
             PyObject *arg = Py_BuildValue("(i)",t);
-            PyObject *result = PyEval_CallObject(call,arg);
+            PyObject *result = PyObject_Call(call,arg,NULL);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1912,7 +1911,7 @@ extern "C" void on_term(void)
         if ( call && PyCallable_Check(call) )
         {
             PyObject *arg = Py_BuildValue("(i)",global_clock);
-            PyObject *result = PyEval_CallObject(call,arg);
+            PyObject *result = PyObject_Call(call,arg,NULL);
             Py_DECREF(arg);
             if ( ! result )
             {
@@ -1985,7 +1984,7 @@ int python_event(OBJECT *obj, const char *function, long long *p_retval)
                 sprintf(name,"%s:%d", obj->oclass->name, obj->id);
             }
             PyObject *args = Py_BuildValue("(si)",obj->name?obj->name:name,global_clock);
-            PyObject *result = PyEval_CallObject(call,args);
+            PyObject *result = PyObject_Call(call,args,NULL);
             Py_DECREF(args);
             if ( p_retval != NULL )
             {

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -8080,7 +8080,7 @@ bool GldLoader::load_import(const char *from, char *to, int len)
 		}
 		output_verbose("changing output to '%s'", to);
 	}
-	int rc = my_instance->subcommand("/usr/local/bin/python3 %s -i %s -o %s %s",converter_path,from,to,unquoted);
+	int rc = my_instance->subcommand("%s %s -i %s -o %s %s",(const char*)global_pythonexec,converter_path,from,to,unquoted);
 	if ( rc != 0 )
 	{
 		output_error("%s: return code %d",converter_path,rc);
@@ -8098,7 +8098,6 @@ STATUS GldLoader::load_python(const char *filename)
 		python_embed_init(0,NULL);
 	}
 	return python_embed_import(filename,global_pythonpath) == NULL ? FAILED : SUCCESS;
-//	return my_instance->subcommand("/usr/local/bin/python3 %s",filename) == 0 ? SUCCESS : FAILED;
 }
 
 /** Load a file

--- a/gldcore/platform.h
+++ b/gldcore/platform.h
@@ -170,5 +170,12 @@
  */
 #define EXPORT DEPRECATED CDECL
 
+/*  Define: PYTHON_EXEC
+		Path to Python executable used to build gridlabd
+ */
+#ifndef PYTHON_EXEC
+#define PYTHON_EXEC "/usr/local/bin/python3"
+#endif
+
 #endif
 /**@}**/

--- a/gldcore/save.cpp
+++ b/gldcore/save.cpp
@@ -129,7 +129,7 @@ int saveall(const char *filename)
 			save_options++;
 			buffer[strlen(buffer)-1] = '\0';
 		}
-		rc = my_instance->subcommand("/usr/local/bin/python3 %s -i %s -o %s %s",converter_path,input_name,filename,save_options?save_options:"");
+		rc = my_instance->subcommand("%s %s -i %s -o %s %s",(const char*)global_pythonexec,converter_path,input_name,filename,save_options?save_options:"");
 		if ( rc != 0 )
 		{
 			output_error("conversion from '%s' to output file '%s' failed (code %d)", input_name, filename, rc);
@@ -617,7 +617,7 @@ void save_outputs(void)
 		{
 			throw_exception("output file '%s' has no extension", item->first.c_str());
 		}
-		int rc = my_instance->subcommand("/usr/local/bin/python3 %s/%s2%s.py -i %s -o %s %s",(const char*)global_datadir,from+1,to+1,filename,item->first.c_str(),item->second.c_str());
+		int rc = my_instance->subcommand("%s %s/%s2%s.py -i %s -o %s %s",(const char*)global_pythonexec,(const char*)global_datadir,from+1,to+1,filename,item->first.c_str(),item->second.c_str());
 		if ( rc != 0 )
 		{
 			throw_exception("automatic conversion of '%s' to '%s %s' failed with return code %d", filename, item->first.c_str(), item->second.c_str(), rc);


### PR DESCRIPTION
This PR fixes warnings when building with python 3.9.

## Current issues

None

## Code changes

- [x] Add global variable `pythonexec` to `gldcore/globals.{h,cpp}`.
- [x] Add use of `pythonexec`global in `gldcore/{load,save}.cpp`.
- [x] Add default value for global `pythonexec` to `gldcore/platform.h`.
- [x] Fix deprecate python library calls in `gldcore/link/python/python.cpp`.
- [x] Add identification of current python executable in `configure.ac`.

## Documentation changes

None

## Test and Validation Notes

- Recommend using python3.9 for all development and validation work from now on.
