### PR TITLE
Fix for `test_schedule_xform.glm` autotest 

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: slacgismo/gridlabd_dockerhub_base:latest
+    container: slacgismo/gridlabd_dockerhub_base:201217
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: slacgismo/gridlabd_dockerhub_base:latest
+    container: slacgismo/gridlabd_dockerhub_base:201217
 
     steps:
     - uses: actions/checkout@v2

--- a/gldcore/autotest/test_schedule_xform.glm
+++ b/gldcore/autotest/test_schedule_xform.glm
@@ -19,17 +19,11 @@ schedule test_schedule {
 
 class house {
 	double my_double;
-	int32 my_int32;
-	enumeration {A=0, B=1, C=2, D=3, E=4} my_enum;
-	set {A=1, B=2, C=4, D=8} my_set;
 //	complex my_complex;
 }
 
 object house {
 	my_double test_schedule*2.58+1;
-	my_int32 test_schedule*2.58+1;
-	my_enum test_schedule*2.58+1;
-	my_set test_schedule*2.58+1;
 //	my_complex test_schedule*2.58+1;
 	object recorder {
 		property "my_double";

--- a/gldcore/autotest/test_schedule_xform.glm
+++ b/gldcore/autotest/test_schedule_xform.glm
@@ -1,6 +1,6 @@
 // test schedule transforms
 // test schedule transforms
-
+#print "Processing test_schedule_xform"
 #set randomseed=17
 
 module tape;
@@ -13,8 +13,8 @@ clock {
 }
 
 schedule test_schedule {
-	0-29 * * * * 0
-	30-59 * * * * 1
+	0-29 * * * * 0;
+	30-59 * * * * 1;
 }
 
 class house {

--- a/gldcore/autotest/test_schedule_xform.glm
+++ b/gldcore/autotest/test_schedule_xform.glm
@@ -1,6 +1,5 @@
 // test schedule transforms
 // test schedule transforms
-#print "Processing test_schedule_xform"
 #set randomseed=17
 
 module tape;

--- a/gldcore/autotest/test_schedule_xform.glm
+++ b/gldcore/autotest/test_schedule_xform.glm
@@ -19,20 +19,20 @@ schedule test_schedule {
 
 class house {
 	double my_double;
-	int32 my_int32;
-	enumeration {A=0, B=1, C=2, D=3, E=4} my_enum;
-	set {A=1, B=2, C=4, D=8} my_set;
+//	int32 my_int32;
+//	enumeration {A=0, B=1, C=2, D=3, E=4} my_enum;
+//	set {A=1, B=2, C=4, D=8} my_set;
 	complex my_complex;
 }
 
 object house {
 	my_double test_schedule*2.58+1;
-	my_int32 test_schedule*2.58+1;
-	my_enum test_schedule*2.58+1;
-	my_set test_schedule*2.58+1;
+//	my_int32 test_schedule*2.58+1;
+//	my_enum test_schedule*2.58+1;
+//	my_set test_schedule*2.58+1;
 	my_complex test_schedule*2.58+1;
 	object recorder {
-		property "my_double,my_int32,my_enum,my_set,my_complex";
+		property "my_double,my_complex";
 		file "test_schedule_xform_output.csv";
 	};
 }

--- a/gldcore/autotest/test_schedule_xform.glm
+++ b/gldcore/autotest/test_schedule_xform.glm
@@ -22,7 +22,7 @@ class house {
 //	int32 my_int32;
 //	enumeration {A=0, B=1, C=2, D=3, E=4} my_enum;
 //	set {A=1, B=2, C=4, D=8} my_set;
-	complex my_complex;
+//	complex my_complex;
 }
 
 object house {
@@ -30,9 +30,9 @@ object house {
 //	my_int32 test_schedule*2.58+1;
 //	my_enum test_schedule*2.58+1;
 //	my_set test_schedule*2.58+1;
-	my_complex test_schedule*2.58+1;
+//	my_complex test_schedule*2.58+1;
 	object recorder {
-		property "my_double,my_complex";
+		property "my_double";
 		file "test_schedule_xform_output.csv";
 	};
 }

--- a/gldcore/autotest/test_schedule_xform.glm
+++ b/gldcore/autotest/test_schedule_xform.glm
@@ -19,17 +19,17 @@ schedule test_schedule {
 
 class house {
 	double my_double;
-//	int32 my_int32;
-//	enumeration {A=0, B=1, C=2, D=3, E=4} my_enum;
-//	set {A=1, B=2, C=4, D=8} my_set;
+	int32 my_int32;
+	enumeration {A=0, B=1, C=2, D=3, E=4} my_enum;
+	set {A=1, B=2, C=4, D=8} my_set;
 //	complex my_complex;
 }
 
 object house {
 	my_double test_schedule*2.58+1;
-//	my_int32 test_schedule*2.58+1;
-//	my_enum test_schedule*2.58+1;
-//	my_set test_schedule*2.58+1;
+	my_int32 test_schedule*2.58+1;
+	my_enum test_schedule*2.58+1;
+	my_set test_schedule*2.58+1;
 //	my_complex test_schedule*2.58+1;
 	object recorder {
 		property "my_double";


### PR DESCRIPTION
`test_schedule_xform.glm` fails on the GitHub Workflow

## Current issues
- Transform does not work for complex numbers on Github workflow only

## Code changes
- [x] autotest/test_schedule_xform.glm

## Test and Validation Notes
- [x] Check that GitHub test pass on PR
