### PR TITLE
Develop add include longurl

### DIFF
--- a/gldcore/object.cpp
+++ b/gldcore/object.cpp
@@ -2848,9 +2848,8 @@ typedef struct s_objecttree {
 	struct s_objecttree *next;
 } OBJECTTREE;
 static OBJECTTREE *top[TREESIZE];
-typedef unsigned long long HASH;
 
-static HASH hash(OBJECTNAME name)
+HASH hash(OBJECTNAME name)
 {
 	static HASH A = 55711, B = 45131; //, C = 60083; isn't used but should be in principle
 	HASH h = 18443;

--- a/gldcore/object.h
+++ b/gldcore/object.h
@@ -31,8 +31,10 @@ typedef unsigned short OBJECTSIZE; /** Object data size */
 typedef unsigned int OBJECTNUM; /** Object id number */
 typedef const char * OBJECTNAME; /** Object name */
 typedef char FULLNAME[1024]; /** Full object name (including space name) */
+typedef unsigned long long HASH;
 
 #define PADDR_X(X,T) ((char*)&((T)->X)-(char*)(T))
+HASH hash(OBJECTNAME name);
 
 /* object flags */
 #define OF_NONE			0x00000000	/**< Object flag; none set */

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -767,7 +767,7 @@ char *encode_result(char *data,size_t sz)
 	return code;
 }
 
-static unsigned long long hash(const char *str)
+static unsigned long long hashcode(const char *str)
 {
 	unsigned long code = 5381;
 	int c;
@@ -1007,7 +1007,7 @@ int validate(void *main, int argc, const char *argv[])
 
 	report_data();
 	report_data("Result code");
-	report_data("%llX",final.get_nfailed()==0?0:hash(encode_result(result_code,next_id)));
+	report_data("%llX",final.get_nfailed()==0?0:hashcode(encode_result(result_code,next_id)));
 	report_newrow();
 
 	report_newrow();


### PR DESCRIPTION
This PR fixes issue #830.

## Current issues

None

## Code changes
- [x] Change `gldcore/load.cpp:process_macro()` to use `GldCurl()`
- [x] Change local cache copy of URL to use a hash

## Documentation changes

None

## Test and Validation Notes

It should be possible now to copy an OpenFIDO GLM artifacts link and use it directly in an `#include [https://openfido-prod-blob.s3.amazonaws.com/<artifact-id>]` statement in a local GLM file. Note that OpenFIDO artifact links expire and thus cannot be used indefinitely, so there is no way to make a permalink that can be used for an autotest. It may be possible to get a permalink from AWS S3 though.
