### PR TITLE
Add output progress flush control for validation

### DIFF
--- a/gldcore/output.cpp
+++ b/gldcore/output.cpp
@@ -40,6 +40,13 @@ static char buffer[65536];
 int overflow=CHECK;
 int flush = 0;
 
+bool output_enable_flush(bool enable)
+{
+	int old = flush;
+	flush = ( enable ? 1 : 0 );
+	return old;
+}
+
 static char prefix[16]="";
 void output_prefix_enable(void)
 {
@@ -705,9 +712,17 @@ int output_message(const char *format,...) /**< \bprintf style argument list */
 		}
 Output:
 		if (redirect.output)
+		{
 			result = fprintf(redirect.output,"%s%s\n", prefix, buffer);
+			if ( flush ) 
+			{
+				fflush(redirect.output);
+			}
+		}
 		else
+		{
 			result = (*printstd)("%s%s\n", prefix, buffer);
+		}
 Unlock:
 		wunlock(&output_lock);
 		return result;

--- a/gldcore/output.h
+++ b/gldcore/output.h
@@ -31,6 +31,7 @@ PRINTFUNCTION output_set_stdout(PRINTFUNCTION call);
 PRINTFUNCTION output_set_stderr(PRINTFUNCTION call);
 
 int output_init(int argc, const char *argv[]);
+bool output_enable_flush(bool enable);
 void output_cleanup(void);
 
 void output_prefix_enable(void);

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -95,7 +95,9 @@ public:
 		}
 		else if ( global_keep_progress )
 		{
+			int old = output_enable_flush(true);
 			output_message("Processing %s...",ptr); 
+			output_enable_flush(old);
 		}
 		else
 		{


### PR DESCRIPTION
This PR fixes issue with progress output flushing with keeping progress using `-D keep_progress=TRUE` command line option.

## Current issues

None

## Code changes

- [x] Add `output_enable_flush()` to `gldcore/output.cpp`
- [x] Add output flush control to validation progress output in `gldcore/validate.cpp`.

## Documentation changes

None

## Test and Validation Notes

None
