### PR TITLE
Develop add template defaults

### DIFF
--- a/docs/Subcommand/Template.md
+++ b/docs/Subcommand/Template.md
@@ -23,6 +23,7 @@ bash$ gridlabd template config show
 bash$ gridlabd template config reset
 bash$ gridlabd template config get <name>
 bash$ gridlabd template config set <name> <value>
+bash$ gridlabd tempalte defaults <name>
 ~~~
 
 # Description
@@ -183,4 +184,12 @@ Submit the local working session to the archive for review.
   gridlabd template config set <name> <value>
 ~~~
 
-Manage the library manager configuration.
+Change default template subcommand settings.
+
+## `defaults`
+
+~~~
+  gridlabd template defaults <name>
+~~~
+
+Output the default values for template configuration CSV file used by the template `<name>`.

--- a/gldcore/scripts/gridlabd-template
+++ b/gldcore/scripts/gridlabd-template
@@ -397,6 +397,14 @@ function add()
     git add -q "$2"
 }
 
+function defaults()
+{
+    if [ $# -eq 0 ]; then
+        error 1 "missing template name"
+    fi
+    python3 $DATADIR/$1/$1.py --defaults
+}
+
 while [ "${1:0:1}" == "-" ]; do
     case "$1" in
     (-b|--branch)

--- a/gldcore/scripts/gridlabd-template
+++ b/gldcore/scripts/gridlabd-template
@@ -190,6 +190,7 @@ function help()
                      reset         Reset the current configuration
                      set <N> <V>   Set configuration variable name <N> to value <V>
                      get <N> <V>   Get configuration variable name <N>
+              defaults <template>  Show the default values of the template configuration file (if any)
 END
     else
         for DOC in $(find $DATADIR -name $1.md -print); do


### PR DESCRIPTION
This PR add support for obtaining the default template configuration file.

## Current issues

None

## Code changes

- [x] Add `defaults()` to `gldcore/scripts/gridlabd-template`

## Documentation changes

- [x] Updated [/Subcommand/Template](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=<<<develop-add-template-defaults>>>&doc=/Subcommand/Template.md)

## Test and Validation Notes

None
