### PR TITLE
Add AWS auto-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ gldcore/autotest/test.glm
 gridlabd-core.*
 documents/gridlabd.md
 documents/gridlabd.pdf
+
+terraform.tfstate
+terraform.tfstate.backup

--- a/.gitignore
+++ b/.gitignore
@@ -165,5 +165,4 @@ gridlabd-core.*
 documents/gridlabd.md
 documents/gridlabd.pdf
 
-terraform.tfstate
-terraform.tfstate.backup
+aws_variables.sh

--- a/cloud/Makefile.mk
+++ b/cloud/Makefile.mk
@@ -1,29 +1,29 @@
 
-cloud-deploy: aws-deploy gcp-deploy azure-deploy
+# cloud-deploy: aws-deploy gcp-deploy azure-deploy
 
-WEBSITES = code$(SUFFIX).gridlabd.us docs$(SUFFIX).gridlabd.us www$(SUFFIX).gridlabd.us
+# WEBSITES = code$(SUFFIX).gridlabd.us docs$(SUFFIX).gridlabd.us www$(SUFFIX).gridlabd.us
 
-aws-deploy: $(WEBSITES)
+aws-deploy: terraform apply -var=version=$(version) -var=branch=$(branch)
 
-$(WEBSITES) :
-if HAVE_AWSCLI
-if SUFFIX
-	@echo "deploying $@ for SUFFIX='$(SUFFIX)'..."
-else
-	@echo "cannot deploy $@ for SUFFIX='$(SUFFIX)'"
-endif
-endif
+# $(WEBSITES) :
+# if HAVE_AWSCLI
 # if SUFFIX
-#  	@echo "aws s3 cp cloud/websites/$@/index.html s3://$@/index.html"
-#  	@echo "aws s3api put-object-acl --bucket $@ --key index.html --acl public-read"
+# 	@echo "deploying $@ for SUFFIX='$(SUFFIX)'..."
+# else
+# 	@echo "cannot deploy $@ for SUFFIX='$(SUFFIX)'"
+# endif
+# endif
+# # if SUFFIX
+# #  	@echo "aws s3 cp cloud/websites/$@/index.html s3://$@/index.html"
+# #  	@echo "aws s3api put-object-acl --bucket $@ --key index.html --acl public-read"
+# # endif
+
+# gcp-deploy:
+# if HAVE_GCPCLI
+# 	@echo "WARNING: gcp-deploy is not implemented yet"
 # endif
 
-gcp-deploy:
-if HAVE_GCPCLI
-	@echo "WARNING: gcp-deploy is not implemented yet"
-endif
-
-azure-deploy:
-if HAVE_AZCLI
-	@echo "WARNING: azure-deploy is not implemented yet"
-endif
+# azure-deploy:
+# if HAVE_AZCLI
+# 	@echo "WARNING: azure-deploy is not implemented yet"
+# endif

--- a/cloud/Makefile.mk
+++ b/cloud/Makefile.mk
@@ -3,7 +3,7 @@
 
 # WEBSITES = code$(SUFFIX).gridlabd.us docs$(SUFFIX).gridlabd.us www$(SUFFIX).gridlabd.us
 
-aws-deploy: terraform apply -var=version=$(version) -var=branch=$(branch)
+aws-deploy: update_ec2 -n=$(release_name)
 
 # $(WEBSITES) :
 # if HAVE_AWSCLI

--- a/cloud/update_ec2.sh
+++ b/cloud/update_ec2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+while getopts "n:" flag
+do
+    case ${flag} in
+        n)
+            n=${OPTARG}
+            shift
+            ;;
+    esac
+    shift
+done
+
+AWS_ACCESS_KEY_ID=$ACCESS_ID AWS_SECRET_ACCESS_KEY=$SECRET_KEY aws sns publish --region $REGION --topic-arn $TOPIC --message $n


### PR DESCRIPTION
This PR fixes issue #NUMBER1.

## Current issues
1. AWS AMI image build is done manually, this set up allows auto-build of AWS AMI images for hipas-gridlabd
- It does this by:
     1. Publishes a message with the release name to SNS in AWS
     2. Triggers Lambda function in AWS that starts the EC2 instance (gridlabd-master), ssh's into that EC2 instance (by using boto3 ssm agent), pulls the latest image from slacgismo/gridlabd dockerhub, and then stops the EC2 instance. 
     3.  After the Lambda function successfully completes, it publishes a message to another SNS topic with the release name.
     4.  Triggers another Lambda function that creates a new AMI image from the recently updated hipas-gridlabd EC2 instance.

## Code changes
- [x] Code change to cloud/update_ec2.sh
- [x] Code change to cloud/Makefile.mk
- [x] Added env variable file for aws to .gitignore
- [x]  IN PROGRESS: Need to configure code change to .github/master.yml

