### PR TITLE
Develop add template cmdarg

### DIFF
--- a/docs/Command/Template.md
+++ b/docs/Command/Template.md
@@ -1,0 +1,31 @@
+[[/Command/Template]] -- load a GLM template
+
+# Synopsis
+
+Shell:
+
+~~~
+$ gridlabd ... [-t|--template] <template-name> ...
+~~~
+
+# Description
+
+The `-t` or `--template` command line option directs the loader to load a template GLM file from the current organization's template folder.  The standard location for a template is in the folder `/usr/local/share/gridlabd/template/$ORGANIZATION/<template-name>/<template-name>.glm`.
+
+## `ORGANIZAITON`
+
+The environment variable `ORGANIZATION` must be set in order for the template option to function properly. 
+
+# Example
+
+The following example loads the IEEE-13 bus model and run the ICA analysis template.
+
+~~~
+$ export ORGANIZATION=$(gridlabd template config get ORGANIZATION)
+$ gridlabd template get ica_analysis
+$ gridlabd IEEE-13.glm -t ica_analysis
+~~~
+
+# See also
+
+* [[/Subcommand/Template]]

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -2119,10 +2119,38 @@ DEPRECATED static int depends(void *main, int argc, const char *argv[])
 	return 0;
 }
 
-DEPRECATED static int rusage(void *main, int args, const char *argv[])
+DEPRECATED static int rusage(void *main, int argc, const char *argv[])
 {
 	global_rusage_rate = 1;
 	return 0;
+}
+
+DEPRECATED static int _template(void *main, int argc, const char *argv[])
+{
+	if ( argc < 2 )
+	{
+		output_error("missing template name");
+		return CMDERR;
+	}
+	char template_glm[1024];
+	const char *organization = getenv("ORGANIZATION");
+	if ( organization == NULL )
+	{
+		output_error("ORGANIZATION is not set in environment");
+		return CMDERR;
+	}
+	char *oldpath = strdup(global_pythonpath);
+	snprintf(global_pythonpath,sizeof(global_pythonpath)-strlen(global_pythonpath)-1,"%s/template/%s/%s",getenv("GLD_ETC"),organization,argv[1]);
+	snprintf(template_glm,sizeof(template_glm)-1,"%s/template/%s/%s/%s.glm",getenv("GLD_ETC"),organization,argv[1],argv[1]);
+	bool result = ((GldMain*)main)->get_loader()->load(template_glm);
+	strcpy(global_pythonpath,oldpath);
+	free(oldpath);
+	if ( ! result ) 
+	{
+		output_error("unable to load template file '%s'", template_glm);
+		return CMDERR;
+	}
+	return 1;
 }
 
 #include "job.h"
@@ -2215,6 +2243,7 @@ DEPRECATED static CMDARG main_commands[] = {
 	{"output",		"o",	output,			"<file>", "Enables save of output to a file (default is gridlabd.glm)" },
 	{"pause",		NULL,	pauseatexit,	NULL, "Toggles pause-at-exit feature" },
 	{"relax",		NULL,	relax,			NULL, "Allows implicit variable definition when assignments are made" },
+	{"template",	"t",	_template,		NULL, "Load template" },
 
 	{NULL,NULL,NULL,NULL, "Server mode"},
 	{"server",		NULL,	server,			NULL, "Enables the server"},

--- a/gldcore/link/python/python.cpp
+++ b/gldcore/link/python/python.cpp
@@ -2083,12 +2083,15 @@ MODULE *python_module_load(const char *file, int argc, const char *argv[])
 {
     char filename[1024];
     char pathname[1024];
-    sprintf(filename,"%s.py",file);
+    snprintf(filename,sizeof(filename)-1,"%s.py",file);
+    output_verbose("looking for module '%s'",filename);
     if ( ! find_file(filename,global_pythonpath,4,pathname,sizeof(pathname)) )
     {
+        output_debug("python module '%s' not found",filename);
         errno = ENOENT;
         return NULL;
     }
+    output_verbose("loading module '%s'",filename);
     extern PyObject *python_embed_import(const char *module, const char *path);
     PyObject *mod = python_embed_import(file,global_pythonpath);
 

--- a/gldcore/scripts/gridlabd-template
+++ b/gldcore/scripts/gridlabd-template
@@ -263,7 +263,7 @@ function get()
     fetch_index
     for TEMPLATE in $(export FORMAT=default; index $1); do
         SRCDIR="$GITFILE/$ORGANIZATION/$TEMPLATE"
-        DSTDIR="$GLD_ETC/template/$TEMPLATE"
+        DSTDIR="$GLD_ETC/template/$ORGANIZATION/$TEMPLATE"
         mkdir -p $DSTDIR
         debug "looking for catalog in $SRCDIR/.catalog"
         CATALOG=$(curl -sL -f "$SRCDIR/.catalog" "$DSTDIR" | grep -v '^#' | cut -f1 -d:) # || error 2 "missing template catalog")


### PR DESCRIPTION
This PR fixes issue #855.

## Current issues

None

## Code changes
- [x] Add `-t|--template` command line argument to direct template load procedure.
- [x] Fixed lack of diagnostic output in python module load process. 

## Documentation changes

- [x] [/Command/Template](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-add-template-cmdarg&doc=/Command/Template.md)

## Test and Validation Notes

The proper way to load a template from now on is to use the command `gridlabd <model-name>.glm -t <template-name>`.  See the example in the new docs.
