### PR TITLE
Updating docker file to use a tagged image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM slacgismo/gridlabd_dockerhub_base:latest
+FROM slacgismo/gridlabd_dockerhub_base:201215
 
 ENV container docker
 ENV REPO=https://github.com/slacgismo/gridlabd


### PR DESCRIPTION
This PR fixes issue that hasn't come up yet. Prepping to rebuild the base image for Python 3.9 upgrade.

## Current issues
N/A

## Code changes
- [x] docker/Dockerfile

## Documentation changes
N/A

## Test and Validation Notes
Check that the docker image still works.
