### PR TITLE
Add contributors subcommand

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update python3 modules
+      run: pip3 install -r requirements.txt
     - name: Run autoconf
       run: autoreconf -isf
     - name: Configure build

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update python3 modules
+      run: pip3 install -r requirements.txt
     - name: Run autoconf
       run: autoreconf -isf
     - name: Configure build

--- a/docs/Subcommand/Contributors.md
+++ b/docs/Subcommand/Contributors.md
@@ -34,7 +34,7 @@ Output only the user login id.
 
 ### `-q|--quotes <str>`
 
-Enclose names quote `<str>`.
+Enclose names quote `<str>`. Note, if using `"` define with an escape character as `"\""`
 
 ### `-s|--separate <str>`
 

--- a/docs/Subcommand/Contributors.md
+++ b/docs/Subcommand/Contributors.md
@@ -1,0 +1,53 @@
+[[/Subcommand/Contributors]] -- Get a list of contributors
+
+# Synopsis
+
+GLM:
+
+~~~
+#contributors [OPTIONS]
+~~~
+
+Shell:
+
+~~~
+sh% gridlabd contributors [OPTIONS]
+~~~
+
+# Description
+
+The `contributors` subcommand obtains a list contributors to the latest version of GridLAB-D. Contributors are listed in descending order of the number of commits.
+
+## Options
+
+### `-h|--help`
+
+Get the command line help list.
+
+### `-k|--known`
+
+Restrict output to github user with names.
+
+### `-l|--login`
+
+Output only the user login id.
+
+### `-q|--quotes <str>`
+
+Enclose names quote `<str>`.
+
+### `-s|--separate <str>`
+
+Separate names using `<str>`.
+
+### `-t|--token <str>`
+
+Use the GitHub access token `<str>`.
+
+# Caveat
+
+This query may be rate-limited by GitHub.  To increase the rate-limit use a github access token on the command line or add your github access token to the file `$HOME/.github/access-token`.
+
+# See also
+
+* [[/Command/Cite]]

--- a/docs/Subcommand/Contributors.md
+++ b/docs/Subcommand/Contributors.md
@@ -46,7 +46,7 @@ Use the GitHub access token `<str>`.
 
 # Caveat
 
-This query may be rate-limited by GitHub.  To increase the rate-limit use a github access token on the command line or add your github access token to the file `$HOME/.github/access-token`.
+This query may be rate-limited by GitHub.  To increase the rate-limit use a github access token on the command line or add your github access token to the file `$HOME/.github/access-token`. Note, you may need to create the folder `./github` and file `access-token` within it that contains the github generated token. 
 
 # See also
 

--- a/gldcore/scripts/Makefile.mk
+++ b/gldcore/scripts/Makefile.mk
@@ -1,6 +1,7 @@
 bin_SCRIPTS += gldcore/scripts/gridlabd-aws
 bin_SCRIPTS += gldcore/scripts/gridlabd-check
 bin_SCRIPTS += gldcore/scripts/gridlabd-compare
+bin_SCRIPTS += gldcore/scripts/gridlabd-contributors
 bin_SCRIPTS += gldcore/scripts/gridlabd-convert
 bin_SCRIPTS += gldcore/scripts/gridlabd-git
 bin_SCRIPTS += gldcore/scripts/gridlabd-help

--- a/gldcore/scripts/autotest/test_contributors.glm
+++ b/gldcore/scripts/autotest/test_contributors.glm
@@ -1,0 +1,1 @@
+#contributors -h

