### PR TITLE
Fix linux build warnings

### DIFF
--- a/gldcore/class.cpp
+++ b/gldcore/class.cpp
@@ -946,7 +946,7 @@ int class_define_map(CLASS *oclass, /**< the object class */
 			else if(proptype == PT_HAS_NOTIFY || proptype == PT_HAS_NOTIFY_OVERRIDE)
 			{
 				char notify_fname[128];
-				sprintf(notify_fname, "notify_%s_%s", prop->oclass->name, prop->name);
+				snprintf(notify_fname,sizeof(notify_fname)-1,"notify_%s_%s", prop->oclass->name, prop->name);
 				prop->notify = (FUNCTIONADDR)DLSYM(prop->oclass->module->hLib, notify_fname);
 				if(prop->notify == 0){
 					errno = EINVAL;
@@ -963,7 +963,7 @@ int class_define_map(CLASS *oclass, /**< the object class */
 			{
 				char tcode[32];
 				const char *ptypestr=class_get_property_typename(proptype);
-				sprintf(tcode,"%d",proptype);
+				snprintf(tcode,sizeof(tcode)-1,"%d",proptype);
 				if (strcmp(ptypestr,"//UNDEF//")==0)
 					ptypestr = tcode;
 				errno = EINVAL;
@@ -1091,7 +1091,7 @@ int class_define_enumeration_member(CLASS *oclass, /**< pointer to the class whi
 	KEYWORD *key = (KEYWORD*)malloc(sizeof(KEYWORD));
 	if (prop==NULL || key==NULL) return 0;
 	key->next = prop->keywords;
-	strncpy(key->name,member,sizeof(key->name));
+	strncpy(key->name,member,sizeof(key->name)-1);
 	key->value = value;
 	prop->keywords = key;
 	return 1;
@@ -1110,7 +1110,7 @@ int class_define_set_member(CLASS *oclass, /**< pointer to the class which imple
 	if (prop->keywords==NULL)
 		prop->flags |= PF_CHARSET; /* enable single character keywords until a long keyword is defined */
 	key->next = prop->keywords;
-	strncpy(key->name,member,sizeof(key->name));
+	strncpy(key->name,member,sizeof(key->name)-1);
 	key->name[sizeof(key->name)-1]='\0'; /* null terminate name in case is was too long for strncpy */
 	if (strlen(key->name)>1 && (prop->flags&PF_CHARSET)) /* long keyword detected */
 		prop->flags ^= PF_CHARSET; /* disable single character keywords */
@@ -1423,7 +1423,7 @@ static int buffer_write(char *buffer, /**< buffer into which string is written *
 		return 0;
 
 	va_start(ptr,format);
-	count = vsprintf(temp, format, ptr);
+	count = vsnprintf(temp, sizeof(temp)-1, format, ptr);
 	va_end(ptr);
 
 	if(count < len){

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -62,12 +62,12 @@ DEPRECATED STATUS load_module_list(FILE *fd,int* test_mod_num)
 }
 DEPRECATED STATUS GldCmdarg::load_module_list(FILE *fd,int* test_mod_num)
 {
-	char mod_test[100];
+	char mod_test[1024];
 	char line[100];
 	while(fscanf(fd,"%s",line) != EOF)
 	{
 		printf("Line: %s",line);
-		sprintf(mod_test,"mod_test%d=%s",(*test_mod_num)++,line);
+		snprintf(mod_test,sizeof(mod_test)-1,"mod_test%d=%s",(*test_mod_num)++,line);
 		if (global_setvar(mod_test)!=SUCCESS)
 		{
 			output_fatal("Unable to store module name");
@@ -250,18 +250,20 @@ STATUS GldCmdarg::no_cmdargs(void)
 	char htmlfile[1024];
 	if ( global_autostartgui && find_file("gridlabd.htm",NULL,R_OK,htmlfile,sizeof(htmlfile)-1)!=NULL )
 	{
-		char cmd[1024];
+		char cmd[4096];
 
 		/* enter server mode and wait */
 #ifdef WIN32
 		if ( htmlfile[1]!=':' )
-			sprintf(htmlfile,"%s\\gridlabd.htm", global_workdir);
+		{
+			snprintf(htmlfile,sizeof(htmlfile)-1,"%s\\gridlabd.htm", global_workdir);
+		}
 		output_message("opening html page '%s'", htmlfile);
-		sprintf(cmd,"start %s file:///%s", global_browser, htmlfile);
+		snprintf(cmd,sizeof(cmd)-1,"start %s file:///%s", global_browser, htmlfile);
 #elif defined(MACOSX)
-		sprintf(cmd,"open -a %s %s", global_browser, htmlfile);
+		snprintf(cmd,sizeof(cmd)-1,"open -a %s %s", global_browser, htmlfile);
 #else
-		sprintf(cmd,"%s '%s' & ps -p $! >/dev/null", global_browser, htmlfile);
+		snprintf(cmd,sizeof(cmd)-1,"%s '%s' & ps -p $! >/dev/null", global_browser, htmlfile);
 #endif
 		IN_MYCONTEXT output_verbose("Starting browser using command [%s]", cmd);
 		if (my_instance->subcommand("%s",cmd)!=0)
@@ -1462,7 +1464,7 @@ int GldCmdarg::xsl(int argc, const char *argv[])
 				p_args[n_args] = p;
 			}
 		}
-		sprintf(fname,"gridlabd-%d_%d.xsl",global_version_major,global_version_minor);
+		snprintf(fname,sizeof(fname)-1,"gridlabd-%d_%d.xsl",global_version_major,global_version_minor);
 		output_xsl(fname,n_args,(const char**)p_args);
 		free(buffer);
 		return CMDOK;
@@ -1620,13 +1622,13 @@ int GldCmdarg::info(int argc, const char *argv[])
 {
 	if ( argc>1 )
 	{
-		char cmd[1024];
+		char cmd[4096];
 #ifdef WIN32
-		sprintf(cmd,"start %s \"%s%s\"", global_browser, global_infourl, argv[1]);
+		snprintf(cmd,sizeof(cmd)-1,"start %s \"%s%s\"", global_browser, global_infourl, argv[1]);
 #elif defined(MACOSX)
-		sprintf(cmd,"open -a %s \"%s%s\"", global_browser, global_infourl, argv[1]);
+		snprintf(cmd,sizeof(cmd)-1,"open -a %s \"%s%s\"", global_browser, global_infourl, argv[1]);
 #else
-		sprintf(cmd,"%s \"%s%s\" & ps -p $! >/dev/null", global_browser, global_infourl, argv[1]);
+		snprintf(cmd,sizeof(cmd)-1,"%s \"%s%s\" & ps -p $! >/dev/null", global_browser, global_infourl, argv[1]);
 #endif
 		IN_MYCONTEXT output_verbose("Starting browser using command [%s]", cmd);
 		if (my_instance->subcommand(cmd)!=0)
@@ -1864,7 +1866,7 @@ int GldCmdarg::mclassdef(int argc, const char *argv[])
         }
 	
 	/* output the classdef */
-	count = sprintf(buffer,"struct('module','%s','class','%s'", modname, classname);
+	count = snprintf(buffer,sizeof(buffer)-1,"struct('module','%s','class','%s'", modname, classname);
 	for ( prop = oclass->pmap ; prop!=NULL && prop->oclass==oclass ; prop=prop->next )
 	{
 		char temp[1024];
@@ -1875,10 +1877,10 @@ int GldCmdarg::mclassdef(int argc, const char *argv[])
 		}
 		if ( value!=NULL )
 		{
-			count += sprintf(buffer+count, ",...\n\t'%s','%s'", prop->name, value);
+			count += snprintf(buffer+count,sizeof(buffer)-1-count,",...\n\t'%s','%s'", prop->name, value);
 		}
 	}
-	count += sprintf(buffer+count,");\n");
+	count += snprintf(buffer+count,sizeof(buffer)-1-count,");\n");
 	output_raw("%s",buffer);
         return CMDOK;
 }
@@ -2374,7 +2376,7 @@ STATUS GldCmdarg::load(int argc,const char *argv[])
 		{
 			CMDARG arg = main_commands[i];
 			char tmp[1024];
-			sprintf(tmp,"%s=",arg.lopt);
+			snprintf(tmp,sizeof(tmp)-1,"%s=",arg.lopt);
 			if ( ( arg.sopt && strncmp(*argv,"-",1)==0 && strcmp((*argv)+1,arg.sopt)==0 ) 
 			  || ( arg.lopt && strncmp(*argv,"--",2)==0 && strcmp((*argv)+2,arg.lopt)==0 ) 
 			  || ( arg.lopt && strncmp(*argv,"--",2)==0 && strncmp((*argv)+2,tmp,strlen(tmp))==0 ) )

--- a/gldcore/convert.cpp
+++ b/gldcore/convert.cpp
@@ -986,7 +986,7 @@ int convert_to_object(const char *buffer, /**< a pointer to the string buffer */
 		*target = NULL;
 		return 1;
 	}
-	else if ( sscanf(buffer,"\"%[^\"]\"",oname) == 1 || (strchr(buffer,':') == NULL && strncpy(oname,buffer,sizeof(oname))) )
+	else if ( sscanf(buffer,"\"%[^\"]\"",oname) == 1 || (strchr(buffer,':') == NULL && strncpy(oname,buffer,sizeof(oname)-1)) )
 	{
 		oname[sizeof(oname)-1]='\0'; /* terminate unterminated string */
 		*target = object_find_name(oname);
@@ -1501,7 +1501,7 @@ int convert_to_struct(const char *buffer, void *data, PROPERTY *structure)
 	{
 		return -1;
 	}
-	strncpy(temp,buffer+1,sizeof(temp));
+	strncpy(temp,buffer+1,sizeof(temp)-1);
 	char *item = NULL;
 	char *last = NULL;
 	while ( (item=strtok_s(item?NULL:temp,";",&last)) != NULL )

--- a/gldcore/debug.cpp
+++ b/gldcore/debug.cpp
@@ -222,7 +222,7 @@ static const char *get_objname(OBJECT *obj)
 {
 	static char buf[1024];
 	if (obj->name) return obj->name;
-	sprintf(buf,"%s:%d", obj->oclass->name, obj->id);
+	snprintf(buf,sizeof(buf)-1,"%s:%d", obj->oclass->name, obj->id);
 	return buf;
 }
 
@@ -241,7 +241,7 @@ static STATUS exec(const char *format,...)
 	char cmd[1024];
 	va_list ptr;
 	va_start(ptr,format);
-	vsprintf(cmd,format,ptr);
+	vsnprintf(cmd,sizeof(cmd)-1,format,ptr);
 	va_end(ptr);
 	output_debug("Running '%s'", cmd);
 	return system(cmd)==0?SUCCESS:FAILED;
@@ -426,7 +426,7 @@ static int exec_add_watchpoint(OBJECT *obj, /**< the object being watched */
 
 static void list_object(OBJECT *obj, PASSCONFIG pass)
 {
-	char details[132] = "";
+	char details[4096] = "";
 	char buf1[64],buf2[64],buf3[64];
 	if (list_unnamed==0 && obj->name==NULL)
 		return;
@@ -438,7 +438,7 @@ static void list_object(OBJECT *obj, PASSCONFIG pass)
 	{
 		char valid_to[64] = "";
 		convert_from_timestamp(obj->valid_to,valid_to,sizeof(valid_to));
-		sprintf(details,"%s %c%c%c %s/%s/%d ", valid_to,
+		snprintf(details,sizeof(details)-1,"%s %c%c%c %s/%s/%d ", valid_to,
 			obj->flags&OF_RECALC?'c':'-', obj->flags&OF_RERANK?'r':'-', obj->flags&OF_FOREIGN?'f':'-',
 			obj->oclass->module->name, obj->oclass->name, obj->id);
 	}

--- a/gldcore/enduse.cpp
+++ b/gldcore/enduse.cpp
@@ -89,7 +89,45 @@ static unsigned int enduse_magic = 0x8c3d7762;
 int enduse_create(void *ptr)
 {
 	enduse *data = (enduse*)ptr;
-	memset(data,0,sizeof(enduse));
+	data->total = 0.0;
+	data->energy = 0.0;
+	data->demand = 0.0;
+	data->config = 0;
+	data->breaker_amps = 0.0;
+	data->admittance = 0.0;
+	data->current = 0.0;
+	data->power = 0.0;
+	for ( unsigned int n = 0 ; n < sizeof(data->motor)/sizeof(data->motor[0]); n++ )
+	{
+		data->motor[n].power = 0.0;
+		data->motor[n].impedance = 0.0;
+		data->motor[n].inertia = 0.0;
+		data->motor[n].v_stall = 0.0;
+		data->motor[n].v_start = 0.0;
+		data->motor[n].v_trip = 0.0;
+		data->motor[n].t_trip = 0.0;
+	}
+	for ( unsigned int n = 0 ; n < sizeof(data->electronic)/sizeof(data->electronic[0]); n++ )
+	{
+		data->electronic[n].power = 0.0;
+		data->electronic[n].inertia = 0.0;
+		data->electronic[n].v_trip = 0.0;
+		data->electronic[n].v_start = 0.0;
+	}
+	data->impedance_fraction = 0.0;
+	data->current_fraction = 0.0;
+	data->power_fraction = 0.0;
+	data->power_factor = 0.0;
+	data->voltage_factor = 0.0;
+	data->heatgain = 0.0;
+	data->cumulative_heatgain = 0.0;
+	data->heatgain_fraction = 0.0;
+	data->gas_fraction = 0.0;
+	data->name = NULL;
+	data->shape = NULL;
+	data->t_last = 0;
+	// @todo this is obsolete and must be retrofitted with the above values
+	data->end_obj = NULL;
 	data->next = enduse_list;
 	enduse_list = data;
 	n_enduses++;

--- a/gldcore/enduse.h
+++ b/gldcore/enduse.h
@@ -168,6 +168,7 @@ typedef struct s_enduse
 	loadshape *shape;
 	TIMESTAMP t_last;
 	// @todo this is obsolete and must be retrofitted with the above values
+	// Don't forget to initialize the data in enduse_create()
 	DEPRECATED struct s_object_list *end_obj;
 	struct s_enduse *next;
 #ifdef _DEBUG

--- a/gldcore/exec.cpp
+++ b/gldcore/exec.cpp
@@ -745,7 +745,7 @@ void GldExec::do_checkpoint(void)
 		/* checkpoint time lapsed */
 		if ( last_checkpoint + global_checkpoint_interval <= now )
 		{
-			static char fn[1024] = "";
+			static char fn[2048] = "";
 			FILE *fp = NULL;
 
 			/* default checkpoint filename */
@@ -767,7 +767,7 @@ void GldExec::do_checkpoint(void)
 				unlink(fn);
 
 			/* create current checkpoint save filename */
-			sprintf(fn,"%s.%d",global_checkpoint_file,global_checkpoint_seqnum++);
+			snprintf(fn,sizeof(fn)-1,"%s.%d",global_checkpoint_file,global_checkpoint_seqnum++);
 			fp = fopen(fn,"w");
 			if ( fp==NULL )
 				output_error("unable to open checkpoint file '%s' for writing");

--- a/gldcore/find.cpp
+++ b/gldcore/find.cpp
@@ -274,7 +274,7 @@ FINDLIST *find_objects(FINDLIST *start, ...)
 	if (start==FL_GROUP)
 	{
 		FINDPGM *pgm;
-		va_list(ptr);
+		va_list ptr;
 		va_start(ptr,start);
 		pgm = find_pgm_new(va_arg(ptr,char*));
 		if (pgm!=NULL){
@@ -289,7 +289,7 @@ FINDLIST *find_objects(FINDLIST *start, ...)
 	for (obj=object_get_first(); obj!=NULL; obj=obj->next)
 	{
 		FINDTYPE ftype;
-		va_list(ptr);
+		va_list ptr;
 		va_start(ptr,start);
 		while ((ftype=(FINDTYPE)va_arg(ptr,int)) != FT_END)
 		{
@@ -1287,7 +1287,7 @@ const char *find_file(const char *name, /**< the name of the file to find */
 	/* locate unit file on GLPATH if not found locally */
 	if ( glpath != NULL )
 	{
-		strncpy(envbuf, glpath, sizeof(envbuf));
+		strncpy(envbuf, glpath, sizeof(envbuf)-1);
 		char *last;
 		dir = strtok_r(envbuf, delim,&last);
 		while (dir)

--- a/gldcore/globals.cpp
+++ b/gldcore/globals.cpp
@@ -411,7 +411,7 @@ STATUS GldGlobals::init(void)
 	global_version_minor = version_minor();
 	global_version_patch = version_patch();
 	global_version_build = version_build();
-	strncpy(global_version_branch,version_branch(),sizeof(global_version_branch));
+	strncpy(global_version_branch,version_branch(),sizeof(global_version_branch)-1);
 	strcpy(global_datadir,global_execdir);
 	char *bin = strstr(global_datadir,"/bin");
 	if ( bin ) *bin = '\0';
@@ -565,7 +565,7 @@ GLOBALVAR *GldGlobals::create_v(const char *name, va_list arg)
 					 */
 				}
 				key->next = prop->keywords;
-				strncpy(key->name, keyword, sizeof(key->name));
+				strncpy(key->name, keyword, sizeof(key->name)-1);
 				key->value = keyvalue;
 				prop->keywords = key;
 			} 
@@ -582,7 +582,7 @@ GLOBALVAR *GldGlobals::create_v(const char *name, va_list arg)
 					 */
 				}
 				key->next = prop->keywords;
-				strncpy(key->name, keyword, sizeof(key->name));
+				strncpy(key->name, keyword, sizeof(key->name)-1);
 				key->value = keyvalue;
 				prop->keywords = key;
 			} 
@@ -735,7 +735,7 @@ STATUS GldGlobals::setvar_v(const char *def, va_list ptr) /**< the definition */
 		v = va_arg(ptr,char*);
 		if ( v != NULL ) 
 		{
-			strncpy(value,v,sizeof(value));
+			strncpy(value,v,sizeof(value)-1);
 			if (strcmp(value,v)!=0)
 				output_error("GldGlobals::setvar_v(const char *def='%s',...): va_list value is too long to store",def);
 				/* TROUBLESHOOT
@@ -1103,7 +1103,7 @@ bool GldGlobals::parameter_expansion(char *buffer, size_t size, const char *spec
 			strncpy(buffer,temp,size);
 			strncpy(buffer+start,string,size-start);
 			strncpy(buffer+start+strlen(string),temp+start+strlen(pattern),size-start-strlen(string));
-			strncpy(temp,buffer,sizeof(temp));
+			strncpy(temp,buffer,sizeof(temp)-1);
 		}
 		return 1;
 	}

--- a/gldcore/gridlabd.in
+++ b/gldcore/gridlabd.in
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Generated from gridlabd.m4sh by GNU Autoconf 2.69.
+# Generated from gldcore/gridlabd.m4sh by GNU Autoconf 2.69.
 ## -------------------- ##
 ## M4sh Initialization. ##
 ## -------------------- ##

--- a/gldcore/gui.cpp
+++ b/gldcore/gui.cpp
@@ -314,7 +314,7 @@ int GldGui::is_action(GUIENTITY *entity)
 /* SET OPERATIONS */
 void GldGui::set_srcref(GUIENTITY *entity, char *filename, int linenum)
 {
-	sprintf(entity->srcref,"%s(%d)", filename, linenum);
+	snprintf(entity->srcref,sizeof(entity->srcref)-1,"%s(%d)", filename, linenum);
 }
 void GldGui::set_type(GUIENTITY *entity, GUIENTITYTYPE type)
 {
@@ -322,21 +322,21 @@ void GldGui::set_type(GUIENTITY *entity, GUIENTITYTYPE type)
 }
 void GldGui::set_value(GUIENTITY *entity, char *value)
 {
-	strncpy(entity->value,value,sizeof(entity->value));
+	strncpy(entity->value,value,sizeof(entity->value)-1);
 }
 void GldGui::set_variablename(GUIENTITY *entity, char *globalname)
 {
-	strncpy(entity->globalname,globalname,sizeof(entity->globalname));
+	strncpy(entity->globalname,globalname,sizeof(entity->globalname)-1);
 }
 void GldGui::set_objectname(GUIENTITY *entity, char *objectname)
 {
 	entity->data = NULL;
-	strncpy(entity->objectname,objectname,sizeof(entity->objectname));
+	strncpy(entity->objectname,objectname,sizeof(entity->objectname)-1);
 }
 void GldGui::set_propertyname(GUIENTITY *entity, char *propertyname)
 {
 	entity->data = NULL;
-	strncpy(entity->propertyname,propertyname,sizeof(entity->propertyname));
+	strncpy(entity->propertyname,propertyname,sizeof(entity->propertyname)-1);
 }
 void GldGui::set_span(GUIENTITY *entity, int span)
 {
@@ -356,22 +356,22 @@ void GldGui::set_parent(GUIENTITY *entity, GUIENTITY *parent)
 }
 void GldGui::set_source(GUIENTITY *entity, char *source)
 {
-	strncpy(entity->source,source,sizeof(entity->source));
+	strncpy(entity->source,source,sizeof(entity->source)-1);
 }
 void GldGui::set_options(GUIENTITY *entity, char *options)
 {
-	strncpy(entity->options,options,sizeof(entity->options));
+	strncpy(entity->options,options,sizeof(entity->options)-1);
 }
 void GldGui::set_wait(GUIENTITY *entity, char *wait)
 {
-	strncpy(entity->wait_for,wait,sizeof(entity->wait_for));
+	strncpy(entity->wait_for,wait,sizeof(entity->wait_for)-1);
 }
 
 /* GET OPERATIONS */
 char *GldGui::get_dump(GUIENTITY *entity)
 {
-	static char buffer[1024];
-	sprintf(buffer,"{type=%s,srcref='%s',value='%s',globalname='%s',object='%s',property='%s',action='%s',span=%d}",
+	static char buffer[4096];
+	snprintf(buffer,sizeof(buffer)-1,"{type=%s,srcref='%s',value='%s',globalname='%s',object='%s',property='%s',action='%s',span=%d}",
 		get_typename(entity), entity->srcref, entity->value, entity->globalname, entity->objectname, entity->propertyname, entity->action, entity->span);
 	return buffer;
 }
@@ -396,26 +396,26 @@ char *GldGui::get_value(GUIENTITY *entity)
 		else if (strcmp(entity->propertyname,"parent")==0)
 			strcpy(entity->value,obj->parent?object_name(obj->parent, buffer, 63):"");
 		else if (strcmp(entity->propertyname,"rank")==0)
-			sprintf(entity->value,"%d",obj->rank);
+			snprintf(entity->value,sizeof(entity->value)-1,"%d",obj->rank);
 		else if (strcmp(entity->propertyname,"clock")==0)
-			convert_from_timestamp(obj->clock,entity->value,sizeof(entity->value));
+			convert_from_timestamp(obj->clock,entity->value,sizeof(entity->value)-1);
 		else if (strcmp(entity->propertyname,"valid_to")==0)
-			convert_from_timestamp(obj->valid_to,entity->value,sizeof(entity->value));
+			convert_from_timestamp(obj->valid_to,entity->value,sizeof(entity->value)-1);
 		else if (strcmp(entity->propertyname,"in_svc")==0)
-			convert_from_timestamp(obj->in_svc,entity->value,sizeof(entity->value));
+			convert_from_timestamp(obj->in_svc,entity->value,sizeof(entity->value)-1);
 		else if (strcmp(entity->propertyname,"out_svc")==0)
-			convert_from_timestamp(obj->out_svc,entity->value,sizeof(entity->value));
+			convert_from_timestamp(obj->out_svc,entity->value,sizeof(entity->value)-1);
 		else if (strcmp(entity->propertyname,"latitude")==0)
-			convert_from_latitude(obj->latitude,entity->value,sizeof(entity->value));
+			convert_from_latitude(obj->latitude,entity->value,sizeof(entity->value)-1);
 		else if (strcmp(entity->propertyname,"longitude")==0)
-			convert_from_longitude(obj->longitude,entity->value,sizeof(entity->value));
-		else if (!object_get_value_by_name(obj,entity->propertyname,entity->value,sizeof(entity->value)))
+			convert_from_longitude(obj->longitude,entity->value,sizeof(entity->value)-1);
+		else if (!object_get_value_by_name(obj,entity->propertyname,entity->value,sizeof(entity->value)-1))
 			output_error_raw("%s: ERROR: %s refers to a non-existent property '%s'", entity->srcref, get_typename(entity), entity->propertyname);
 	}
 	else if (get_variable(entity))
 	{
 		entity->var = global_find(entity->globalname);
-		global_getvar(entity->globalname,entity->value,sizeof(entity->value));
+		global_getvar(entity->globalname,entity->value,sizeof(entity->value)-1);
 	}
 	else if (get_environment(entity))
 		strcpy(entity->value,entity->env);
@@ -442,7 +442,7 @@ const char *GldGui::get_name(GUIENTITY *entity)
 	if (get_object(entity))
 	{
 		static char buffer[1024];
-		sprintf(buffer,"%s.%s", entity->objectname, entity->propertyname); 
+		snprintf(buffer,sizeof(buffer)-1,"%s.%s", entity->objectname, entity->propertyname); 
 		return buffer;
 	}
 	else if (get_variable(entity))
@@ -573,7 +573,7 @@ void GldGui::cmd_prompt(GUIENTITY *parent)
 Retry:
 	fprintf(stdout,"\n%s> [%s] ",label, get_value(entity));
 	fflush(stdout);
-	if ( fgets(buffer,sizeof(buffer),stdin) == NULL )
+	if ( fgets(buffer,sizeof(buffer)-1,stdin) == NULL )
 		output_error("GldGui::cmd_prompt read failed");
 	buffer[strlen(buffer)-1]='\0';
 	if (strcmp(buffer,"")==0)
@@ -592,7 +592,7 @@ Retry:
 	{
 #ifdef WIN32
 		char env[1024];
-		sprintf(env,"%s=%s",entity->env,buffer);
+		snprintf(env,sizeof(env)-1,"%s=%s",entity->env,buffer);
 		putenv(env);
 #else
 		setenv(entity->env,buffer,1);
@@ -640,7 +640,7 @@ void GldGui::cmd_menu(GUIENTITY *parent)
 Retry:
 		fprintf(stdout,"\nGLM> [%d] ",ans<item?ans+1:0);
 		fflush(stdout);
-		if ( fgets(buffer,sizeof(buffer),stdin) == NULL )
+		if ( fgets(buffer,sizeof(buffer)-1,stdin) == NULL )
 			output_error("GldGui::cmd_menu read failed");
 		buffer[strlen(buffer)-1]='\0';
 		ans = atoi(buffer);
@@ -739,23 +739,23 @@ void GldGui::output_html_textarea(GUIENTITY *entity)
 	size_t len;
 	char rows[32]="";
 	char cols[32]="";
-	if (entity->height>0) sprintf(rows," rows=\"%d\"",entity->height);
-	if (entity->width>0) sprintf(cols," cols=\"%d\"",entity->width);
+	if (entity->height>0) snprintf(rows,sizeof(rows)-1," rows=\"%d\"",entity->height);
+	if (entity->width>0) snprintf(cols,sizeof(cols)-1," cols=\"%d\"",entity->width);
 	html_output(fp,"<textarea class=\"browse\"%s%s >\n",rows,cols);
 	if (src==NULL)
 	{
 		html_output(fp,"***'%s' is not found: %s***",entity->source,strerror(errno));
 		goto Done;
 	}
-	len = fread(buffer,1,sizeof(buffer),src);
+	len = fread(buffer,1,sizeof(buffer)-1,src);
 	if ( len<0 )
 		html_output(fp,"***'%s' read failed: %s***",entity->source,strerror(errno));
-	else if (len<sizeof(buffer))
+	else if (len<sizeof(buffer)-1)
 	{
 		buffer[len]='\0';
 		html_output(fp,"%s",buffer);
 	}
-	if ( len>=sizeof(buffer) )
+	if ( len>=sizeof(buffer)-1 )
 		html_output(fp,"\n***file truncated***");
 Done:
 	html_output(fp,"</textarea>\n");
@@ -773,14 +773,14 @@ void GldGui::output_html_table(GUIENTITY *entity)
 		html_output(fp,"***'%s' is not found: %s***",entity->source,strerror(errno));
 		goto Done;
 	}
-	while ( fgets(line,sizeof(line),src)!=NULL )
+	while ( fgets(line,sizeof(line)-1,src)!=NULL )
 	{
 		char *eol = strchr(line,'\n');
 		if (eol) *eol='\0';
 		if ( line[0]=='#' )
 		{
 			if ( row==0 )
-				strncpy(header,line+1,sizeof(header));
+				strncpy(header,line+1,sizeof(header)-1);
 		}
 		else 
 		{
@@ -810,23 +810,23 @@ Done:
 
 void GldGui::output_html_graph(GUIENTITY *entity)
 {
-	char script[1024];
-	char command[1024];
-	char image[1024];
+	char script[2048];
+	char command[4096];
+	char image[2048];
 	char height[32]="";
 	char width[32]="";
 	FILE *plot=NULL;
 
 	/* setup gnuplot command */
-	sprintf(script,"%s.plt",entity->source);
+	snprintf(script,sizeof(script)-1,"%s.plt",entity->source);
 #ifdef WIN32
-	sprintf(command,"start wgnuplot %s",script);
+	snprintf(command,sizeof(command)-1,"start wgnuplot %s",script);
 #else
-	sprintf(command,"gnuplot %s",script);
+	snprintf(command,sizeof(command)-1,"gnuplot %s",script);
 #endif
-	sprintf(image,"%s.png",entity->source);
-	if (entity->width>0) sprintf(width," width=\"%d\"", entity->width);
-	if (entity->height>0) sprintf(height, " height=\"%d\"", entity->height);
+	snprintf(image,sizeof(image)-1,"%s.png",entity->source);
+	if (entity->width>0) snprintf(width,sizeof(width)-1," width=\"%d\"", entity->width);
+	if (entity->height>0) snprintf(height,sizeof(height)-1," height=\"%d\"", entity->height);
 
 	/* generate script */
 	plot = fopen(script,"w");
@@ -958,7 +958,7 @@ void GldGui::entity_html_content(GUIENTITY *entity)
 			KEYWORD *key = NULL;
 			const char *multiple = (prop->ptype==PT_set?"multiple":"");
 			char size[64] = "";
-			if (entity->size>0) sprintf(size,"size=\"%d\"",entity->size);
+			if (entity->size>0) snprintf(size,sizeof(size)-1,"size=\"%d\"",entity->size);
 			if (!entity->parent || get_type(entity->parent)!=GUI_SPAN) newcol(entity);
 			html_output(fp,"<select class=\"%s\" name=\"%s\" %s %s onchange=\"update_%s(this)\">\n", ptype, get_name(entity),multiple,size,ptype);
 			for (key=prop->keywords; key!=NULL; key=key->next)
@@ -1053,7 +1053,7 @@ void GldGui::html_output_children(GUIENTITY *entity)
 void GldGui::include_element(const char *tag, const char *options, const char *file)
 {
 	char path[1024];
-	if (!find_file(file,NULL,R_OK,path,sizeof(path)))
+	if (!find_file(file,NULL,R_OK,path,sizeof(path)-1))
 		output_error("unable to find '%s'", file);
 	else
 	{
@@ -1063,7 +1063,7 @@ void GldGui::include_element(const char *tag, const char *options, const char *f
 		else
 		{
 			char buffer[65536];
-			size_t len = fread(buffer,1,sizeof(buffer),fin);
+			size_t len = fread(buffer,1,sizeof(buffer)-1,fin);
 			if (len>=0)
 			{
 				buffer[len]='\0';
@@ -1223,13 +1223,13 @@ size_t GldGui::glm_write_all(FILE *fp)
 STATUS GldGui::startup(int argc, const char *argv[])
 {
 	static int started = 0;
-	char cmd[1024];
+	char cmd[2048];
 	if (started)
 		return SUCCESS;
 #ifdef WIN32
-	sprintf(cmd,"start %s http://localhost:%d/gui/", global_browser, global_server_portnum);
+	snprintf(cmd,sizeof(cmd)-1,"start %s http://localhost:%d/gui/", global_browser, global_server_portnum);
 #else
-	sprintf(cmd,"%s http://localhost:%d/gui/ & ps -p $! >/dev/null", global_browser, global_server_portnum);
+	snprintf(cmd,sizeof(cmd)-1,"%s http://localhost:%d/gui/ & ps -p $! >/dev/null", global_browser, global_server_portnum);
 #endif
 	if (system(cmd)!=0)
 	{

--- a/gldcore/http_client.cpp
+++ b/gldcore/http_client.cpp
@@ -78,7 +78,7 @@ HTTP* hopen(const char *url, int maxlen)
 	}
 
 	/* format/send request */
-	len = sprintf(request,"GET %s HTTP/1.1\r\nHost: %s:80\r\nUser-Agent: %s/%d.%d\r\nConnection: close\r\n\r\n",PACKAGE_NAME,filespec,hostname,REV_MAJOR,REV_MINOR);
+	len = snprintf(request,sizeof(request)-1,"GET %s HTTP/1.1\r\nHost: %s:80\r\nUser-Agent: %s/%d.%d\r\nConnection: close\r\n\r\n",PACKAGE_NAME,filespec,hostname,REV_MAJOR,REV_MINOR);
 	IN_MYCONTEXT output_debug("sending HTTP message \n%s", request);
 	if ( send(http->sd,request,len,0)<len )
 	{
@@ -347,8 +347,8 @@ void http_get_options(void)
 	char *option=NULL, *last=NULL;
 	while ( (option=global_wget_options.token(option,";",&last))!=NULL )
 	{
-		char name[1024], value[1024];
-		int n = sscanf(option,"%[^:]:%[^\n\r]",name,value);
+		char name[1023], value[1023];
+		int n = sscanf(option,"%1022[^:]:%1022[^\n\r]",name,value);
 		if ( n>0 )
 		{
 			if ( strcmp(name,"maxsize")==0 )

--- a/gldcore/instance_cnx.cpp
+++ b/gldcore/instance_cnx.cpp
@@ -12,7 +12,7 @@ extern int sock_created;
 
 STATUS instance_cnx_mmap(instance *inst){
 #ifdef WIN32
-		char cachename[1024];
+		char cachename[2048];
 		char eventname[64];
 		SECURITY_ATTRIBUTES secAttr = {sizeof(SECURITY_ATTRIBUTES),(LPSECURITY_ATTRIBUTES)NULL,TRUE}; 
 
@@ -26,7 +26,7 @@ STATUS instance_cnx_mmap(instance *inst){
 		}
 
 		/* setup cache */
-		sprintf(cachename,"GLD-%" FMT_INT64 "x",inst->cacheid);
+		snprintf(cachename,sizeof(cachename)-1,"GLD-%" FMT_INT64 "x",inst->cacheid);
 		inst->hMap = OpenFileMapping(FILE_MAP_ALL_ACCESS,FALSE,cachename);
 		if ( !inst->hMap )
 		{
@@ -106,7 +106,7 @@ STATUS instance_cnx_shmem(instance *inst){
 
 STATUS instance_cnx_socket(instance *inst){
 	char cmd[1024];
-	char sendcmd[1024];
+	char sendcmd[4097];
 	INSTANCE_PICKLE pickle;
 	char *colon;
 	int rv, return_addr_sz;
@@ -244,7 +244,7 @@ STATUS instance_cnx_socket(instance *inst){
 
 	// build command
 	// HS_CMD dir file r_port cacheid profile relax debug verbose warn quiet avlbalance
-	sprintf(sendcmd, HS_CMD	"dir=\"%s\" file=\"%s\" port=%d id=%" FMT_INT64 "d %s %s %s %s %s %s %s",
+	snprintf(sendcmd,sizeof(sendcmd)-1, HS_CMD	"dir=\"%s\" file=\"%s\" port=%d id=%" FMT_INT64 "d %s %s %s %s %s %s %s",
 		inst->execdir,
 		inst->model,
 		inst->return_port,

--- a/gldcore/job.cpp
+++ b/gldcore/job.cpp
@@ -48,7 +48,7 @@ static const char *GetLastErrorMsg(void)
 	char *p;
 	while ( (p=strchr((char*)lpMsgBuf,'\n'))!=NULL ) *p=' ';
 	while ( (p=strchr((char*)lpMsgBuf,'\r'))!=NULL ) *p=' ';
-    sprintf(szBuf, "%s (error code %d)", lpMsgBuf, dw); 
+    snprintf(szBuf,sizeof(szBuf)-1,"%s (error code %d)", lpMsgBuf, dw); 
  
     LocalFree(lpMsgBuf);
 	wunlock(&lock);
@@ -58,7 +58,7 @@ static DIR *opendir(const char *dirname)
 {
 	WIN32_FIND_DATA fd;
 	char search[MAX_PATH];
-	sprintf(search,"%s/*",dirname);
+	snprintf(search,sizeof(search)-1,"%s/*",dirname);
 	HANDLE dh = FindFirstFile(search,&fd);
 	if ( dh==INVALID_HANDLE_VALUE )
 	{
@@ -131,7 +131,7 @@ static int vsystem(const char *fmt, ...)
 	char command[1024];
 	va_list ptr;
 	va_start(ptr,fmt);
-	vsprintf(command,fmt,ptr);
+	vsnprintf(command,sizeof(command)-1,fmt,ptr);
 	va_end(ptr);
 	IN_MYCONTEXT output_debug("calling system('%s')",command);
 	int rc = system(command);
@@ -151,7 +151,7 @@ bool job_destroy_dir(char *name)
 		if ( strcmp(dp->d_name,".")!=0 && strcmp(dp->d_name,"..")!=0 )
 		{
 			char file[1024];
-			sprintf(file,"%s/%s",name,dp->d_name);
+			snprintf(file,sizeof(file)-1,"%s/%s",name,dp->d_name);
 			if ( unlink(file)!=0 )
 			{
 				output_error("destroy_dir(char *name='%s'): unlink('%s') returned '%s'", name, dp->d_name,strerror(errno));
@@ -246,7 +246,7 @@ static bool run_job(char *file, double *elapsed_time=NULL)
 
 /* simple stack to handle directories that need to be processed */
 typedef struct s_jobstack {
-	char name[1024];
+	char name[4097];
 	struct s_jobstack *next;
 } JOBLIST;
 static JOBLIST *jobstack = NULL;
@@ -298,8 +298,8 @@ static size_t process_dir(const char *path)
 	if ( dirp==NULL ) return 0; // nothing to do
 	while ( (dp=readdir(dirp))!=NULL )
 	{
-		char item[1024];
-		sprintf(item,"%s/%s",path,dp->d_name);
+		char item[4096];
+		snprintf(item,sizeof(item)-1,"%s/%s",path,dp->d_name);
 		char *ext = strrchr(dp->d_name,'.');
 		if ( dp->d_name[0]=='.' ) continue; // ignore anything that starts with a dot
 		if ( ext && strcmp(ext,".glm")==0 )

--- a/gldcore/legal.cpp
+++ b/gldcore/legal.cpp
@@ -86,7 +86,6 @@ STATUS legal_notice(void)
  **/
 const char *legal_license_text(void)
 {
-
 	char tmp[1024];
 	strcpy(tmp,global_execdir);
 	char *p = strrchr(tmp,'/');
@@ -94,13 +93,14 @@ const char *legal_license_text(void)
 	{
 		*p = '\0';
 	}
-	char license_filename[1024];
-	sprintf(license_filename,"%s/LICENSE",tmp);
+	char license_filename[2048];
+	snprintf(license_filename,sizeof(license_filename)-1,"%s/LICENSE",tmp);
 	FILE *fp = fopen(license_filename,"r");
 	if ( fp == NULL )
 	{
-		sprintf(tmp,"file '%s' not found", license_filename);
-		return strdup(tmp);
+		char *errmsg;
+		asprintf(&errmsg,"file '%s' not found", license_filename);
+		return strdup(errmsg);
 	}
 	static char license_text[65536];
 	license_text[fread(license_text,1,sizeof(license_text)-1,fp)] = '\0';
@@ -170,7 +170,7 @@ void *check_version_proc(void *ptr)
 	}
 
 	/* read version data */
-	sprintf(target,"%d.%d:",version_major(),version_minor());
+	snprintf(target,sizeof(target)-1,"%d.%d:",version_major(),version_minor());
 	pv = strstr(result->body.data,target);
 	if ( pv==NULL )
 	{

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -369,7 +369,7 @@ int GldLoader::write_file(FILE *fp, const char *data, ...)
 	char *b;
 	va_list ptr;
 	va_start(ptr,data);
-	vsprintf(buffer,data,ptr);
+	vsnprintf(buffer,sizeof(buffer)-1,data,ptr);
 	va_end(ptr);
 	while ( (c=strstr(d,"/*RESETLINE*/\n")) != NULL )
 	{
@@ -477,7 +477,7 @@ STATUS GldLoader::compile_code(CLASS *oclass, int64 functions)
 	{
 		if ( getenv("GRIDLABD") )
 		{
-			strncpy(global_include,getenv("GRIDLABD"),sizeof(global_include));
+			strncpy(global_include,getenv("GRIDLABD"),sizeof(global_include)-1);
 			IN_MYCONTEXT output_verbose("global_include is not set, assuming value of GRIDLABD variable '%s'", global_include);
 		}
 		else
@@ -499,17 +499,17 @@ STATUS GldLoader::compile_code(CLASS *oclass, int64 functions)
 		FILE *fp;
 		struct stat stat;
 		int outdated = true;
-		char cfile[1024];
-		char ofile[1024];
-		char afile[1024];
-		char file[1024];
-		char tmp[1024];
-		char tbuf[1024];
+		char cfile[4097];
+		char ofile[4097];
+		char afile[4097];
+		char file[4097];
+		char tmp[1025];
+		char tbuf[1025];
 		size_t ifs_off = 0;
 		INCLUDELIST *lptr = 0;
 
 		/* build class implementation files */
-		strncpy(tmp, global_tmp, sizeof(tmp));
+		strncpy(tmp, global_tmp, sizeof(tmp)-1);
 		if ( mkdirs(tmp) ) 
 		{
 			errno = 0;
@@ -519,10 +519,10 @@ STATUS GldLoader::compile_code(CLASS *oclass, int64 functions)
 		{
 			strcat(tmp,"/");
 		}
-		sprintf(cfile,"%s%s.cpp", (use_msvc||global_gdb||global_gdb_window)?"":tmp,oclass->name);
-		sprintf(ofile,"%s%s.%s", (use_msvc||global_gdb||global_gdb_window)?"":tmp,oclass->name, use_msvc?"obj":"o");
-		sprintf(file,"%s%s", (use_msvc||global_gdb||global_gdb_window)?"":tmp, oclass->name);
-		sprintf(afile, "%s" DLEXT , oclass->name);
+		snprintf(cfile,sizeof(cfile)-1,"%s%s.cpp", (use_msvc||global_gdb||global_gdb_window)?"":tmp,oclass->name);
+		snprintf(ofile,sizeof(ofile)-1,"%s%s.%s", (use_msvc||global_gdb||global_gdb_window)?"":tmp,oclass->name, use_msvc?"obj":"o");
+		snprintf(file,sizeof(file)-1,"%s%s", (use_msvc||global_gdb||global_gdb_window)?"":tmp, oclass->name);
+		snprintf(afile,sizeof(afile)-1,"%s" DLEXT , oclass->name);
 
 		/* peek at library file */
 		fp = fopen(afile,"r");
@@ -572,7 +572,7 @@ STATUS GldLoader::compile_code(CLASS *oclass, int64 functions)
 			ifs_off = 0;
 			for ( lptr = header_list ; lptr != 0; lptr = lptr->next )
 			{
-				sprintf(include_file_str+ifs_off, "#include \"%s\"\n;", lptr->file);
+				snprintf(include_file_str+ifs_off, sizeof(include_file_str)-ifs_off-1, "#include \"%s\"\n;", lptr->file);
 				ifs_off+=strlen(lptr->file)+13;
 			}
 			if ( write_file(fp,"/* automatically generated from %s */\n\n"
@@ -627,12 +627,12 @@ STATUS GldLoader::compile_code(CLASS *oclass, int64 functions)
 #define DEFAULT_CXX "g++"
 #define DEFAULT_CXXFLAGS ""
 #define DEFAULT_LDFLAGS ""
-			char execstr[1024];
-			char ldstr[1024];
+			char execstr[65537];
+			char ldstr[65537];
 			char mopt[8]="";
 			const char *libs = "-lstdc++";
 
-			sprintf(execstr, "%s %s %s %s %s -fPIC -c \"%s\" -o \"%s\"",
+			snprintf(execstr,sizeof(execstr)-1, "%s %s %s %s %s -fPIC -c \"%s\" -o \"%s\"",
 					getenv("CXX")?getenv("CXX"):DEFAULT_CXX,
 					global_warn_mode?"-w":"",
 					global_debug_output?"-g -O0":"-O0",
@@ -656,7 +656,7 @@ STATUS GldLoader::compile_code(CLASS *oclass, int64 functions)
 
 			/* link new runtime module */
 			IN_MYCONTEXT output_verbose("linking inline code from '%s'", ofile);
-			sprintf(ldstr, "%s %s %s %s -shared -Wl,\"%s\" -o \"%s\" %s",
+			snprintf(ldstr,sizeof(ldstr)-1, "%s %s %s %s -shared -Wl,\"%s\" -o \"%s\" %s",
 					getenv("CXX")?getenv("CXX"):DEFAULT_CXX,
 					mopt,
 					global_debug_output?"-g -O0":"",
@@ -1128,7 +1128,7 @@ int GldLoader::pattern(PARSER, const char *pattern, char *result, int size)
 {
 	char format[64];
 	START;
-	sprintf(format,"%%%s",pattern);
+	snprintf(format,sizeof(format)-1,"%%%s",pattern);
 	if (sscanf(_p,format,result)==1)
 		_n = (int)strlen(result);
 	DONE;
@@ -2417,11 +2417,11 @@ int GldLoader::expanded_value(const char *text, char *result, int size, const ch
 				else if (strcmp(varname,"hostaddr")==0)
 					strcpy(value,global_hostaddr); 
 				else if (strcmp(varname,"cpu")==0)
-					sprintf(value,"%d",sched_get_cpuid(0)); 
+					snprintf(value,sizeof(value)-1,"%d",sched_get_cpuid(0)); 
 				else if (strcmp(varname,"pid")==0)
-					sprintf(value,"%d",sched_get_procid()); 
+					snprintf(value,sizeof(value)-1,"%d",sched_get_procid()); 
 				else if (strcmp(varname,"port")==0)
-					sprintf(value,"%d",global_server_portnum);
+					snprintf(value,sizeof(value)-1,"%d",global_server_portnum);
 				else if (strcmp(varname,"mastername")==0)
 					strcpy(value,"localhost"); /* @todo copy actual master name */
 				else if (strcmp(varname,"masteraddr")==0)
@@ -2431,7 +2431,7 @@ int GldLoader::expanded_value(const char *text, char *result, int size, const ch
 				else if (strcmp(varname,"id")==0)
 				{
 					if (current_object)
-						sprintf(value,"%d",current_object->id);
+						snprintf(value,sizeof(value)-1,"%d",current_object->id);
 					else
 						strcpy(value,"");
 				}
@@ -2735,7 +2735,7 @@ int GldLoader::module_block(PARSER)
 	/* foreign module */
 	if (TERM(name(HERE,fmod,sizeof(fmod))) && LITERAL("::") && TERM(name(HERE,mod,sizeof(mod))))
 	{
-		sprintf(module_name,"%s::%s",fmod,mod);
+		snprintf(module_name,sizeof(module_name)-1,"%s::%s",fmod,mod);
 		if ((module=module_load(module_name,0,NULL))!=NULL)
 		{
 			ACCEPT;
@@ -3019,8 +3019,9 @@ int GldLoader::source_code(PARSER, char *code, int size)
 		case COMMENTBLOCK:
 			if (c1=='*' && c2=='/')
 			{
+				int len = strlen(code);
 				if (!global_debug_output && global_getvar("noglmrefs",buffer,63)==NULL)
-					sprintf(code+strlen(code),"#line %d \"%s\"\n", linenum,forward_slashes(filename).c_str());
+					snprintf(code+len,size-len-1,"#line %d \"%s\"\n", linenum,forward_slashes(filename).c_str());
 				state = CODE;
 			}
 			break;
@@ -3743,8 +3744,8 @@ int GldLoader::property_ref(PARSER, TRANSFORMSOURCE *xstype, void **ref, OBJECT 
 		if (obj==NULL)
 		{
 			// add to unresolved list
-			char id[1024];
-			sprintf(id,"%s.%s",oname,pname);
+			char id[4096];
+			snprintf(id,sizeof(id)-1,"%s.%s",oname,pname);
 			*ref = (void*)add_unresolved(from,PT_double,NULL,from->oclass,id,filename,linenum,UR_TRANSFORM);
 			ACCEPT;
 		}
@@ -4170,7 +4171,7 @@ int GldLoader::object_properties(PARSER, CLASS *oclass, OBJECT *obj)
 			if ( prop!=NULL && prop->ptype == PT_object && MARKTERM(object_block(HERE,NULL,&subobj)) )
 			{
 				char objname[64];
-				if (subobj->name) strcpy(objname,subobj->name); else sprintf(objname,"%s:%d", subobj->oclass->name,subobj->id);
+				if (subobj->name) strcpy(objname,subobj->name); else snprintf(objname,sizeof(objname)-1,"%s:%d", subobj->oclass->name,subobj->id);
 				if (object_set_value_by_name(obj,propname,objname))
 				{
 					SAVETERM;
@@ -4604,8 +4605,9 @@ int GldLoader::object_properties(PARSER, CLASS *oclass, OBJECT *obj)
 						SAVETERM;
 						ACCEPT;
 					}
-					else if (strcmp(propname,"groupid")==0){
-						strncpy(obj->groupid, propval, sizeof(obj->groupid));
+					else if (strcmp(propname,"groupid")==0)
+					{
+						memcpy(obj->groupid, propval, sizeof(obj->groupid));
 					}
 					else if (strcmp(propname,"flags")==0)
 					{
@@ -5284,7 +5286,7 @@ int GldLoader::gui_entity_parameter(PARSER, GUIENTITY *entity)
 		{
 			char fullname[256];
 			ACCEPT;
-			sprintf(fullname,"%s::%s",modname,varname);
+			snprintf(fullname,sizeof(fullname)-1,"%s::%s",modname,varname);
 			gui_set_variablename(entity,fullname);
 			DONE;
 		}
@@ -6226,8 +6228,8 @@ int GldLoader::loader_hook(PARSER)
 	if ( LITERAL("extension") && WHITE && name(HERE,libname,sizeof(libname)) )
 	{
 		// find the library
-		char pathname[1024];
-		snprintf(pathname, sizeof(pathname), "%s" DLEXT, libname);
+		char pathname[2048];
+		snprintf(pathname, sizeof(pathname)-1, "%s" DLEXT, libname);
 		if ( find_file(pathname, NULL, X_OK|R_OK, pathname,sizeof(pathname)) == NULL )
 		{
 			syntax_error(filename,linenum,"unable to locate %s in GLPATH=%s", pathname,getenv("GLPATH")?getenv("GLPATH"):"");
@@ -7163,7 +7165,7 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 			syntax_error(filename,linenum,"#insert syntax error -- name not found");
 			return FALSE;
 		}
-		sprintf(line,"#include using(%s) \"%s.glm\"",values,name);
+		snprintf(line,size-1,"#include using(%s) \"%s.glm\"",values,name);
 		/* fall through to normal parsing of macros */
 	}
 	else /* add other macro macros here */
@@ -7206,7 +7208,7 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 			++term;
 		if (sscanf(term,"\"%[^\"]\"",value)==1)
 		{
-			int len = sprintf(line,"@%s;%d\n",value,0);
+			int len = snprintf(line,size-1,"@%s;%d\n",value,0);
 			line+=len; size-=len;
 			strcpy(oldfile, filename);	// push old filename
 			strcpy(filename, value);	// use include file name for errors while within context
@@ -7223,7 +7225,7 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 			}
 			else
 			{
-				len = sprintf(line,"@%s;%d\n",filename,linenum);
+				len = snprintf(line,size-1,"@%s;%d\n",filename,linenum);
 				line+=len; size-=len;
 				return size>0;
 			}
@@ -7270,7 +7272,7 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 			}
 			else
 			{
-				sprintf(line+len,"@%s;%d\n",filename,linenum);
+				snprintf(line+len,size-len-1,"@%s;%d\n",filename,linenum);
 				if ( old_stack ) global_restore(old_stack);
 				return TRUE;
 			}
@@ -7321,7 +7323,7 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 		{
 			if ( strcmp(options,"") != 0 )
 			{
-				sprintf(varname,"%s_load_options",ext+1);
+				snprintf(varname,sizeof(varname)-1,"%s_load_options",ext+1);
 				int old_global_strictnames = global_strictnames;
 				if ( global_isdefined(varname) )
 				{
@@ -7549,8 +7551,8 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 		{
 			command++;
 		}
-		char command_line[1024];
-		sprintf(command_line,"%s/gridlabd-%s",global_execdir,command);
+		char command_line[4096];
+		snprintf(command_line,sizeof(command_line)-1,"%s/gridlabd-%s",global_execdir,command);
 		output_verbose("executing system(%s)", command_line);
 		global_return_code = my_instance->subcommand("%s",command_line);
 		if( global_return_code != 0 )

--- a/gldcore/local.cpp
+++ b/gldcore/local.cpp
@@ -33,7 +33,7 @@ void locale_push(void)
 				<a href="http://gridlab-d.svn.sourceforge.net/viewvc/gridlab-d/trunk/core/tzinfo.txt?view=markup">tzinfo.txt</a>
 				file.
 			 */
-		strncpy(locale->tz,tz?tz:"",sizeof(locale->tz));
+		strncpy(locale->tz,tz?tz:"",sizeof(locale->tz)-1);
 		return;
 	}
 }
@@ -48,9 +48,9 @@ void locale_pop(void)
 	else
 	{
 		LOCALE *next = stack;
-		char tz[32];
+		char tz[64];
 		stack = stack->next;
-		sprintf(tz,"TZ=%s",next->tz);
+		snprintf(tz,sizeof(tz)-1,"TZ=%s",next->tz);
 		if (putenv(tz)!=0)
 			output_warning("locale pop failed");
 			/* TROUBLESHOOT

--- a/gldcore/module.cpp
+++ b/gldcore/module.cpp
@@ -292,8 +292,8 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 	char buffer[FILENAME_MAX+1];
 	char *fmod;
 	bool isforeign = false;
-	char pathname[1024];
-	char tpath[1024];
+	char pathname[2048];
+	char tpath[4096];
 #ifdef WIN32
 	char from='/', to='\\';
 #else
@@ -413,12 +413,12 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 	}
 
 	/* locate the module */
-	snprintf(pathname, sizeof(pathname), "%s" DLEXT, file);
+	snprintf(pathname, sizeof(pathname)-1, "%s" DLEXT, file);
 
 	if(find_file(pathname, NULL, X_OK|R_OK, tpath,sizeof(tpath)) == NULL)
 	{
 		IN_MYCONTEXT output_verbose("unable to locate %s in GLPATH, using library loader instead", pathname);
-		strncpy(tpath,pathname,sizeof(tpath));
+		strncpy(tpath,pathname,sizeof(tpath)-1);
 	}
 	else
 	{
@@ -427,10 +427,10 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 		struct stat buf;
 		if (tpath[0]!='/' && stat(tpath,&buf)==0) 
 		{
-			char buffer[1024];
+			char buffer[5000];
 
 			/* add ./ to the beginning of the path */
-			sprintf(buffer,"./%s", tpath);
+			snprintf(buffer,sizeof(buffer)-1,"./%s", tpath);
 			strcpy(tpath,buffer);
 		}
 #endif
@@ -568,7 +568,7 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 		};
 		for ( size_t i = 0 ; i < sizeof(map)/sizeof(map[0]) ; i++ )
 		{
-			snprintf(fname, sizeof(fname) ,"%s_%s",map[i].name,isforeign?fmod:c->name);
+			snprintf(fname, sizeof(fname)-1 ,"%s_%s",map[i].name,isforeign?fmod:c->name);
 			*(map[i].func) = (FUNCTIONADDR)DLSYM(hLib,fname);
 			if ( *(map[i].func) == NULL && ! map[i].optional )
 			{
@@ -659,7 +659,7 @@ static void _module_list (char *path)
 	/* open directory */
 	IN_MYCONTEXT output_debug("module_list(char *path='%s')", path);
 #ifdef WIN32
-	sprintf(search,"%s\\*.dll",path);
+	snprintf(search,sizeof(search)-1,"%s\\*.dll",path);
 	hFind=FindFirstFile(search,&sFind);
 	if ( hFind==INVALID_HANDLE_VALUE )
 		return;
@@ -760,15 +760,15 @@ int module_setvar(MODULE *mod, const char *varname, const char *value)
 {
 	if ( mod->setvar != NULL && mod->setvar(varname,value)>0 )
 		return 1;
-	char modvarname[1024];
-	sprintf(modvarname,"%s::%s",mod->name,varname);
+	char modvarname[2000];
+	snprintf(modvarname,sizeof(modvarname)-1,"%s::%s",mod->name,varname);
 	return global_setvar(modvarname,value)==SUCCESS;
 }
 
 const char* module_getvar(MODULE *mod, const char *varname, char *value, unsigned int size)
 {
-	char modvarname[1024];
-	sprintf(modvarname,"%s::%s",mod->name,varname);
+	char modvarname[2000];
+	snprintf(modvarname,sizeof(modvarname)-1,"%s::%s",mod->name,varname);
 	return global_getvar(modvarname,value,size);
 }
 
@@ -778,12 +778,12 @@ void* module_getvar_old(MODULE *mod, const char *varname, char *value, unsigned 
 	{
 		if (strcmp(varname,"major")==0)
 		{
-			sprintf(value,"%d",mod->major);
+			snprintf(value,sizeof(value)-1,"%d",mod->major);
 			return value;
 		}
 		else if (strcmp(varname,"minor")==0)
 		{
-			sprintf(value,"%d",mod->minor);
+			snprintf(value,sizeof(value)-1,"%d",mod->minor);
 			return value;
 		}
 		else
@@ -795,9 +795,9 @@ void* module_getvar_old(MODULE *mod, const char *varname, char *value, unsigned 
 
 void* module_getvar_addr(MODULE *mod, const char *varname)
 {
-	char modvarname[1024];
+	char modvarname[2049];
 	GLOBALVAR *var;
-	sprintf(modvarname,"%s::%s",mod->name,varname);
+	snprintf(modvarname,sizeof(modvarname)-1,"%s::%s",mod->name,varname);
 	var = global_find(modvarname);
 	if (var!=NULL)
 		return var->prop->addr;
@@ -856,10 +856,10 @@ int module_saveall_xml(FILE *fp){
 	char1024 buffer;
 
 	for (mod = first_module; mod != NULL; mod = mod->next){
-		char tname[67];
+		char tname[2000];
 		size_t tlen;
 		gvptr = global_getnext(NULL);
-		sprintf(tname, "%s::", mod->name);
+		snprintf(tname,sizeof(tname)-1, "%s::", mod->name);
 		tlen = strlen(tname);
 		count += fprintf(fp, "\t<module type=\"%s\" ", mod->name);
 		if (mod->major > 0){
@@ -902,7 +902,7 @@ int module_saveobj_xml(FILE *fp, MODULE *mod){ /**< the stream to write to */
 		if(obj->name != NULL){
 			strcpy(oname, obj->name);
 		} else {
-			sprintf(oname, "%s:%i", obj->oclass->name, obj->id);
+			snprintf(oname,sizeof(oname)-1, "%s:%i", obj->oclass->name, obj->id);
 		}
 		if ((oclass == NULL) || (obj->oclass != oclass))
 			oclass = obj->oclass;
@@ -913,7 +913,7 @@ int module_saveobj_xml(FILE *fp, MODULE *mod){ /**< the stream to write to */
 			if(obj->parent->name != NULL){
 				strcpy(oname, obj->parent->name);
 			} else {
-				sprintf(oname, "%s:%i", obj->parent->oclass->name, obj->parent->id);
+				snprintf(oname,sizeof(oname)-1, "%s:%i", obj->parent->oclass->name, obj->parent->id);
 			}
 			count += fprintf(fp,"\t\t\t<parent>%s</parent>\n", oname);
 		} else {
@@ -1337,7 +1337,7 @@ static int execf(const char *format, /**< format string  */
 	int rc;
 	va_list ptr;
 	va_start(ptr,format);
-	vsprintf(command,format,ptr); /* note the lack of check on buffer overrun */
+	vsnprintf(command,sizeof(command)-1,format,ptr); /* note the lack of check on buffer overrun */
 	va_end(ptr);
 	if (cc_verbose || global_verbose_mode ) output_message(command);
 	else
@@ -1375,7 +1375,7 @@ int module_compile(const char *name,	/**< name of library */
 	char srcfile[1024];
 	char mopt[8] = "";
 #ifdef WIN32
-	snprintf(mopt,sizeof(mopt),"-m%d",sizeof(void*)*8);
+	snprintf(mopt,sizeof(mopt)-1,"-m%d",sizeof(void*)*8);
 #endif
 
 	/* normalize source file name */
@@ -1402,9 +1402,9 @@ int module_compile(const char *name,	/**< name of library */
 	cc_keepwork = (flags&MC_KEEPWORK);
 
 	/* construct the file names */
-	snprintf(cfile,sizeof(cfile),"%s.c",name);
-	snprintf(ofile,sizeof(ofile),"%s.o",name);
-	snprintf(afile,sizeof(afile),"%s" DLEXT,name);
+	snprintf(cfile,sizeof(cfile)-1,"%s.c",name);
+	snprintf(ofile,sizeof(ofile)-1,"%s.o",name);
+	snprintf(afile,sizeof(afile)-1,"%s" DLEXT,name);
 
 	/* create the C source file */
 	if ( (fp=fopen(cfile,"wt"))==NULL)
@@ -1537,9 +1537,9 @@ int module_load_function_list(const char *libname, const char *fnclist)
 
 	/* load the library */
 	if ( strchr(libname,'/')==NULL )
-		snprintf(libpath,sizeof(libpath),"./%s" DLEXT, libname);
+		snprintf(libpath,sizeof(libpath)-1,"./%s" DLEXT, libname);
 	else
-		snprintf(libpath,sizeof(libpath),"%s" DLEXT, libname);
+		snprintf(libpath,sizeof(libpath)-1,"%s" DLEXT, libname);
 
 	lib = DLLOAD(libpath);
 #ifdef WIN32
@@ -1961,13 +1961,13 @@ int sched_getinfo(int n,char *buf, size_t sz)
 				/* compute elapsed time */
 				h = (int)(s/3600); s=s%3600;
 				m = (int)(s/60); s=s%60;
-				if ( h>0 ) sprintf(t,"%4d:%02d:%02d",h,m,(int)s);
-				else if ( m>0 ) sprintf(t,"     %2d:%02d",m,(int)s);
-				else sprintf(t,"       %2ds", (int)s);
+				if ( h>0 ) snprintf(t,sizeof(t)-1,"%4d:%02d:%02d",h,m,(int)s);
+				else if ( m>0 ) snprintf(t,sizeof(t)-1,"     %2d:%02d",m,(int)s);
+				else snprintf(t,sizeof(t)-1,"       %2ds", (int)s);
 			}
 			else if ( process_map[n].stoptime!=TS_NEVER )
 			{
-				sprintf(t,"%.0f%%",100.0*(process_map[n].progress - process_map[n].starttime)/(process_map[n].stoptime-process_map[n].starttime));
+				snprintf(t,sizeof(t)-1,"%.0f%%",100.0*(process_map[n].progress - process_map[n].starttime)/(process_map[n].stoptime-process_map[n].starttime));
 			}
 		}
 
@@ -1999,10 +1999,10 @@ int sched_getinfo(int n,char *buf, size_t sz)
 		}
 
 		/* print info */
-		sz = sprintf(buf,"%4d %5d %10s %-7s %-23s %s", n, process_map[n].pid, t, status, process_map[n].progress==TS_ZERO?"INIT":ts, name);
+		sz = snprintf(buf,sz,"%4d %5d %10s %-7s %-23s %s", n, process_map[n].pid, t, status, process_map[n].progress==TS_ZERO?"INIT":ts, name);
 	}
 	else
-		sz = sprintf(buf,"%4d   -", n);
+		sz = snprintf(buf,sz,"%4d   -", n);
 	sched_unlock(n);
 	return (int)sz;
 }
@@ -2060,16 +2060,16 @@ void sched_print(int flags) /* flag=0 for single listing, flag=1 for continuous 
 		unsigned int n;
 		if ( flags==1 )
 		{
-			sched_getinfo(-1,line,sizeof(line));
+			sched_getinfo(-1,line,sizeof(line)-1);
 			printf("%s\n",line);
-			sched_getinfo(-2,line,sizeof(line));
+			sched_getinfo(-2,line,sizeof(line)-1);
 			printf("%s\n",line);
 		}
 		for ( n=0 ; n<n_procs ; n++ )
 		{
 			if ( process_map[n].pid!=0 || flags==1 )
 			{
-				if ( sched_getinfo(n,line,sizeof(line))>0 )
+				if ( sched_getinfo(n,line,sizeof(line)-1)>0 )
 					printf("%s\n",line);
 				else
 					printf("%4d (error)\n",n);
@@ -2489,19 +2489,19 @@ void sched_continuous(void)
 			char line[1024];
 			clear();
 			mvprintw(0,0,"%s Process Control - Version %d.%d.%d-%d (%s)",PACKAGE_NAME,REV_MAJOR,REV_MINOR,REV_PATCH,version_build(),version_branch());
-			sched_getinfo(-1,line,sizeof(line));
+			sched_getinfo(-1,line,sizeof(line)-1);
 			mvprintw(2,0,"%s",line);
-			sched_getinfo(-2,line,sizeof(line));
+			sched_getinfo(-2,line,sizeof(line)-1);
 			mvprintw(3,0,"%s",line);
 			for ( n=0 ; n<n_procs ; n++ )
 			{
 				if ( sched_getinfo(n,line,sizeof(line))<0 )
-					sprintf(message,"ERROR: unable to read process %d", n);
+					snprintf(message,sizeof(message)-1,"ERROR: unable to read process %d", n);
 				if ( n==sel ) attron(A_BOLD);
 				mvprintw(n+4,0,"%s",line);
 				if ( n==sel ) attroff(A_BOLD);
 			}
-			sched_getinfo(-3,line,sizeof(line));
+			sched_getinfo(-3,line,sizeof(line)-1);
 			mvprintw(n_procs+5,0,"%s",line);
 			tb = localtime(&now);
 			strftime(ts,sizeof(ts),"%Y/%m/%d %H:%M:%S",tb);
@@ -2512,13 +2512,13 @@ void sched_continuous(void)
 		switch (c) {
 		case KEY_UP:
 			if ( sel>0 ) sel--;
-			sprintf(message,"Process %d selected", sel);
+			snprintf(message,sizeof(message)-1,"Process %d selected", sel);
 			refresh_count=0;
 			break;
 		case KEY_DOWN:
 			if ( sel<n_procs-1 ) sel++;
 			refresh_count=0;
-			sprintf(message,"Process %d selected", sel);
+			snprintf(message,sizeof(message)-1,"Process %d selected", sel);
 			break;
 		case 'q':
 		case 'Q':
@@ -2527,25 +2527,25 @@ void sched_continuous(void)
 		case 'k':
 		case 'K':
 			sched_pkill(sel);
-			sprintf(message,"Kill signal sent to process %d",sel);
+			snprintf(message,sizeof(message)-1,"Kill signal sent to process %d",sel);
 			refresh_count=0;
 			break;
 		case 'c':
 		case 'C':
 			sched_clear();
-			sprintf(message,"Defunct processes cleared ok");
+			snprintf(message,sizeof(message)-1,"Defunct processes cleared ok");
 			refresh_count=0;
 			break;
 		case 'r':
 		case 'R':
 			show_progress = 0;
-			sprintf(message,"Runtime display selected");
+			snprintf(message,sizeof(message)-1,"Runtime display selected");
 			refresh_count = 0;
 			break;
 		case 'p':
 		case 'P':
 			show_progress = 1;
-			sprintf(message,"Progress display selected");
+			snprintf(message,sizeof(message)-1,"Progress display selected");
 			refresh_count = 0;
 			break;
 		default:
@@ -2643,8 +2643,8 @@ void module_help_md(MODULE *mod, CLASS *oclass)
 	output_raw("~~~\n");
 	bool first = true;
 	GLOBALVAR *global = NULL;
-	char prefix[1024];
-	sprintf(prefix,"%s::",mod->name);
+	char prefix[2000];
+	snprintf(prefix,sizeof(prefix)-1,"%s::",mod->name);
 	if ( oclass == NULL )
 	{
 		while ( (global=global_getnext(global)) != NULL )
@@ -2780,8 +2780,8 @@ void module_help_md(MODULE *mod, CLASS *oclass)
 	{
 		bool first = true;
 		GLOBALVAR *global = NULL;
-		char prefix[1024];
-		sprintf(prefix,"%s::",mod->name);
+		char prefix[2000];
+		snprintf(prefix,sizeof(prefix)-1,"%s::",mod->name);
 		if ( oclass == NULL )
 		{
 			while ( (global=global_getnext(global)) != NULL )

--- a/gldcore/object.cpp
+++ b/gldcore/object.cpp
@@ -513,9 +513,9 @@ const char *object_get_unit(OBJECT *obj, const char *name)
 	LOCKVAR unitlock = 0;
 	PROPERTY *prop = object_get_property(obj, name,NULL);
 	
-	if(prop == NULL){
-		char *buffer = (char *)malloc(64);
-		memset(buffer, 0, 64);
+	if(prop == NULL)
+	{
+		static char buffer[64];
 		throw_exception("property '%s' not found in object '%s'", name, object_name(obj, buffer, 63));
 		/* TROUBLESHOOT
 			The property for which the unit was requested does not exist.  
@@ -588,7 +588,7 @@ OBJECT *object_create_single(CLASS *oclass) /**< the class of the object */
 			The system has run out of memory and is unable to create the object requested.  Try freeing up system memory and try again.
 		 */
 	}
-	memset(obj, 0, sz+oclass->size);
+	memset((void*)obj, 0, sz+oclass->size);
 
 	obj->id = next_object_id++;
 	obj->oclass = oclass;
@@ -3201,7 +3201,7 @@ int object_open_namespace(const char *space)
 		 */
 		return 0;
 	}
-	strncpy(ns->name,space,sizeof(ns->name));
+	strncpy(ns->name,space,sizeof(ns->name)-1);
 	ns->next = current_namespace;
 	current_namespace = ns;
 	return 1;
@@ -3301,7 +3301,7 @@ FORECAST *forecast_create(OBJECT *obj, const char *specs)
 		   memory or a problem with the memory allocation system.  Free up system
 		   memory, reducing the complexity and/or size of the model and try again.
 		 */
-	memset(fc,0,sizeof(FORECAST));
+	memset((void*)fc,0,sizeof(FORECAST));
 
 	/* add to current list of forecasts */
 	fc->next = obj->forecast;

--- a/gldcore/output.cpp
+++ b/gldcore/output.cpp
@@ -581,9 +581,10 @@ int output_debug(const char *format,...) /**< \bprintf style argument list */
 		struct timeval tv;
 		gettimeofday(&tv,NULL);
 		struct tm *t = localtime(&tv.tv_sec);
-		char timestamp[256];
+		char timestamp[1024];
 		strftime(timestamp,64,"%Y-%m-%d %H:%M:%S",t);
-		snprintf(timestamp+strlen(timestamp),64,".%06d %s",tv.tv_usec,time_context);
+		int len = strlen(timestamp);
+		snprintf(timestamp+len,sizeof(timestamp)-len-1,".%06u %s",(unsigned int)tv.tv_usec,time_context);
 
 		/* check for repeated message */
 		static char lastfmt[4096] = "";

--- a/gldcore/python_embed.cpp
+++ b/gldcore/python_embed.cpp
@@ -108,7 +108,7 @@ const char *truncate(const char *command)
     while ( isspace(*command) ) command++;
     static char buf[20];
     memset(buf,0,sizeof(buf));
-    strncpy(buf,command,sizeof(buf));
+    strncpy(buf,command,sizeof(buf)-1);
     char *eol = strchr(buf,'\n');
     if ( eol ) *eol = '\0';
     if ( buf[sizeof(buf)-1] != '\0' ) 

--- a/gldcore/random.cpp
+++ b/gldcore/random.cpp
@@ -1463,7 +1463,7 @@ size_t randomvar_getspec(char *str, size_t size, const randomvar *var)
 	size_t len;
 	if ( _random_specs(var->type,var->a,var->b,specs,sizeof(specs))<=0 )
 		return 0;
-	len = sprintf(buffer,"state: %u; type: %s; min: %g; max: %g; refresh: %u%s",
+	len = snprintf(buffer,sizeof(buffer)-1,"state: %u; type: %s; min: %g; max: %g; refresh: %u%s",
 		var->state, specs, var->low, var->high, var->update_rate, var->flags&RNF_INTEGRATE ? "; integrate" : "");
 	if ( len > 0 && len<size )
 	{

--- a/gldcore/server.cpp
+++ b/gldcore/server.cpp
@@ -347,15 +347,15 @@ static void http_send(HTTPCNX *http)
 {
 	char header[4096];
 	int len=0;
-	len += sprintf(header+len, "HTTP/1.1 %s", http->status?http->status:HTTP_INTERNALSERVERERROR);
+	len += snprintf(header+len,sizeof(header)-len-1,"HTTP/1.1 %s", http->status?http->status:HTTP_INTERNALSERVERERROR);
 	IN_MYCONTEXT output_verbose("%s (len=%d, mime=%s)",header,http->len,http->type?http->type:"none");
-	len += sprintf(header+len, "\nContent-Length: %zu\n", http->len);
+	len += snprintf(header+len,sizeof(header)-len-1, "\nContent-Length: %zu\n", http->len);
 	if (http->type && http->type[0]!='\0')
-		len += sprintf(header+len, "Content-Type: %s\n", http->type);
-	len += sprintf(header+len, "Cache-Control: no-cache\n");
-	len += sprintf(header+len, "Cache-Control: no-store\n");
-	len += sprintf(header+len, "Expires: -1\n");
-	len += sprintf(header+len,"\n");
+		len += snprintf(header+len,sizeof(header)-len-1, "Content-Type: %s\n", http->type);
+	len += snprintf(header+len,sizeof(header)-len-1, "Cache-Control: no-cache\n");
+	len += snprintf(header+len,sizeof(header)-len-1, "Cache-Control: no-store\n");
+	len += snprintf(header+len,sizeof(header)-len-1, "Expires: -1\n");
+	len += snprintf(header+len,sizeof(header)-len-1,"\n");
 	send_data(http->s,header,len);
 	if (http->len>0)
 		send_data(http->s,http->buffer,http->len);
@@ -507,7 +507,7 @@ static int http_format(HTTPCNX *http, const char *format, ...)
 	va_list ptr;
 
 	va_start(ptr,format);
-	len = vsprintf(data,format,ptr);
+	len = vsnprintf(data,sizeof(data)-1,format,ptr);
 	va_end(ptr);
 
 	http_write(http,data,len);
@@ -653,40 +653,40 @@ int get_value_with_unit(OBJECT *obj, char *arg1, char *arg2, char *buffer, size_
 			}
 			switch ( spec[2]=='\0' ? cvalue.Notation() : spec[2] ) {
 			case I: // i-notation
-				sprintf(fmt,"%%.%c%c%%+.%c%ci %%s",spec[0],spec[1],spec[0],spec[1]);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c%%+.%c%ci %%s",spec[0],spec[1],spec[0],spec[1]);
 				snprintf(buffer,len,fmt,cvalue.Re(),cvalue.Im(),uname);
 				break;
 			case J: // j-notation
-				sprintf(fmt,"%%.%c%c%%+.%c%cj %%s",spec[0],spec[1],spec[0],spec[1]);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c%%+.%c%cj %%s",spec[0],spec[1],spec[0],spec[1]);
 				snprintf(buffer,len,fmt,cvalue.Re(),cvalue.Im(),uname);
 				break;
 			case A: // degrees
-				sprintf(fmt,"%%.%c%c%%+.%c%cd %%s",spec[0],spec[1],spec[0],spec[1]);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c%%+.%c%cd %%s",spec[0],spec[1],spec[0],spec[1]);
 				snprintf(buffer,len,fmt,cvalue.Mag(),cvalue.Ang(),uname);
 				break;
 			case R: // radians
-				sprintf(fmt,"%%.%c%c%%+.%c%cr %%s",spec[0],spec[1],spec[0],spec[1]);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c%%+.%c%cr %%s",spec[0],spec[1],spec[0],spec[1]);
 				snprintf(buffer,len,fmt,cvalue.Mag(),cvalue.Arg(),uname);
 				break;
 			case 'M': // magnitude only
-				sprintf(fmt,"%%.%c%c %%s",spec[0],spec[1]);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c %%s",spec[0],spec[1]);
 				snprintf(buffer,len,fmt,cvalue.Mag(),uname);
 				break;
 			case 'D': // angle only in degrees
-				sprintf(fmt,"%%.%c%c deg",spec[0],spec[1]);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c deg",spec[0],spec[1]);
 				snprintf(buffer,len,fmt,cvalue.Ang(),uname);
 				break;
 			case 'R': // angle only in radians
-				sprintf(fmt,"%%.%c%c rad",spec[0],spec[1]);
-				sprintf(buffer,fmt,cvalue.Arg(),uname);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c rad",spec[0],spec[1]);
+				snprintf(buffer,len,fmt,cvalue.Arg(),uname);
 				break;
 			case 'X': // real part only
-				sprintf(fmt,"%%.%c%c %%s",spec[0],spec[1]);
-				sprintf(buffer,fmt,cvalue.Re(),uname);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c %%s",spec[0],spec[1]);
+				snprintf(buffer,len,fmt,cvalue.Re(),uname);
 				break;
 			case 'Y': // imaginary part only
-				sprintf(fmt,"%%.%c%c %%s",spec[0],spec[1]);
-				sprintf(buffer,fmt,cvalue.Im(),uname);
+				snprintf(fmt,sizeof(fmt)-1,"%%.%c%c %%s",spec[0],spec[1]);
+				snprintf(buffer,len,fmt,cvalue.Im(),uname);
 				break;
 			default:
 				output_warning("object '%s' property '%s' complex angle notation '%c' is not valid", arg1, arg2, spec[2]=='\0' ? cvalue.Notation() : spec[3]);
@@ -695,14 +695,14 @@ int get_value_with_unit(OBJECT *obj, char *arg1, char *arg2, char *buffer, size_
 		}
 		else /* handle doubles */
 		{
-			sprintf(fmt,"%%.%c%c %%s",spec[0],spec[1]);
+			snprintf(fmt,len,"%%.%c%c %%s",spec[0],spec[1]);
 			rvalue = *object_get_double_quick(obj,prop);
 			if ( !unit_convert_ex(prop->unit,unit,&rvalue) )
 			{
 				output_warning("object '%s' property '%s' conversion from '%s' to '%s' failed", arg1, arg2, prop->unit->name, unit);
 				return 0;
 			}
-			sprintf(buffer,fmt,rvalue,uname);
+			snprintf(buffer,len,fmt,rvalue,uname);
 		}
 	}
 	else if ( !object_get_value_by_name(obj,arg2,buffer,len) )
@@ -1305,7 +1305,7 @@ int http_output_request(HTTPCNX *http,char *uri)
 int http_run_java(HTTPCNX *http,char *uri)
 {
 	char script[1024];
-	char command[1024];
+	char command[1200];
 	char output[1024];
 	char *mime = strchr(uri,'?');
 	char *ext = mime?strchr(mime,'/'):NULL;
@@ -1330,11 +1330,11 @@ int http_run_java(HTTPCNX *http,char *uri)
 	}
 
 	/* setup gnuplot command */
-	sprintf(script,"%s",uri);
-	sprintf(command,"java -jar %s",script);
+	snprintf(script,sizeof(script)-1,"%s",uri);
+	snprintf(command,sizeof(command)-1,"java -jar %s",script);
 
 	/* temporary cut off of plt extension to build output file */
-	*jar = '\0'; sprintf(output,"%s.%s",uri,ext); *jar='.';
+	*jar = '\0'; snprintf(output,sizeof(output)-1,"%s.%s",uri,ext); *jar='.';
 
 	/* run gnuplot */
 	IN_MYCONTEXT output_verbose("%s", command);
@@ -1363,7 +1363,7 @@ int http_run_java(HTTPCNX *http,char *uri)
 int http_run_perl(HTTPCNX *http,char *uri)
 {
 	char script[1024];
-	char command[1024];
+	char command[1200];
 	char output[1024];
 	char *mime = strchr(uri,'?');
 	char *ext = mime?strchr(mime,'/'):NULL;
@@ -1388,11 +1388,11 @@ int http_run_perl(HTTPCNX *http,char *uri)
 	}
 
 	/* setup gnuplot command */
-	sprintf(script,"%s",uri);
-	sprintf(command,"perl %s",script);
+	snprintf(script,sizeof(script)-1,"%s",uri);
+	snprintf(command,sizeof(command)-1,"perl %s",script);
 
 	/* temporary cut off of plt extension to build output file */
-	*pl = '\0'; sprintf(output,"%s.%s",uri,ext); *pl='.';
+	*pl = '\0'; snprintf(output,sizeof(output)-1,"%s.%s",uri,ext); *pl='.';
 
 	/* run gnuplot */
 	IN_MYCONTEXT output_verbose("%s", command);
@@ -1420,7 +1420,7 @@ int http_run_perl(HTTPCNX *http,char *uri)
 int http_run_python(HTTPCNX *http,char *uri)
 {
 	char script[1024];
-	char command[1024];
+	char command[1200];
 	char output[1024];
 	char *mime = strchr(uri,'?');
 	char *ext = mime?strchr(mime,'/'):NULL;
@@ -1445,11 +1445,11 @@ int http_run_python(HTTPCNX *http,char *uri)
 	}
 
 	/* setup gnuplot command */
-	sprintf(script,"%s",uri);
-	sprintf(command,"python %s",script);
+	snprintf(script,sizeof(script)-1,"%s",uri);
+	snprintf(command,sizeof(command)-1,"python %s",script);
 
 	/* temporary cut off of plt extension to build output file */
-	*py = '\0'; sprintf(output,"%s.%s",uri,ext); *py='.';
+	*py = '\0'; snprintf(output,sizeof(output)-1,"%s.%s",uri,ext); *py='.';
 
 	/* run gnuplot */
 	IN_MYCONTEXT output_verbose("%s", command);
@@ -1477,7 +1477,7 @@ int http_run_python(HTTPCNX *http,char *uri)
 int http_run_r(HTTPCNX *http,char *uri)
 {
 	char script[1024];
-	char command[1024];
+	char command[1200];
 	char output[1024];
 	char *mime = strchr(uri,'?');
 	char *ext = mime?strchr(mime,'/'):NULL;
@@ -1502,15 +1502,15 @@ int http_run_r(HTTPCNX *http,char *uri)
 	}
 
 	/* setup gnuplot command */
-	sprintf(script,"%s",uri);
+	snprintf(script,sizeof(script)-1,"%s",uri);
 #ifdef WIN32
-	sprintf(command,"r CMD BATCH %s",script);
+	snprintf(command,sizeof(command)-1,"r CMD BATCH %s",script);
 #else
-	sprintf(command,"R --vanilla CMD BATCH %s",script);
+	snprintf(command,sizeof(command)-1,"R --vanilla CMD BATCH %s",script);
 #endif
 
 	/* temporary cut off of plt extension to build output file */
-	*r = '\0'; sprintf(output,"%s.%s",uri,ext); *r='.';
+	*r = '\0'; snprintf(output,sizeof(output)-1,"%s.%s",uri,ext); *r='.';
 
 	/* run gnuplot */
 	IN_MYCONTEXT output_verbose("%s", command);
@@ -1538,7 +1538,7 @@ int http_run_r(HTTPCNX *http,char *uri)
 int http_run_scilab(HTTPCNX *http,char *uri)
 {
 	char script[1024];
-	char command[1024];
+	char command[1200];
 	char output[1024];
 	char *mime = strchr(uri,'?');
 	char *ext = mime?strchr(mime,'/'):NULL;
@@ -1563,11 +1563,11 @@ int http_run_scilab(HTTPCNX *http,char *uri)
 	}
 
 	/* setup gnuplot command */
-	sprintf(script,"%s",uri);
-	sprintf(command,"scilab %s",script);
+	snprintf(script,sizeof(script)-1,"%s",uri);
+	snprintf(command,sizeof(command)-1,"scilab %s",script);
 
 	/* temporary cut off of plt extension to build output file */
-	*sce = '\0'; sprintf(output,"%s.%s",uri,ext); *sce='.';
+	*sce = '\0'; snprintf(output,sizeof(output)-1,"%s.%s",uri,ext); *sce='.';
 
 	/* run gnuplot */
 	IN_MYCONTEXT output_verbose("%s", command);
@@ -1595,7 +1595,7 @@ int http_run_scilab(HTTPCNX *http,char *uri)
 int http_run_octave(HTTPCNX *http,char *uri)
 {
 	char script[1024];
-	char command[1024];
+	char command[1200];
 	char output[1024];
 	char *mime = strchr(uri,'?');
 	char *ext = mime?strchr(mime,'/'):NULL;
@@ -1620,11 +1620,11 @@ int http_run_octave(HTTPCNX *http,char *uri)
 	}
 
 	/* setup gnuplot command */
-	sprintf(script,"%s",uri);
-	sprintf(command,"octave %s",script);
+	snprintf(script,sizeof(script)-1,"%s",uri);
+	snprintf(command,sizeof(command)-1,"octave %s",script);
 
 	/* temporary cut off of plt extension to build output file */
-	*m = '\0'; sprintf(output,"%s.%s",uri,ext); *m='.';
+	*m = '\0'; snprintf(output,sizeof(output)-1,"%s.%s",uri,ext); *m='.';
 
 	/* run gnuplot */
 	IN_MYCONTEXT output_verbose("%s", command);
@@ -1652,7 +1652,7 @@ int http_run_octave(HTTPCNX *http,char *uri)
 int http_run_gnuplot(HTTPCNX *http,char *uri)
 {
 	char script[1024];
-	char command[1024];
+	char command[1200];
 	char output[1024];
 	char *mime = strchr(uri,'?');
 	char *ext = mime?strchr(mime,'/'):NULL;
@@ -1677,14 +1677,14 @@ int http_run_gnuplot(HTTPCNX *http,char *uri)
 	}
 
 	/* setup gnuplot command */
-	sprintf(script,"%s",uri);
+	snprintf(script,sizeof(script)-1,"%s",uri);
 #ifdef WIN32
-	sprintf(command,"wgnuplot %s",script);
+	snprintf(command,sizeof(command)-1,"wgnuplot %s",script);
 #else
-	sprintf(command,"gnuplot %s",script);
+	snprintf(command,sizeof(command)-1,"gnuplot %s",script);
 #endif
 	/* temporary cut off of plt extension to build output file */
-	*plt = '\0'; sprintf(output,"%s.%s",uri,ext); *plt='.';
+	*plt = '\0'; snprintf(output,sizeof(output)-1,"%s.%s",uri,ext); *plt='.';
 
 	/* run gnuplot */
 	IN_MYCONTEXT output_verbose("%s", command);

--- a/gldcore/stream.cpp
+++ b/gldcore/stream.cpp
@@ -365,9 +365,22 @@ size_t stream(void *ptr, ///< pointer to buffer
 	}
 	throw;
 }
-void stream(const char *s,size_t max=0) { char t[1024]; strncpy(t,s,sizeof(t)); stream((void*)t,max?max:strlen(s),true,(void*)s); }
-void stream(char *s,size_t max=0) { stream((void*)s,max?max:strlen(s),true); }
-template<class T> void stream(T &v) { stream(&v,sizeof(T)); }
+void stream(const char *s,size_t max=0) 
+{ 
+	char t[1024]; 
+	strncpy(t,s,sizeof(t)-1); 
+	stream((void*)t,max?max:strlen(s),true,(void*)s); 
+}
+
+void stream(char *s,size_t max=0) 
+{ 
+	stream((void*)s,max?max:strlen(s),true); 
+}
+
+template<class T> void stream(T &v) 
+{ 
+	stream(&v,sizeof(T)); 
+}
 
 // module stream
 void stream(MODULE *mod)
@@ -465,7 +478,11 @@ void stream(OBJECT *obj)
 		char oname[64]; if ( obj ) strcpy(oname,obj->name?obj->name:"");
 		stream(oname,sizeof(oname));
 
-		OBJECT *data=(OBJECT*)malloc(size); if ( obj ) memcpy(data,obj,size);
+		OBJECT *data=(OBJECT*)malloc(size); 
+		if ( obj ) 
+		{
+			memcpy((void*)data,obj,size);
+		}
 		stream(data,size);
 
 		// TODO forecast and namespace

--- a/gldcore/timestamp.cpp
+++ b/gldcore/timestamp.cpp
@@ -308,7 +308,7 @@ int local_datetime(TIMESTAMP ts, DATETIME *dt)
 	dt->nanosecond = (unsigned int)(rem * 1e9);
 
 	/* determine timezone */
-	strncpy(dt->tz, tzvalid ? (dt->is_dst ? tzdst : tzstd) : "GMT", sizeof(dt->tz));
+	memcpy(dt->tz, tzvalid ? (dt->is_dst ? tzdst : tzstd) : "GMT", sizeof(dt->tz));
 
 	/* timezone offset in seconds */
 	dt->tzoffset = (int)(tzoffset - (isdst(dt->timestamp)?3600:0));
@@ -442,7 +442,7 @@ int local_datetime_delta(double tsdbl, DATETIME *dt)
 	dt->nanosecond = (unsigned int)((tsdbl - (double)(ts))*1e9 + 0.5);
 
 	/* determine timezone */
-	strncpy(dt->tz, tzvalid ? (dt->is_dst ? tzdst : tzstd) : "GMT", sizeof(dt->tz));
+	memcpy(dt->tz, tzvalid ? (dt->is_dst ? tzdst : tzstd) : "GMT", sizeof(dt->tz));
 
 	/* timezone offset in seconds */
 	dt->tzoffset = (int)(tzoffset - (isdst(dt->timestamp)?3600:0));
@@ -899,10 +899,10 @@ void load_tzspecs(const char *tz )
 		 */
 	}
 
-	strncpy(current_tzname, pTzname, sizeof(current_tzname));
+	strncpy(current_tzname, pTzname, sizeof(current_tzname)-1);
 	tzoffset = tz_offset(current_tzname);
-	strncpy(tzstd, tz_std(current_tzname), sizeof(tzstd));
-	strncpy(tzdst, tz_dst(current_tzname), sizeof(tzdst));
+	strncpy(tzstd, tz_std(current_tzname), sizeof(tzstd)-1);
+	strncpy(tzdst, tz_dst(current_tzname), sizeof(tzdst)-1);
 
 	if ( find_file(TZFILE, NULL, R_OK,filepath,sizeof(filepath)) == NULL ) {
 		throw_exception("timezone specification file %s not found in GLPATH=%s: %s", TZFILE, getenv("GLPATH"), strerror(errno));

--- a/gldcore/unit.cpp
+++ b/gldcore/unit.cpp
@@ -162,7 +162,7 @@ int unit_scalar(const char *name,int scalar)
 			This is actually triggered by a malloc failure, and the rest of the system is likely unstable.
 		*/
 	}
-	strncpy(ptr->name, name, sizeof(ptr->name));
+	strncpy(ptr->name, name, sizeof(ptr->name)-1);
 	ptr->scalar = scalar;
 	ptr->len = (unsigned char)strlen(ptr->name);
 	ptr->next = scalar_list;

--- a/gldcore/validate.cpp
+++ b/gldcore/validate.cpp
@@ -514,8 +514,8 @@ static counters run_test(char *file, size_t id, double *elapsed_time=NULL)
 	{
 		IN_MYCONTEXT output_debug("(proc %d) created test folder '%s'", id, dir);
 	}
-	char out[1024];
-	sprintf(out,"%s/%s.glm",dir,name);
+	char out[1200];
+	snprintf(out,sizeof(out)-1,"%s/%s.glm",dir,name);
 	if ( !copyfile(file,out) )
 	{
 		output_error("(proc %d) run_test(char *file='%s'): unable to copy to test folder %s", id, file, dir);
@@ -612,7 +612,7 @@ static counters run_test(char *file, size_t id, double *elapsed_time=NULL)
 
 /* simple stack to handle directories that need to be processed */
 typedef struct s_dirstack {
-	char name[1024];
+	char name[1200];
 	unsigned short id;
 	struct s_dirstack *next;
 } DIRLIST;
@@ -687,8 +687,8 @@ void *run_test_proc(void *arg)
 			if ( result.get_nsuccess() ) code=2;
 			if ( result.get_nexceptions() ) code=3;
 			result_code[item->id] = code;
-			char buffer[1024];
-			sprintf(buffer,"%s%s%6.1f%s%s",flags[code],report_col,dt,report_col,item->name);
+			char buffer[2048];
+			snprintf(buffer,sizeof(buffer)-1,"%s%s%6.1f%s%s",flags[code],report_col,dt,report_col,item->name);
 			report_data("%s",buffer);
 			report_newrow();
 		}

--- a/module/assert/complex_assert.cpp
+++ b/module/assert/complex_assert.cpp
@@ -47,7 +47,7 @@ complex_assert::complex_assert(MODULE *module)
 			PT_char1024, "target", get_target_offset(),PT_DESCRIPTION,"Property to perform the assert upon",	
 			NULL)<1){
 				char msg[256];
-				sprintf(msg, "unable to publish properties in %s",__FILE__);
+				snprintf(msg,sizeof(msg)-1, "unable to publish properties in %s",__FILE__);
 				throw msg;
 		}
 	}
@@ -221,7 +221,7 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 {
 	char buff[64];
 	char dateformat[8]="";
-	char error_output_buff[1024];
+	char error_output_buff[4000];
 	char datebuff[64];
 	complex_assert *da = OBJECTDATA(obj,complex_assert);
 	DATETIME delta_dt_val;
@@ -290,16 +290,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - real part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Re(), da->get_within(), da->get_value().Re());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - real part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Re(), da->get_within(), da->get_value().Re());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);
@@ -327,16 +327,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - imaginary part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Im(), da->get_within(), da->get_value().Im());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - imaginary part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Im(), da->get_within(), da->get_value().Im());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);
@@ -366,16 +366,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - Magnitude of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Mag(), da->get_within(), da->get_value().Mag());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - Magnitude of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Mag(), da->get_within(), da->get_value().Mag());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);
@@ -405,16 +405,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - Angle of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Arg(), da->get_within(), da->get_value().Arg());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - Angle of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Arg(), da->get_within(), da->get_value().Arg());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);
@@ -453,16 +453,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - real part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Re(), da->get_within(), da->get_value().Re());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - real part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Re(), da->get_within(), da->get_value().Re());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);
@@ -490,16 +490,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - imaginary part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Im(), da->get_within(), da->get_value().Im());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - imaginary part of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Im(), da->get_within(), da->get_value().Im());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);
@@ -529,16 +529,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - Magnitude of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Mag(), da->get_within(), da->get_value().Mag());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - Magnitude of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Mag(), da->get_within(), da->get_value().Mag());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);
@@ -568,16 +568,16 @@ EXPORT SIMULATIONMODE update_complex_assert(OBJECT *obj, TIMESTAMP t0, unsigned 
 
 						//Output date appropriately
 						if ( strcmp(dateformat,"ISO")==0)
-							sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"US")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else if ( strcmp(dateformat,"EURO")==0)
-							sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 						else
-							sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+							snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 						//Actual error part
-						sprintf(error_output_buff,"Assert failed on %s - Angle of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Arg(), da->get_within(), da->get_value().Arg());
+						snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - Angle of %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), (*x).Arg(), da->get_within(), da->get_value().Arg());
 
 						//Send it out
 						gl_output("%s%s",datebuff,error_output_buff);

--- a/module/assert/double_assert.cpp
+++ b/module/assert/double_assert.cpp
@@ -162,7 +162,7 @@ EXPORT SIMULATIONMODE update_double_assert(OBJECT *obj, TIMESTAMP t0, unsigned i
 {
 	char buff[64];
 	char dateformat[8]="";
-	char error_output_buff[1024];
+	char error_output_buff[4000];
 	char datebuff[64];
 	double_assert *da = OBJECTDATA(obj,double_assert);
 	DATETIME delta_dt_val;
@@ -241,16 +241,16 @@ EXPORT SIMULATIONMODE update_double_assert(OBJECT *obj, TIMESTAMP t0, unsigned i
 
 					//Output date appropriately
 					if ( strcmp(dateformat,"ISO")==0)
-						sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"US")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"EURO")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else
-						sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 					//Actual error part
-					sprintf(error_output_buff,"Assert failed on %s - %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_within(), da->get_value());
+					snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_within(), da->get_value());
 
 					//Send it out
 					gl_output("%s%s",datebuff,error_output_buff);
@@ -282,16 +282,16 @@ EXPORT SIMULATIONMODE update_double_assert(OBJECT *obj, TIMESTAMP t0, unsigned i
 
 					//Output date appropriately
 					if ( strcmp(dateformat,"ISO")==0)
-						sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"US")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"EURO")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else
-						sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 					//Actual error part
-					sprintf(error_output_buff,"Assert failed on %s - %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_within(), da->get_value());
+					snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - %s (%g) not within %f of given value %g",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_within(), da->get_value());
 
 					//Send it out
 					gl_output("%s%s",datebuff,error_output_buff);

--- a/module/assert/enum_assert.cpp
+++ b/module/assert/enum_assert.cpp
@@ -35,7 +35,7 @@ enum_assert::enum_assert(MODULE *module)
 			PT_char1024, "target", get_target_offset(),PT_DESCRIPTION,"Property to perform the assert upon",	
 			NULL)<1){
 				char msg[256];
-				sprintf(msg, "unable to publish properties in %s",__FILE__);
+				snprintf(msg,sizeof(msg)-1, "unable to publish properties in %s",__FILE__);
 				throw msg;
 		}
 	}
@@ -109,7 +109,7 @@ EXPORT SIMULATIONMODE update_enum_assert(OBJECT *obj, TIMESTAMP t0, unsigned int
 {
 	char buff[64];
 	char dateformat[8]="";
-	char error_output_buff[1024];
+	char error_output_buff[4000];
 	char datebuff[64];
 	enum_assert *da = OBJECTDATA(obj,enum_assert);
 	DATETIME delta_dt_val;
@@ -159,16 +159,16 @@ EXPORT SIMULATIONMODE update_enum_assert(OBJECT *obj, TIMESTAMP t0, unsigned int
 
 					//Output date appropriately
 					if ( strcmp(dateformat,"ISO")==0)
-						sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"US")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"EURO")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else
-						sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 					//Actual error part
-					sprintf(error_output_buff,"Assert failed on %s - %s (%d) did not match %d",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_value());
+					snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - %s (%d) did not match %d",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_value());
 
 					//Send it out
 					gl_output("%s%s",datebuff,error_output_buff);
@@ -202,16 +202,16 @@ EXPORT SIMULATIONMODE update_enum_assert(OBJECT *obj, TIMESTAMP t0, unsigned int
 
 					//Output date appropriately
 					if ( strcmp(dateformat,"ISO")==0)
-						sprintf(datebuff,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%04d-%02d-%02d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.year,delta_dt_val.month,delta_dt_val.day,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"US")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.month,delta_dt_val.day,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else if ( strcmp(dateformat,"EURO")==0)
-						sprintf(datebuff,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    [%02d-%02d-%04d %02d:%02d:%02d.%.06d %s] : ",delta_dt_val.day,delta_dt_val.month,delta_dt_val.year,delta_dt_val.hour,delta_dt_val.minute,delta_dt_val.second,del_microseconds,delta_dt_val.tz);
 					else
-						sprintf(datebuff,"ERROR    %.09f : ",del_clock);
+						snprintf(datebuff,sizeof(datebuff)-1,"ERROR    %.09f : ",del_clock);
 
 					//Actual error part
-					sprintf(error_output_buff,"Assert failed on %s - %s (%d) did not match %d",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_value());
+					snprintf(error_output_buff,sizeof(error_output_buff)-1,"Assert failed on %s - %s (%d) did not match %d",gl_name(obj->parent, buff, 64),da->get_target(), *x, da->get_value());
 
 					//Send it out
 					gl_output("%s%s",datebuff,error_output_buff);

--- a/module/climate/csv_reader.cpp
+++ b/module/climate/csv_reader.cpp
@@ -32,12 +32,11 @@ EXPORT TIMESTAMP sync_csv_reader(OBJECT *obj, TIMESTAMP t0)
 
 csv_reader::csv_reader()
 {
-	memset(this, 0, sizeof(csv_reader));
+	memset((void*)this, 0, sizeof(csv_reader));
 }
 
 csv_reader::csv_reader(MODULE *module)
 {
-	memset(this, 0, sizeof(csv_reader));
 	if (oclass==NULL)
 	{
 		oclass = gl_register_class(module,"csv_reader",sizeof(csv_reader),PC_NOSYNC);
@@ -63,7 +62,7 @@ csv_reader::csv_reader(MODULE *module)
 			PT_char256,"columns",PADDR(columns_str), PT_DESCRIPTION, "column names",
 			PT_char256,"filename",PADDR(filename), PT_DESCRIPTION, "filename",
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
-		memset(this,0,sizeof(csv_reader));
+		memset((void*)this,0,sizeof(csv_reader));
 	}
 }
 
@@ -247,7 +246,8 @@ int csv_reader::read_prop(char *line)
 	} 
 	else if ( prop->ptype == PT_char32 ) 
 	{
-		strncpy((char *)addr, valstr, 32);
+		memcpy((char *)addr, valstr, 32);
+		((char*)addr)[31] = '\0';
 //	} else if ( prop->ptype == PT_char256 ) {
 //		strncpy((char *)addr, valstr, 256);
 	} 

--- a/module/generators/battery.cpp
+++ b/module/generators/battery.cpp
@@ -195,7 +195,7 @@ battery::battery(MODULE *module)
 				PT_DESCRIPTION, "INTERNAL BATTERY MODEL: the reserve state of charge the battery can reach.",
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = NULL;
-		memset(this,0,sizeof(battery));
+		memset((void*)this,0,sizeof(battery));
 
 		if (gl_publish_function(oclass,	"preupdate_battery_object", (FUNCTIONADDR)preupdate_battery)==NULL)
 			GL_THROW("Unable to publish battery deltamode function");

--- a/module/generators/controller_dg.cpp
+++ b/module/generators/controller_dg.cpp
@@ -37,7 +37,7 @@ controller_dg::controller_dg(MODULE *mod)
 
 		defaults = this;
 
-		memset(this,0,sizeof(controller_dg));
+		memset((void*)this,0,sizeof(controller_dg));
 
 		if (gl_publish_function(oclass,	"interupdate_controller_object", (FUNCTIONADDR)interupdate_controller_dg)==NULL)
 			GL_THROW("Unable to publish controller_dg deltamode function");
@@ -550,7 +550,7 @@ SIMULATIONMODE controller_dg::inter_deltaupdate(unsigned int64 delta_time, unsig
 			prev_Vset_val[index] = ctrlGen[index]->curr_state->Vset_ref;
 
 			// Replicate curr_state into next
-			memcpy(ctrlGen[index]->next_state,ctrlGen[index]->curr_state,sizeof(CTRL_VARS));
+			memcpy((void*)ctrlGen[index]->next_state,ctrlGen[index]->curr_state,sizeof(CTRL_VARS));
 		}
 
 	} // End first pass and timestep of deltamode (initial condition stuff)
@@ -604,7 +604,7 @@ SIMULATIONMODE controller_dg::inter_deltaupdate(unsigned int64 delta_time, unsig
 			pDG[index]->gen_base_set_vals.vset = ctrlGen[index]->next_state->Vset_ctrl;
 
 			// Copy everything back into curr_state, since we'll be back there
-			memcpy(ctrlGen[index]->curr_state,ctrlGen[index]->next_state,sizeof(CTRL_VARS));
+			memcpy((void*)ctrlGen[index]->curr_state,ctrlGen[index]->next_state,sizeof(CTRL_VARS));
 
 			// Check convergence - pick the max difference
 			temp_double = fmax(temp_double, fabs(ctrlGen[index]->curr_state->Pref_ctrl - prev_Pref_val[index]));

--- a/module/generators/dc_dc_converter.cpp
+++ b/module/generators/dc_dc_converter.cpp
@@ -65,11 +65,7 @@ dc_dc_converter::dc_dc_converter(MODULE *module)
 				PT_KEYWORD, "S",(set)PHASE_S,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-
-
-
-
-		memset(this,0,sizeof(dc_dc_converter));
+		memset((void*)this,0,sizeof(dc_dc_converter));
 		/* TODO: set the default values of all properties here */
 	}
 }
@@ -80,7 +76,7 @@ dc_dc_converter::dc_dc_converter(MODULE *module)
 /* Object creation is called once for each object that is created by the core */
 int dc_dc_converter::create(void) 
 {
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 	/* TODO: set the context-free initial value of properties */
 	return 1; /* return 1 on success, 0 on failure */
 }

--- a/module/generators/diesel_dg.cpp
+++ b/module/generators/diesel_dg.cpp
@@ -408,7 +408,7 @@ diesel_dg::diesel_dg(MODULE *module)
 
 		defaults = this;
 
-		memset(this,0,sizeof(diesel_dg));
+		memset((void*)this,0,sizeof(diesel_dg));
 
 		if (gl_publish_function(oclass,	"interupdate_gen_object", (FUNCTIONADDR)interupdate_diesel_dg)==NULL)
 			GL_THROW("Unable to publish diesel_dg deltamode function");
@@ -2083,7 +2083,7 @@ SIMULATIONMODE diesel_dg::inter_deltaupdate(unsigned int64 delta_time, unsigned 
 		prev_rotor_speed_val = curr_state.omega;
 
 		//Replicate curr_state into next
-		memcpy(&next_state,&curr_state,sizeof(MAC_STATES));
+		memcpy((void*)&next_state,&curr_state,sizeof(MAC_STATES));
 
 	}//End first pass and timestep of deltamode (initial condition stuff)
 	else if (iteration_count_val == 0)	//Not first run, just first run of this timestep
@@ -3035,7 +3035,7 @@ SIMULATIONMODE diesel_dg::inter_deltaupdate(unsigned int64 delta_time, unsigned 
 		IGenerated[2] = next_state.EintVal[2]*YS1*omega_pu;
 
 		//Copy everything back into curr_state, since we'll be back there
-		memcpy(&curr_state,&next_state,sizeof(MAC_STATES));
+		memcpy((void*)&curr_state,&next_state,sizeof(MAC_STATES));
 
 		//Check convergence
 		temp_double = fabs(curr_state.omega - prev_rotor_speed_val);

--- a/module/generators/energy_storage.cpp
+++ b/module/generators/energy_storage.cpp
@@ -77,11 +77,7 @@ energy_storage::energy_storage(MODULE *module)
 				PT_KEYWORD, "S",(set)PHASE_S,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-
-
-
-
-		memset(this,0,sizeof(energy_storage));
+		memset((void*)this,0,sizeof(energy_storage));
 		/* TODO: set the default values of all properties here */
 	}
 }
@@ -89,7 +85,7 @@ energy_storage::energy_storage(MODULE *module)
 /* Object creation is called once for each object that is created by the core */
 int energy_storage::create(void) 
 {
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 	/* TODO: set the context-free initial value of properties */
 	return 1; /* return 1 on success, 0 on failure */
 }

--- a/module/generators/inverter.cpp
+++ b/module/generators/inverter.cpp
@@ -452,7 +452,7 @@ inverter::inverter(MODULE *module)
 
 			defaults = this;
 
-			memset(this,0,sizeof(inverter));
+			memset((void*)this,0,sizeof(inverter));
 
 			if (gl_publish_function(oclass,	"preupdate_gen_object", (FUNCTIONADDR)preupdate_inverter)==NULL)
 				GL_THROW("Unable to publish inverter deltamode function");
@@ -5790,7 +5790,7 @@ SIMULATIONMODE inverter::inter_deltaupdate(unsigned int64 delta_time, unsigned l
 					}
 
 					// Copy everything back into curr_state, since we'll be back there
-					memcpy(&curr_state, &next_state, sizeof(INV_STATE));
+					memcpy((void*)&curr_state, &next_state, sizeof(INV_STATE));
 
 					simmode_return_value =  SM_DELTA;
 				}

--- a/module/generators/microturbine.cpp
+++ b/module/generators/microturbine.cpp
@@ -107,11 +107,7 @@ microturbine::microturbine(MODULE *module)
 				PT_KEYWORD, "S",(set)PHASE_S,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-
-	
-
-
-		memset(this,0,sizeof(microturbine));
+		memset((void*)this,0,sizeof(microturbine));
 		/* TODO: set the default values of all properties here */
 	}
 }
@@ -120,7 +116,7 @@ microturbine::microturbine(MODULE *module)
 /* Object creation is called once for each object that is created by the core */
 int microturbine::create(void) 
 {
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 	/* TODO: set the context-free initial value of properties */
 	return 1; /* return 1 on success, 0 on failure */
 }

--- a/module/generators/power_electronics.cpp
+++ b/module/generators/power_electronics.cpp
@@ -157,7 +157,7 @@ power_electronics::power_electronics(MODULE *module)
 				PT_KEYWORD, "S",(set)PHASE_S,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-		memset(this,0,sizeof(power_electronics));
+		memset((void*)this,0,sizeof(power_electronics));
 		/* TODO: set the default values of all properties here */
 	}
 }
@@ -378,7 +378,7 @@ double power_electronics::calculate_frequency_loss(double frequency, double Rtot
 /* Object creation is called once for each object that is created by the core */
 int power_electronics::create(void) 
 {
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 	/* TODO: set the context-free initial value of properties */
 	return 1; /* return 1 on success, 0 on failure */
 }

--- a/module/generators/rectifier.cpp
+++ b/module/generators/rectifier.cpp
@@ -71,13 +71,7 @@ rectifier::rectifier(MODULE *module)
 			PT_KEYWORD, "S",(set)PHASE_S,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-
-
-
-
-
-
-		memset(this,0,sizeof(rectifier));
+		memset((void*)this,0,sizeof(rectifier));
 		/* TODO: set the default values of all properties here */
 	}
 }
@@ -88,7 +82,7 @@ rectifier::rectifier(MODULE *module)
 /* Object creation is called once for each object that is created by the core */
 int rectifier::create(void) 
 {
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 	/* TODO: set the context-free initial value of properties */
 	return 1; /* return 1 on success, 0 on failure */
 }

--- a/module/generators/solar.cpp
+++ b/module/generators/solar.cpp
@@ -134,7 +134,7 @@ solar::solar(MODULE *module)
 			GL_THROW("Unable to publish solar deltamode function");
 
 		defaults = this;
-		memset(this,0,sizeof(solar));
+		memset((void*)this,0,sizeof(solar));
 
 	}
 }

--- a/module/market/auction.cpp
+++ b/module/market/auction.cpp
@@ -200,7 +200,7 @@ auction::auction(MODULE *module)
 		gl_publish_function(oclass, "register_participant", (FUNCTIONADDR)register_participant);
 		defaults = this;
 //		immediate = 1;
-		memset(this,0,sizeof(auction));
+		memset((void*)this,0,sizeof(auction));
 	}
 }
 
@@ -215,7 +215,7 @@ int auction::create(void)
 {
 	STATISTIC *stat;
 	double val = -1.0;
-	memcpy(this,defaults,sizeof(auction));
+	memcpy((void*)this,defaults,sizeof(auction));
 	lasthr = thishr = -1;
 	verbose = 0;
 	use_future_mean_price = 0;
@@ -381,7 +381,7 @@ int auction::init(OBJECT *parent)
 	latency_count = (uint32)(latency / period + 2);
 	latency_stride = sizeof(MARKETFRAME) + statistic_count * sizeof(double);
 	framedata = (MARKETFRAME *)malloc(latency_stride * latency_count);
-	memset(framedata, 0, latency_stride * latency_count);
+	memset((void*)framedata, 0, latency_stride * latency_count);
 	for(i = 0; i < latency_count; ++i){
 		MARKETFRAME *frameptr;
 		int64 addr = latency_stride * i + (int64)framedata;
@@ -463,7 +463,7 @@ int auction::init_statistics()
 	PROPERTY *prop = oclass->pmap;
 	for(prop = oclass->pmap; prop != NULL; prop = prop->next){
 		char frame[32], price[32], stat[32], period[32], period_unit[32];
-		memset(&statprop, 0, sizeof(STATISTIC));
+		memset((void*)&statprop, 0, sizeof(STATISTIC));
 		period_unit[0] = 0;
 		if(sscanf(prop->name, "%[^\n_]_%[^\n_]_%[^\n_]_%[0-9]%[A-Za-z]", frame, price, stat, period, period_unit) >= 4){
 			if(strcmp(price, "price") != 0){
@@ -508,7 +508,7 @@ int auction::init_statistics()
 			} // months and years are of varying length
 			// enqueue a new STATPROP instance
 			sp = (STATISTIC *)malloc(sizeof(STATISTIC));
-			memcpy(sp, &statprop, sizeof(STATISTIC));
+			memcpy((void*)sp, &statprop, sizeof(STATISTIC));
 			strcpy(sp->statname, prop->name);
 			sp->prop = prop;
 			sp->value = 0;
@@ -526,8 +526,8 @@ int auction::init_statistics()
 			}
 		}
 	}
-	memset(&cleared_frame, 0, latency_stride);
-	memset(&current_frame, 0, latency_stride);
+	memset((void*)&cleared_frame, 0, latency_stride);
+	memset((void*)&current_frame, 0, latency_stride);
 	return 1;
 }
 
@@ -726,7 +726,7 @@ TIMESTAMP auction::pop_market_frame(TIMESTAMP t1)
 	}
 	// valid, time-applicable data
 	// ~ copy current data to past_frame
-	memcpy(&past_frame, &current_frame, sizeof(MARKETFRAME)); // not copying lagging stats
+	memcpy((void*)&past_frame, &current_frame, sizeof(MARKETFRAME)); // not copying lagging stats
 	// ~ copy new data in
 	current_frame.market_id = frame->market_id;
 	current_frame.start_time = frame->start_time;
@@ -874,7 +874,7 @@ void auction::clear_market(void)
 	extern double bid_offset;
 	double cap_ref_unrep = 0.0;
 
-	memset(&unresponsive, 0, sizeof(unresponsive));
+	memset((void*)&unresponsive, 0, sizeof(unresponsive));
 
 	/* handle unbidding capacity */
 	if(capacity_reference_property != NULL && special_mode != MD_FIXED_BUYER){
@@ -1416,7 +1416,7 @@ void auction::clear_market(void)
 	} 
 	else 
 	{
-		memcpy(&past_frame, &current_frame, sizeof(MARKETFRAME)); // just the frame
+		memcpy((void*)&past_frame, &current_frame, sizeof(MARKETFRAME)); // just the frame
 		// ~ copy new data in
 		current_frame.market_id = cleared_frame.market_id;
 		current_frame.start_time = cleared_frame.start_time;

--- a/module/market/controller.cpp
+++ b/module/market/controller.cpp
@@ -167,12 +167,12 @@ controller::controller(MODULE *module){
 				PT_KEYWORD, "FAILURE", (enumeration)CT_FAILURE,
 				PT_KEYWORD, "NULL", (enumeration)CT_NULL,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
-		memset(this,0,sizeof(controller));
+		memset((void*)this,0,sizeof(controller));
 	}
 }
 
 int controller::create(){
-	memset(this, 0, sizeof(controller));
+	memset((void*)this, 0, sizeof(controller));
 	sprintf((char *)(&avg_target), "avg24");
 	sprintf((char *)(&std_target), "std24");
 	slider_setting_heat = -0.001;
@@ -512,7 +512,7 @@ int controller::init(OBJECT *parent){
 		if(fetch_property(&pClearingType, "proxy_clearing_type", pMarket) == 0) {
 			return 0;
 		}
-		strncpy(market_unit, proxy_mkt_unit, 31);
+		strcpy(market_unit, proxy_mkt_unit);
 		submit = (FUNCTIONADDR)(gl_get_function(pMarket, "submit_bid_state"));
 		if(submit == NULL){
 			char buf[256];
@@ -550,7 +550,7 @@ int controller::init(OBJECT *parent){
 			if(fetch_property(&pClearingType2, "proxy_clearing_type2", pMarket2) == 0) {
 				return 0;
 			}
-			strncpy(market_unit2, proxy_mkt_unit2, 31);
+			strcpy(market_unit2, proxy_mkt_unit2);
 			submit2 = (FUNCTIONADDR)(gl_get_function(pMarket2, "submit_bid_state"));
 			if(submit2 == NULL){
 				char buf[256];

--- a/module/market/double_controller.cpp
+++ b/module/market/double_controller.cpp
@@ -81,12 +81,12 @@ double_controller::double_controller(MODULE *module)
 			PT_double, "stdev_price", PADDR(stdev_price),
 			
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
-		memset(this,0,sizeof(double_controller));
+		memset((void*)this,0,sizeof(double_controller));
 	}
 }
 
 int double_controller::create( ) {
-	memset(this, 0, sizeof(double_controller));
+	memset((void*)this, 0, sizeof(double_controller));
 	sprintf(avg_target, "avg24");
 	sprintf(std_target, "std24");
 	controller_bid.rebid = false;

--- a/module/market/passive_controller.cpp
+++ b/module/market/passive_controller.cpp
@@ -201,7 +201,7 @@ passive_controller::passive_controller(MODULE *mod)
 		{
 				GL_THROW("unable to publish properties in %s",__FILE__);
 		}
-		memset(this,0,sizeof(passive_controller));
+		memset((void*)this,0,sizeof(passive_controller));
 	}
 }
 
@@ -251,7 +251,7 @@ void passive_controller::fetch_int(int **prop, const char *name, OBJECT *parent)
 
 int passive_controller::create()
 {
-	memset(this, 0, sizeof(passive_controller));
+	memset((void*)this, 0, sizeof(passive_controller));
 	sensitivity = 1.0;
 	comfort_level = 1.0;
 	zipLoadParent = false;

--- a/module/market/stub_bidder.cpp
+++ b/module/market/stub_bidder.cpp
@@ -23,7 +23,7 @@ stub_bidder::stub_bidder(MODULE *module)
 				NULL)<1) 
 			GL_THROW("unable to publish properties in %s",__FILE__);
 		
-		memset(this,0,sizeof(stub_bidder));
+		memset((void*)this,0,sizeof(stub_bidder));
 	}
 }
 

--- a/module/market/stubauction.cpp
+++ b/module/market/stubauction.cpp
@@ -52,14 +52,14 @@ stubauction::stubauction(MODULE *module)
 				PT_KEYWORD,"DISABLED",(enumeration)CON_DISABLED,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-		memset(this,0,sizeof(stubauction));
+		memset((void*)this,0,sizeof(stubauction));
 	}
 }
 
 /* Object creation is called once for each object that is created by the core */
 int stubauction::create(void)
 {
-	memcpy(this,defaults,sizeof(stubauction));
+	memcpy((void*)this,defaults,sizeof(stubauction));
 	lasthr = thishr = -1;
 	verbose = 0;
 	control_mode = CON_NORMAL;

--- a/module/market/supervisory_control.cpp
+++ b/module/market/supervisory_control.cpp
@@ -50,7 +50,7 @@ supervisory_control::supervisory_control(MODULE *module) {
 				PT_KEYWORD,"VOLTAGE_EXTREMES",(enumeration)SORT_VOLTAGE2,
 			NULL)<1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-		memset(this,0,sizeof(supervisory_control));
+		memset((void*)this,0,sizeof(supervisory_control));
 	}
 }
 
@@ -79,7 +79,7 @@ void supervisory_control::fetch_double(double **prop, const char *name, OBJECT *
 /* Object creation is called once for each object that is created by the core */
 int supervisory_control::create(void) 
 {
-	memcpy(this,defaults,sizeof(supervisory_control));
+	memcpy((void*)this,defaults,sizeof(supervisory_control));
 	return 1; /* return 1 on success, 0 on failure */
 }
 

--- a/module/powerflow/capacitor.cpp
+++ b/module/powerflow/capacitor.cpp
@@ -1616,7 +1616,7 @@ SIMULATIONMODE capacitor::inter_deltaupdate_capacitor(unsigned int64 delta_time,
 		if (fmeas_type != FM_NONE)
 		{
 			//Copy the tracker value
-			memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+			memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 		}
 	}
 

--- a/module/powerflow/line_sensor.cpp
+++ b/module/powerflow/line_sensor.cpp
@@ -54,13 +54,13 @@ line_sensor::line_sensor(MODULE *module)
 				throw msg;
 		}
 
-		memset(this,0,sizeof(line_sensor));
+		memset((void*)this,0,sizeof(line_sensor));
 	}
 }
 
 int line_sensor::create(void)
 {
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 
 	return 1; /* return 1 on success, 0 on failure */
 }

--- a/module/powerflow/link.cpp
+++ b/module/powerflow/link.cpp
@@ -2895,7 +2895,7 @@ void link_object::perform_limit_checks(double *over_limit_value, bool *over_limi
 				*over_limit_value = (temp_power_check - (power_out.Mag()/1000.0))*1000.0;
 
 				//Flag as over
-				*over_limits = violation_detected = true;
+				*over_limits = (violation_detected = true);
 			}
 		}//End transformers
 		else	//Must be a line - that's the only other option right now
@@ -2935,7 +2935,7 @@ void link_object::perform_limit_checks(double *over_limit_value, bool *over_limi
 					*over_limit_value += temp_power_check;
 
 					//Flag as over
-					*over_limits = violation_detected = true;
+					*over_limits = (violation_detected = true);
 
 				}//End Phase 1 check
 
@@ -2971,7 +2971,7 @@ void link_object::perform_limit_checks(double *over_limit_value, bool *over_limi
 					*over_limit_value += temp_power_check;
 
 					//Flag as over
-					*over_limits = violation_detected = true;
+					*over_limits = (violation_detected = true);
 
 				}//End Phase 2 check
 			}//End triplex line check
@@ -3012,7 +3012,7 @@ void link_object::perform_limit_checks(double *over_limit_value, bool *over_limi
 						*over_limit_value += temp_power_check;
 
 						//Flag as over
-						*over_limits = violation_detected = true;
+						*over_limits = (violation_detected = true);
 
 					}//End Phase A check
 				}//End has Phase A
@@ -3051,7 +3051,7 @@ void link_object::perform_limit_checks(double *over_limit_value, bool *over_limi
 						*over_limit_value += temp_power_check;
 
 						//Flag as over
-						*over_limits = violation_detected = true;
+						*over_limits = (violation_detected = true);
 
 					}//End Phase B check
 				}//End has Phase B
@@ -3090,7 +3090,7 @@ void link_object::perform_limit_checks(double *over_limit_value, bool *over_limi
 						*over_limit_value += temp_power_check;
 
 						//Flag as over
-						*over_limits = violation_detected = true;
+						*over_limits = (violation_detected = true);
 
 					}//End Phase C check
 				}//End has Phase C

--- a/module/powerflow/load.cpp
+++ b/module/powerflow/load.cpp
@@ -3119,7 +3119,7 @@ SIMULATIONMODE load::inter_deltaupdate_load(unsigned int64 delta_time, unsigned 
 		if (fmeas_type != FM_NONE)
 		{
 			//Copy the tracker value
-			memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+			memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 		}
 	}
 

--- a/module/powerflow/meter.cpp
+++ b/module/powerflow/meter.cpp
@@ -879,7 +879,7 @@ SIMULATIONMODE meter::inter_deltaupdate_meter(unsigned int64 delta_time, unsigne
 		if (fmeas_type != FM_NONE)
 		{
 			//Copy the tracker value
-			memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+			memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 		}
 	}
 

--- a/module/powerflow/motor.cpp
+++ b/module/powerflow/motor.cpp
@@ -588,7 +588,7 @@ SIMULATIONMODE motor::inter_deltaupdate(unsigned int64 delta_time, unsigned long
 	if ((iteration_count_val==0) && (interupdate_pos == false) && (fmeas_type != FM_NONE)) 
 	{
 		//Update frequency calculation values (if needed)
-		memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+		memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 	}
 
 	//In the first call we need to initilize the dynamic model

--- a/module/powerflow/node.cpp
+++ b/module/powerflow/node.cpp
@@ -419,12 +419,12 @@ int node::create(void)
 	LoadHistTermL = NULL;
 	LoadHistTermC = NULL;
 
-	memset(voltage,0,sizeof(voltage));
-	memset(voltaged,0,sizeof(voltaged));
-	memset(current,0,sizeof(current));
-	memset(pre_rotated_current,0,sizeof(pre_rotated_current));
-	memset(power,0,sizeof(power));
-	memset(shunt,0,sizeof(shunt));
+	memset((void*)voltage,0,sizeof(voltage));
+	memset((void*)voltaged,0,sizeof(voltaged));
+	memset((void*)current,0,sizeof(current));
+	memset((void*)pre_rotated_current,0,sizeof(pre_rotated_current));
+	memset((void*)power,0,sizeof(power));
+	memset((void*)shunt,0,sizeof(shunt));
 
 	current_dy[0] = current_dy[1] = current_dy[2] = complex(0.0,0.0);
 	current_dy[3] = current_dy[4] = current_dy[5] = complex(0.0,0.0);
@@ -4205,7 +4205,7 @@ SIMULATIONMODE node::inter_deltaupdate_node(unsigned int64 delta_time, unsigned 
 		if (fmeas_type != FM_NONE)
 		{
 			//Copy the tracker value
-			memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+			memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 		}
 	}
 
@@ -4609,7 +4609,7 @@ void node::init_freq_dynamics(void)
 	}//End FOR loop
 
 	//Copy into current, since we may have already just done this
-	memcpy(&curr_freq_state,&prev_freq_state,sizeof(FREQM_STATES));
+	memcpy((void*)&curr_freq_state,&prev_freq_state,sizeof(FREQM_STATES));
 }
 
 //Function to perform the GFA-type responses

--- a/module/powerflow/pqload.cpp
+++ b/module/powerflow/pqload.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 SCHED_LIST *new_slist(){
 	SCHED_LIST *l = (SCHED_LIST *)gl_malloc(sizeof(SCHED_LIST));
-	memset(l, 0, sizeof(SCHED_LIST));
+	memset((void*)l, 0, sizeof(SCHED_LIST));
 	return l;
 }
 
@@ -104,7 +104,7 @@ pqload::pqload(MODULE *mod) : load(mod)
 				GL_THROW("unable to publish properties in %s",__FILE__);
 		}
 	defaults = this;
-	memset(this,0,sizeof(pqload));
+	memset((void*)this,0,sizeof(pqload));
 	input[5] = 1.0; /* constant term */
 	//imped_p[5] = 0;
 	strcpy(schedule, "* * * * *:1.0;");
@@ -159,7 +159,7 @@ int pqload::create(void)
 {
 	int res = 0;
 	
-	memcpy(this, defaults, sizeof(pqload));
+	memcpy((void*)this, defaults, sizeof(pqload));
 
 	res = node::create();
 

--- a/module/powerflow/switch_coordinator.cpp
+++ b/module/powerflow/switch_coordinator.cpp
@@ -76,14 +76,14 @@ switch_coordinator::switch_coordinator(MODULE *module)
 				sprintf(msg, "unable to publish properties in %s",__FILE__);
 				throw msg;
 		}
-		memset(this,0,sizeof(switch_coordinator));
+		memset((void*)this,0,sizeof(switch_coordinator));
 	}
 }
 
 int switch_coordinator::create(void)
 {
 	debug("switch_coordinator::create()");
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 	debug("switch_coordinator::create() -> 1");
 	return 1; /* return 1 on success, 0 on failure */
 }

--- a/module/powerflow/triplex_load.cpp
+++ b/module/powerflow/triplex_load.cpp
@@ -664,7 +664,7 @@ SIMULATIONMODE triplex_load::inter_deltaupdate_triplex_load(unsigned int64 delta
 		if (fmeas_type != FM_NONE)
 		{
 			//Copy the tracker value
-			memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+			memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 		}
 	}
 

--- a/module/powerflow/triplex_meter.cpp
+++ b/module/powerflow/triplex_meter.cpp
@@ -667,7 +667,7 @@ SIMULATIONMODE triplex_meter::inter_deltaupdate_triplex_meter(unsigned int64 del
 		if (fmeas_type != FM_NONE)
 		{
 			//Copy the tracker value
-			memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+			memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 		}
 	}
 

--- a/module/powerflow/triplex_node.cpp
+++ b/module/powerflow/triplex_node.cpp
@@ -263,7 +263,7 @@ SIMULATIONMODE triplex_node::inter_deltaupdate_triplex_node(unsigned int64 delta
 		if (fmeas_type != FM_NONE)
 		{
 			//Copy the tracker value
-			memcpy(&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
+			memcpy((void*)&prev_freq_state,&curr_freq_state,sizeof(FREQM_STATES));
 		}
 	}
 

--- a/module/residential/house_e.cpp
+++ b/module/residential/house_e.cpp
@@ -1022,7 +1022,7 @@ int house_e::create()
 						return FAILED;
 					}
 					IMPLICITENDUSE *item = (IMPLICITENDUSE*)gl_malloc(sizeof(IMPLICITENDUSE));
-					memset(item,0,sizeof(IMPLICITENDUSE));
+					memset((void*)item,0,sizeof(IMPLICITENDUSE));
 					gl_enduse_create(&(item->load));
 					item->load.shape = gl_loadshape_create(sched);
 					if (gl_set_value_by_type(PT_loadshape,item->load.shape,eu->shape)==0)
@@ -2114,7 +2114,7 @@ CIRCUIT *house_e::attach(OBJECT *obj, ///< object to attach
 	c->smartfuse->vMax = 1.05;
 
 	// initialize measurements
-	memset(c->measurement,0,sizeof(c->measurement));
+	memset((void*)c->measurement,0,sizeof(c->measurement));
 
 	return c;
 }

--- a/module/residential/rbsa.cpp
+++ b/module/residential/rbsa.cpp
@@ -56,7 +56,7 @@ rbsa::RBSADATA *rbsa::add_file(const char *filename)
 	RBSADATA *repo = (RBSADATA*)malloc(sizeof(RBSADATA));
 	if ( repo != NULL ) 
 	{
-		memset(repo,0,sizeof(RBSADATA));
+		memset((void*)repo,0,sizeof(RBSADATA));
 		repo->filename = strdup(filename);
 		repo->next_file = repository;
 		repository = repo;
@@ -99,7 +99,7 @@ rbsa::RBSADATA * rbsa::add_enduse(RBSADATA *repo, const char *enduse)
 	if ( repo->enduse != NULL ) // this is aleady in use
 	{
 		RBSADATA *item = (RBSADATA*)malloc(sizeof(RBSADATA));
-		memset(item,0,sizeof(RBSADATA));
+		memset((void*)item,0,sizeof(RBSADATA));
 		item->filename = repo->filename;
 		item->next_file = repo->next_file;
 		repo->next_enduse = item;
@@ -207,7 +207,7 @@ rbsa::COMPONENT *rbsa::add_component(const char *enduse, const char *composition
 	}
 
 	COMPONENT *c = (COMPONENT*)malloc(sizeof(COMPONENT));
-	memset(c,0,sizeof(COMPONENT));
+	memset((void*)c,0,sizeof(COMPONENT));
 	c->fraction = 1.0;
 	c->data = data;
 	char *buffer = strdup(composition);
@@ -382,7 +382,7 @@ rbsa::rbsa(MODULE *module)
 int rbsa::create(void) 
 {
 
-	memcpy(this,defaults,sizeof(*this));
+	memcpy((void*)this,defaults,sizeof(*this));
 	return 1; 
 }
 

--- a/module/tape/group_recorder.cpp
+++ b/module/tape/group_recorder.cpp
@@ -45,12 +45,12 @@ group_recorder::group_recorder(MODULE *mod){
 			GL_THROW("Unable to publish deltamode postupdate function for group_recorder");
 
 		defaults = this;
-		memset(this, 0, sizeof(group_recorder));
+		memset((void*)this, 0, sizeof(group_recorder));
     }
 }
 
 int group_recorder::create(){
-	memcpy(this, defaults, sizeof(group_recorder));
+	memcpy((void*)this, defaults, sizeof(group_recorder));
 	deltamode_gr = false;
 	return 1;
 }
@@ -453,7 +453,7 @@ int group_recorder::read_line()
 		if(0 == line_buffer){
 			return 0;
 		}
-		memset(line_buffer, 0, line_size);
+		memset((void*)line_buffer, 0, line_size);
 		if(-1 == write_interval){ // 'on change', will need second buffer
 			prev_line_buffer = (char *)malloc(line_size);
 			if(0 == prev_line_buffer){
@@ -463,7 +463,7 @@ int group_recorder::read_line()
 				*/
 				return 0;
 			}
-			memset(prev_line_buffer, 0, line_size);
+			memset((void*)prev_line_buffer, 0, line_size);
 		}
 	}
 
@@ -473,7 +473,7 @@ int group_recorder::read_line()
 		prev_line_buffer = line_buffer;
 		line_buffer = swap_ptr;
 	}
-	memset(line_buffer, 0, line_size);
+	memset((void*)line_buffer, 0, line_size);
 	for(curr = obj_list; curr != 0; curr = curr->next){
 		// GETADDR is a macro defined in object.h
 		if(curr->prop.ptype == PT_complex && complex_part != CP_NONE){

--- a/module/tape/histogram.cpp
+++ b/module/tape/histogram.cpp
@@ -56,10 +56,10 @@ histogram::histogram(MODULE *mod)
 			PT_int32, "limit", PADDR(limit),PT_DESCRIPTION,"the number of samples to write",
             NULL) < 1) GL_THROW("unable to publish properties in %s",__FILE__);
 		defaults = this;
-		memset(filename, 0, 1025);
-		memset(group, 0, 1025);
-		memset(bins, 0, 1025);
-		memset(property, 0, 33);
+		memset((void*)filename, 0, sizeof(filename));
+		memset((void*)group, 0, sizeof(group));
+		memset((void*)bins, 0, sizeof(bins));
+		memset((void*)property, 0, sizeof(property));
 		min = 0;
 		max = -1;
 		bin_count = -1;
@@ -78,7 +78,7 @@ histogram::histogram(MODULE *mod)
 
 int histogram::create()
 {
-	memcpy(this, defaults, sizeof(histogram));
+	memcpy((void*)this, defaults, sizeof(histogram));
 	return 1;
 }
 

--- a/module/tape/metrics_collector.cpp
+++ b/module/tape/metrics_collector.cpp
@@ -38,7 +38,7 @@ metrics_collector::metrics_collector(MODULE *mod){
 			NULL) < 1) GL_THROW("unable to publish properties in %s",__FILE__);
 
 		defaults = this;
-		memset(this, 0, sizeof(metrics_collector));
+		memset((void*)this, 0, sizeof(metrics_collector));
     }
 }
 
@@ -48,7 +48,7 @@ int metrics_collector::isa(char *classname){
 
 int metrics_collector::create(){
 
-	memcpy(this, defaults, sizeof(metrics_collector));
+	memcpy((void*)this, defaults, sizeof(metrics_collector));
 
 	// Give default values to parameters related to triplex_meter
 	real_power_array = NULL;

--- a/module/tape/metrics_collector_writer.cpp
+++ b/module/tape/metrics_collector_writer.cpp
@@ -55,18 +55,12 @@ int metrics_collector_writer::init(OBJECT *parent)
 	}
 
 	// Write seperate json files for meters, triplex_meters, inverters, capacitors, regulators, houses, substation_meter:
-	filename_billing_meter = "billing_meter_";
-	strcat(filename_billing_meter, filename);
-	filename_inverter = "inverter_";
-	strcat(filename_inverter, filename);
-	filename_capacitor = "capacitor_";
-	strcat(filename_capacitor, filename);
-	filename_regulator = "regulator_";
-	strcat(filename_regulator, filename);
-	filename_house = "house_";
-	strcat(filename_house, filename);
-	filename_substation = "substation_";
-	strcat(filename_substation, filename);
+	snprintf(filename_billing_meter,sizeof(filename_billing_meter)-1,"billing_meter_%s",(const char*)filename);
+	snprintf(filename_inverter,sizeof(filename_inverter)-1,"inverter_%s",(const char*)filename);
+	snprintf(filename_capacitor,sizeof(filename_capacitor)-1,"capacitor_%s",(const char*)filename);
+	snprintf(filename_regulator,sizeof(filename_regulator)-1,"regulator_%s",(const char*)filename);
+	snprintf(filename_house,sizeof(filename_house)-1,"house_%s",(const char*)filename);
+	snprintf(filename_substation,sizeof(filename_substation)-1,"substation_%s",(const char*)filename);
 
 	// Check valid metrics_collector output interval
 	interval_length = (int64)(interval_length_dbl);

--- a/module/tape/metrics_collector_writer.h
+++ b/module/tape/metrics_collector_writer.h
@@ -59,12 +59,12 @@ private:
 	Json::Value ary_capacitors;
 	Json::Value ary_regulators;
 
-	char256 filename_billing_meter;
-	char256 filename_inverter;
-	char256 filename_house;
-	char256 filename_substation;
-	char256 filename_capacitor;
-	char256 filename_regulator;
+	char1024 filename_billing_meter;
+	char1024 filename_inverter;
+	char1024 filename_house;
+	char1024 filename_substation;
+	char1024 filename_capacitor;
+	char1024 filename_regulator;
 
 	TIMESTAMP startTime;
 	TIMESTAMP final_write;

--- a/module/tape/tape.h
+++ b/module/tape/tape.h
@@ -95,16 +95,16 @@ struct player {
 	struct {
 		TIMESTAMP ts;
 		int64 ns;
-		char1024 value;
+		char value[5000];
 	} next;
 	struct {
 		TIMESTAMP ts;
 		TIMESTAMP ns;
-		char1024 value;
+		char value[5000];
 	} delta_track;	/* Added for deltamode fixes */
 	PROPERTY *target;
 	TAPEOPS *ops;
-	char lasterr[1024];
+	char lasterr[2048];
 }; /**< a player item */
 /** @}
 	@addtogroup shaper
@@ -135,7 +135,7 @@ struct shaper {
 		/** add handles for other type of sources as needed */
 	};
 	TAPESTATUS status;
-	char lasterr[1024];
+	char lasterr[2048];
 	int16 interval;	/* the interval over which events is counted (usually 24) */
 	int16 step;		/* the duration of a single step in the shape integral (usually 3600s) */
 	double scale;	/* the scaling of the shape over the interval */
@@ -189,7 +189,7 @@ struct recorder {
 	struct {
 		TIMESTAMP ts;
 		int64 ns;
-		char1024 value;
+		char value[5000];
 	} last;
 	int32 samples;
 	PROPERTY *target;
@@ -232,7 +232,7 @@ struct collector {
 	char8 delim;
 	struct {
 		TIMESTAMP ts;
-		char1024 value;
+		char value[5000];
 	} last;
 	int32 samples;
 	AGGREGATION *aggr;

--- a/module/tape/violation_recorder.cpp
+++ b/module/tape/violation_recorder.cpp
@@ -64,12 +64,12 @@ violation_recorder::violation_recorder(MODULE *mod){
 		}
         // TODO set defaults here
 		defaults = this;
-		memset(this, 0, sizeof(violation_recorder));
+		memset((void*)this, 0, sizeof(violation_recorder));
     }
 }
 
 int violation_recorder::create(){
-	memcpy(this, defaults, sizeof(violation_recorder));
+	memcpy((void*)this, defaults, sizeof(violation_recorder));
 	strict = false;
 	return 1;
 }

--- a/module/tape_file/tape_file.cpp
+++ b/module/tape_file/tape_file.cpp
@@ -72,7 +72,7 @@ EXPORT int open_player(struct player *my, char *fname, char *flags)
 	my->fp = (strcmp(fname,"-")==0?stdin:(ff?fopen(ff,flags):NULL));
 	if (my->fp==NULL)
 	{
-		sprintf(my->lasterr, "player file %s: %s", fname, strerror(errno));
+		snprintf(my->lasterr,sizeof(my->lasterr)-1, "player file %s: %s", fname, strerror(errno));
 		my->status = TS_DONE;
 		return 0;
 	}
@@ -113,7 +113,7 @@ static int setmap(char *spec, unsigned char *map, int size)
 {
 	char *p=spec;
 	int last=-1;
-	memset(map,0,MAPSIZE(size));
+	memset((void*)map,0,MAPSIZE(size));
 	while (*p!='\0')
 	{
 		if (*p=='*')
@@ -203,7 +203,7 @@ EXPORT int open_shaper(struct shaper *my, char *fname, char *flags)
 	char *ff = fname;
 
 	/* clear everything */
-	memset(scale,0,sizeof(scale));
+	memset((void*)scale,0,sizeof(scale));
 	linenum=0; 
 	file=fname;
 
@@ -211,7 +211,7 @@ EXPORT int open_shaper(struct shaper *my, char *fname, char *flags)
 	my->fp = (strcmp(fname,"-")==0?stdin:(ff?fopen(ff,flags):NULL));
 	if (my->fp==NULL)
 	{
-		sprintf(my->lasterr, "shaper file %s: %s", fname, strerror(errno));
+		snprintf(my->lasterr,sizeof(my->lasterr)-1, "shaper file %s: %s", fname, strerror(errno));
 		goto Error;
 	}
 	my->status=TS_OPEN;
@@ -219,7 +219,7 @@ EXPORT int open_shaper(struct shaper *my, char *fname, char *flags)
 	/* TODO: these should be read from the shape file, or better yet, inferred from it */
 	my->step = 3600; /* default interval step is one hour */
 	my->interval = 24; /* default unint shape integrated over one day */
-	memset(my->shape,0,sizeof(my->shape));
+	memset((void*)my->shape,0,sizeof(my->shape));
 	/* load the file into the shape */
 	while (fgets(line,sizeof(line),my->fp)!=NULL)
 	{
@@ -234,37 +234,37 @@ EXPORT int open_shaper(struct shaper *my, char *fname, char *flags)
 			int h, d, m, w;
 			if (sscanf(line,"%s %s %s %s %[^,],%[^,\n]",min,hour,day,month,weekday,value)<6)
 			{
-				sprintf(my->lasterr, "%s(%d) : shape '%s' missing specification '%s'", file, linenum, group, line);
+				snprintf(my->lasterr,sizeof(my->lasterr)-1, "%s(%d) : shape '%s' missing specification '%s'", file, linenum, group, line);
 				goto Error;
 			}
 			/* minutes are ignored right now */
 			if (min[0]!='*') //gl_warning
 			{
-				sprintf(my->lasterr, "%s(%d) : minutes are ignored in '%s'", file, linenum, line);
+				snprintf(my->lasterr,sizeof(my->lasterr)-1, "%s(%d) : minutes are ignored in '%s'", file, linenum, line);
 				goto Error;
 			}
 			hours=hourmap(hour);
 			if (hours==NULL)
 			{
-				sprintf(my->lasterr,"%s(%d): hours in '%s' not valid", file, linenum, line);
+				snprintf(my->lasterr,sizeof(my->lasterr)-1,"%s(%d): hours in '%s' not valid", file, linenum, line);
 				goto Error;
 			}
 			days=daymap(day);
 			if (days==NULL)
 			{
-				sprintf(my->lasterr,"%s(%d): days in '%s' not valid", file, linenum, line);
+				snprintf(my->lasterr,sizeof(my->lasterr)-1,"%s(%d): days in '%s' not valid", file, linenum, line);
 				goto Error;
 			}
 			months=monthmap(month);
 			if (months==NULL)
 			{
-				sprintf(my->lasterr,"%s(%d): months in '%s' not valid", file, linenum, line);
+				snprintf(my->lasterr,sizeof(my->lasterr)-1,"%s(%d): months in '%s' not valid", file, linenum, line);
 				goto Error;
 			}
 			weekdays=weekdaymap(weekday);
 			if (weekdays==NULL)
 			{
-				sprintf(my->lasterr,"%s(%d): weekdays in '%s' not valid", file, linenum, line);
+				snprintf(my->lasterr,sizeof(my->lasterr)-1,"%s(%d): weekdays in '%s' not valid", file, linenum, line);
 				goto Error;
 			}
 			load = (float)atof(value);

--- a/module/tape_plot/tape_plot.cpp
+++ b/module/tape_plot/tape_plot.cpp
@@ -495,7 +495,7 @@ EXPORT void close_recorder(struct recorder *my)
 		strcpy(gnuplot,plotcmd);
 	char fname[sizeof(char32)];
 	char type[sizeof(char32)];
-	char command[sizeof(char1024)];
+	char command[4096];
 
 	my->status = TS_DONE;
 
@@ -507,7 +507,7 @@ EXPORT void close_recorder(struct recorder *my)
 		fprintf(my->fp,"# end of tape\n");
 		fclose(my->fp);
 		sscanf(my->file,"%32[^:]:%32[^:]",type,fname);
-		sprintf(command,"%s %s", gnuplot, fname);
+		snprintf(command,sizeof(command)-1,"%s %s", gnuplot, fname);
 		system( command );
 	}
  	my->fp = NULL;


### PR DESCRIPTION
This PR fixes the large number of build warning on some linux systems.

## Current issues

None

## Code changes

- [x] Fixed numerous problems with `sprintf`, `snprintf`, `memset`, `strcpy`, and `strncpy` that caused warnings.

## Documentation changes

None

## Test and Validation Notes

None