--- a/gldcore/scripts/gridlabd-contributors
+++ b/gldcore/scripts/gridlabd-contributors
@@ -1,0 +1,101 @@
+#!/usr/local/bin/python3
+
+import sys, os, github
+
+E_NONE = None
+E_OK = 0
+E_INVALID = 1
+E_TOKEN = 2
+E_EXCEPTION = 9
+
+separator = "\n"
+quotes = ""
+login = False
+known = False
+token = None
+
+def error(msg,code=E_NONE):
+	if type(msg) is Exception:
+		e_type, e_value, e_trace = sys.exc_info()
+		error(e_value,E_EXCEPTION)
+	else:
+		print(f"ERROR [{sys.argv[0]}]: {msg}",file=sys.stderr)
+	if code:
+		exit(code)
+
+def output(msg):
+	if type(msg) is Exception:
+		e_type, e_value, e_trace = sys.exc_info()
+		warning(e_value,E_EXCEPTION)
+	else:
+		print(f"{quotes}{msg}{quotes}",end=separator)
+
+def warning(msg):
+	print(f"WARNING [{sys.argv[0]}]: {msg}")
+
+n = 1
+while n < len(sys.argv):
+	tag = sys.argv[n]
+	if n < len(sys.argv)-1:
+		value = sys.argv[n+1]
+	else:
+		value = None
+	if tag in ["-h","--help"]:
+		print(f"{sys.argv[0]} [<options>]")
+		print("Options:")
+		print("  -h|--help           get this help list")
+		print("  -k|--known          print known users only")
+		print("  -l|--login          print only login ids")
+		print("  -q|--quotes <str>   quote names with <str>")
+		print("  -s|--separate <str> separate names with <str>")
+		print("  -t|--token <str>    use github access token <str>")
+		exit(0)
+	elif tag in ["-t","--token"]:
+		if value == "None":
+			token = None
+		else:
+			token = value
+		n += 1
+	elif tag in ["-s","--separate"]:
+		if value == "SPACE":
+			separator = " "
+		elif value == "NEWLINE":
+			separate = "\n"
+		else:
+			separator = value
+		n += 1
+	elif tag in ["-q","--quotes"]:
+		quotes = value
+		n += 1
+	elif tag in ["-k","--known"]:
+		known = True
+		n += 1
+	elif tag in ["-l","--login"]:
+		login = True
+		n += 1
+	else:
+		error(f"'{tag}' is not valid",code=E_INVALID)
+	n += 1
+
+if not token:
+	try:
+		HOME = os.getenv("HOME")
+		with open(f"{HOME}/.github/access-token","r") as fh:
+			token = fh.read().strip()
+	except Exception as exc:
+		warning(exc)
+		pass
+
+try:
+	git = github.Github(token)
+
+	repo = git.get_repo("slacgismo/gridlabd")
+	for user in repo.get_contributors():
+		if login:
+			output(user.login)
+		elif user.name:
+			output(user.name)
+		elif not known:
+			output(f"<user:{user.login}>")
+except Exception as exc:
+	error(exc)

--- a/gldcore/scripts/gridlabd-contributors
+++ b/gldcore/scripts/gridlabd-contributors
@@ -65,7 +65,10 @@ while n < len(sys.argv):
 			separator = value
 		n += 1
 	elif tag in ["-q","--quotes"]:
-		quotes = value
+		if value == None or value == "None":
+			quotes = ""
+		else:
+			quotes = value
 		n += 1
 	elif tag in ["-k","--known"]:
 		known = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas==1.1.4
 Pillow==8.0.1
 pytz==2020.4
 pysolar==0.9
+PyGithub=1.54.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas==1.1.4
 Pillow==8.0.1
 pytz==2020.4
 pysolar==0.9
-PyGithub=1.54.1
+PyGithub==1.54.1


### PR DESCRIPTION
This PR add support to getting list of contributors to GridLAB-D.

## Current issues

1. Only lists contributors to master, not the current branch or a specified commit id.

## Code changes
- [x] Add `gldcore/scripts/gridlabd-contributors`

## Documentation changes

- [x] [/Subcommand/Contributors](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-add-contributors&doc=/Subcommand/Contributors.md)

## Test and Validation Notes

- [x] Add `gldcore/scripts/autotest/test_contributors.glm`
