### PR TITLE
Develop add varchar

### DIFF
--- a/gldcore/Makefile.mk
+++ b/gldcore/Makefile.mk
@@ -66,6 +66,7 @@ GLD_SOURCES_PLACE_HOLDER += gldcore/timestamp.cpp gldcore/timestamp.h
 GLD_SOURCES_PLACE_HOLDER += gldcore/transform.cpp gldcore/transform.h
 GLD_SOURCES_PLACE_HOLDER += gldcore/unit.cpp gldcore/unit.h
 GLD_SOURCES_PLACE_HOLDER += gldcore/validate.cpp gldcore/validate.h
+GLD_SOURCES_PLACE_HOLDER += gldcore/varchar.cpp gldcore/varchar.h
 GLD_SOURCES_PLACE_HOLDER += gldcore/version.cpp gldcore/version.h
 GLD_SOURCES_PLACE_HOLDER += gldcore/link/python/python.cpp
 

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -66,7 +66,7 @@ DEPRECATED STATUS GldCmdarg::load_module_list(FILE *fd,int* test_mod_num)
 	varchar line;
 	while(fscanf(fd,"%s",line.resize(100)) != EOF)
 	{
-		snprintf(mod_test,sizeof(mod_test)-1,"mod_test%d=%s",(*test_mod_num)++,line.get_string());
+		sprintf(mod_test,"mod_test%d=%s",(*test_mod_num)++,line.get_string());
 		if (global_setvar(mod_test)!=SUCCESS)
 		{
 			output_fatal("Unable to store module name");

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -185,7 +185,6 @@ void GldCmdarg::print_class_d(CLASS *oclass, int tabdepth)
 				printf("%s\t%s %s;", tabs.get_string(), propname, prop->name);
 			}
 			varchar flags(1024);
-			TODO: this does not work correctly
 			if ( prop->flags&PF_DEPRECATED ) strcat(flags,flags[0]?",":"("),strcat(flags,"DEPRECATED");
 			if ( prop->flags&PF_REQUIRED ) strcat(flags,flags[0]?",":"("),strcat(flags,"REQUIRED");
 			if ( prop->flags&PF_OUTPUT ) strcat(flags,flags[0]?",":"("),strcat(flags,"OUTPUT");

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -62,12 +62,11 @@ DEPRECATED STATUS load_module_list(FILE *fd,int* test_mod_num)
 }
 DEPRECATED STATUS GldCmdarg::load_module_list(FILE *fd,int* test_mod_num)
 {
-	char mod_test[1024];
-	char line[100];
-	while(fscanf(fd,"%s",line) != EOF)
+	varchar mod_test;
+	varchar line;
+	while(fscanf(fd,"%s",line.resize(100)) != EOF)
 	{
-		printf("Line: %s",line);
-		snprintf(mod_test,sizeof(mod_test)-1,"mod_test%d=%s",(*test_mod_num)++,line);
+		snprintf(mod_test,sizeof(mod_test)-1,"mod_test%d=%s",(*test_mod_num)++,(const char*)line);
 		if (global_setvar(mod_test)!=SUCCESS)
 		{
 			output_fatal("Unable to store module name");
@@ -122,11 +121,11 @@ void GldCmdarg::modhelp_alpha(PNTREE **ctree, CLASS *oclass)
 	}
 }
 
-DEPRECATED void set_tabs(char *tabs, int tabdepth)
+DEPRECATED void set_tabs(varchar &tabs, int tabdepth)
 {
 	my_instance->get_cmdarg()->set_tabs(tabs,tabdepth);
 }
-void GldCmdarg::set_tabs(char *tabs, int tabdepth)
+void GldCmdarg::set_tabs(varchar &tabs, int tabdepth)
 {
 	if(tabdepth > 32){
 		throw_exception("print_class_d: tabdepth > 32, which is mightily deep!");
@@ -150,17 +149,18 @@ void GldCmdarg::print_class_d(CLASS *oclass, int tabdepth)
 {
 	PROPERTY *prop;
 	FUNCTION *func;
-	char tabs[33];
+	varchar tabs;
 
 	set_tabs(tabs, tabdepth);
 
-	printf("%sclass %s {\n", tabs, oclass->name);
-	if (oclass->parent){
-		printf("%s\tparent %s;\n", tabs, oclass->parent->name);
+	printf("%sclass %s {\n", (const char*)tabs, oclass->name);
+	if (oclass->parent)
+	{
+		printf("%s\tparent %s;\n", (const char*)tabs, oclass->parent->name);
 		print_class_d(oclass->parent, tabdepth+1);
 	}
 	for (func=oclass->fmap; func!=NULL && func->oclass==oclass; func=func->next)
-		printf( "%s\tfunction %s();\n", tabs, func->name);
+		printf( "%s\tfunction %s();\n", (const char*)tabs, func->name);
 	for (prop=oclass->pmap; prop!=NULL && prop->oclass==oclass; prop=prop->next)
 	{
 		const char *propname = class_get_property_typename(prop->ptype);
@@ -170,19 +170,19 @@ void GldCmdarg::print_class_d(CLASS *oclass, int tabdepth)
 				continue;
 			if (prop->unit != NULL)
 			{
-				printf("%s\t%s %s[%s];", tabs, propname, prop->name, prop->unit->name);
+				printf("%s\t%s %s[%s];", (const char*)tabs, propname, prop->name, prop->unit->name);
 			}
 			else if (prop->ptype==PT_set || prop->ptype==PT_enumeration)
 			{
 				KEYWORD *key;
-				printf("%s\t%s {", tabs, propname);
+				printf("%s\t%s {", (const char*)tabs, propname);
 				for (key=prop->keywords; key!=NULL; key=key->next)
 					printf("%s=%" FMT_INT64 "u%s", key->name, (int64)key->value, key->next==NULL?"":", ");
 				printf("} %s;", prop->name);
 			} 
 			else 
 			{
-				printf("%s\t%s %s;", tabs, propname, prop->name);
+				printf("%s\t%s %s;", (const char*)tabs, propname, prop->name);
 			}
 			char flags[1024] = "";
 			if ( prop->flags&PF_DEPRECATED ) strcat(flags,flags[0]?",":"("),strcat(flags,"DEPRECATED");
@@ -195,7 +195,7 @@ void GldCmdarg::print_class_d(CLASS *oclass, int tabdepth)
 			printf("\n");
 		}
 	}
-	printf("%s}\n\n", tabs);
+	printf("%s}\n\n", (const char*)tabs);
 }
 
 DEPRECATED void print_class(CLASS *oclass)

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -185,6 +185,7 @@ void GldCmdarg::print_class_d(CLASS *oclass, int tabdepth)
 				printf("%s\t%s %s;", tabs.get_string(), propname, prop->name);
 			}
 			varchar flags(1024);
+			TODO: this does not work correctly
 			if ( prop->flags&PF_DEPRECATED ) strcat(flags,flags[0]?",":"("),strcat(flags,"DEPRECATED");
 			if ( prop->flags&PF_REQUIRED ) strcat(flags,flags[0]?",":"("),strcat(flags,"REQUIRED");
 			if ( prop->flags&PF_OUTPUT ) strcat(flags,flags[0]?",":"("),strcat(flags,"OUTPUT");

--- a/gldcore/cmdarg.h
+++ b/gldcore/cmdarg.h
@@ -7,6 +7,8 @@
 #ifndef _CMDARG_H
 #define _CMDARG_H
 
+#include "varchar.h"
+
 #if ! defined _GLDCORE_H && ! defined _GRIDLABD_H
 #error "this header may only be included from gldcore.h or gridlabd.h"
 #endif
@@ -130,7 +132,7 @@ public:
 	STATUS no_cmdargs(void);
 	STATUS load_module_list(FILE *fd,int* test_mod_num);
 	void modhelp_alpha(PNTREE **ctree, CLASS *oclass);
-	void set_tabs(char *tabs, int tabdepth);
+	void set_tabs(varchar &tabs, int tabdepth);
 	void print_class_d(CLASS *oclass, int tabdepth);
 	void print_class(CLASS *oclass);
 	void print_modhelp_tree(PNTREE *ctree);

--- a/gldcore/gldcore.h
+++ b/gldcore/gldcore.h
@@ -138,6 +138,7 @@ typedef enum e_status {FAILED=FALSE, SUCCESS=TRUE} STATUS;
 #include "ufile.h"
 #include "unit.h"
 #include "validate.h"
+#include "varchar.h"
 #include "version.h"
 
 #endif

--- a/gldcore/gridlabd.h
+++ b/gldcore/gridlabd.h
@@ -201,6 +201,7 @@ typedef enum e_status {FAILED=FALSE, SUCCESS=TRUE} STATUS;
 #include "ufile.h"
 #include "unit.h"
 #include "validate.h"
+#include "varchar.h"
 #include "version.h"
 
 #ifdef DLMAIN

--- a/gldcore/object.cpp
+++ b/gldcore/object.cpp
@@ -1763,6 +1763,10 @@ int object_set_dependent(OBJECT *obj, /**< the object to set */
  */
 const char *object_property_to_string(OBJECT *obj, const char *name, char *buffer, int sz)
 {
+	return object_property_to_string(obj,name,buffer.get_string(),buffer.get_size());
+}
+const char *object_property_to_string(OBJECT *obj, const char *name, char *buffer, int sz)
+{
 	PROPERTY *prop = class_find_property(obj->oclass,name);
 	if ( prop == NULL )
 	{

--- a/gldcore/object.h
+++ b/gldcore/object.h
@@ -24,6 +24,7 @@
 #include "schedule.h"
 #include "transform.h"
 #include "enduse.h"
+#include "varchar.h"
 
 /* this must match property_type list in object.c */
 typedef unsigned int OBJECTRANK; /**< Object rank number */
@@ -434,6 +435,7 @@ complex *object_get_complex_quick(OBJECT *pObj, PROPERTY *prop);
 const char *object_get_string(OBJECT *pObj, PROPERTY *prop);
 const char *object_get_string_by_name(OBJECT *obj, const char *name);
 FUNCTIONADDR object_get_function(CLASSNAME classname, FUNCTIONNAME functionname);
+const char *object_property_to_string(OBJECT *obj, const char *name, varchar &buffer);
 const char *object_property_to_string(OBJECT *obj, const char *name, char *buffer, int sz);
 const char *object_property_to_string_x(OBJECT *obj, PROPERTY *prop, char *buffer, int sz);
 const char *object_get_unit(OBJECT *obj, const char *name);

--- a/gldcore/varchar.cpp
+++ b/gldcore/varchar.cpp
@@ -43,6 +43,7 @@ varchar::varchar(size_t len)
 	{
 		str = (char*)malloc(len+1);
 		ASSERT(str!=NULL,"varchar::varchar() malloc failed");
+		memset(str,0,len+1);
 		sz = len+1;
 	}
 	else
@@ -177,10 +178,10 @@ int varchar::format(size_t size, const char *fmt, va_list ptr)
 
 void varchar::append(const char *s)
 {
+	size_t len = strlen(str);
 	size_t slen = strlen(s);
-	size_t tlen = strlen(str);
-	resize(tlen+slen+1,true);
-	strcpy(str+slen,s);
+	resize(len+slen+1,true);
+	strcpy(str+len,s);
 	return;
 }
 

--- a/gldcore/varchar.cpp
+++ b/gldcore/varchar.cpp
@@ -11,7 +11,7 @@ varchar::varchar()
 	sz = 0;
 }
 
-varchar::varchar(char *src, size_t len)
+varchar::varchar(const char *src, size_t len)
 {
 	if ( src )
 	{
@@ -56,7 +56,7 @@ varchar::varchar(varchar &s)
 {
 	if ( s.str != NULL && s.sz > 0 )
 	{
-		str = strdup(s);
+		str = strdup(s.get_string());
 		ASSERT(str!=NULL,"varchar::varchar() strdup failed");
 		sz = s.sz;
 	}
@@ -179,12 +179,8 @@ void varchar::append(const char *s)
 {
 	size_t slen = strlen(s);
 	size_t tlen = strlen(str);
-	if ( tlen + slen > sz )
-	{
-		char *tmp = (char*)realloc(str,slen+tlen+1);
-		ASSERT(tmp!=NULL,"varchar::append() realloc failed");
-	}
-	strcpy(str+tlen,s);
+	resize(tlen+slen+1,true);
+	strcpy(str+slen,s);
 	return;
 }
 
@@ -196,16 +192,6 @@ void *memset(varchar &dst, int c, size_t len)
 {
 	dst.clear(len,c);
 	return (void*)dst.get_string();
-}
-
-int asprintf(varchar *dst, const char *fmt, ...)
-{
-	*dst = varchar();
-	va_list ptr;
-	va_start(ptr,fmt);
-	size_t len = sprintf(*dst,fmt,ptr);
-	va_end(ptr);
-	return len;
 }
 
 int sprintf(varchar &dst, const char *fmt, ...)

--- a/gldcore/varchar.cpp
+++ b/gldcore/varchar.cpp
@@ -1,0 +1,258 @@
+// gldcore/string.h
+// Copyright (C) 2021, Regents of the Leland Stanford Junior University
+
+#include "varchar.h"
+
+#define ASSERT(TEST,MESSAGE) if ( !(TEST) ) { throw MESSAGE; }
+
+varchar::varchar()
+{
+	str = NULL;
+	sz = 0;
+}
+
+varchar::varchar(char *src, size_t len)
+{
+	if ( src )
+	{
+		if ( len == 0 )
+		{
+			str = strdup(src);
+			ASSERT(str!=NULL,"varchar::varchar() strdup failed");
+			sz = strlen(src)+1;
+		}
+		else
+		{
+			str = (char*)malloc(len+1);
+			ASSERT(str!=NULL,"varchar::varchar() malloc failed");
+			strncpy(str,src,len);
+			str[len] = '\0';
+			sz = len+1;
+		}
+	}
+	else
+	{
+		str = NULL;
+		sz = 0;
+	}
+}
+
+varchar::varchar(size_t len)
+{
+	if ( len > 0 )
+	{
+		str = (char*)malloc(len+1);
+		ASSERT(str!=NULL,"varchar::varchar() malloc failed");
+		sz = len+1;
+	}
+	else
+	{
+		str = NULL;
+		sz = 0;
+	}
+}
+
+varchar::varchar(varchar &s)
+{
+	if ( s.str != NULL && s.sz > 0 )
+	{
+		str = strdup(s);
+		ASSERT(str!=NULL,"varchar::varchar() strdup failed");
+		sz = s.sz;
+	}
+	else
+	{
+		str = NULL;
+		sz = 0;
+	}
+}
+
+varchar::~varchar()
+{
+	if ( str != NULL )
+	{
+		free(str);
+	}
+	str = NULL;
+	sz = 0;
+}
+
+void varchar::_realloc(char *s, size_t len)
+{
+	if ( str != NULL )
+	{
+		free(str);
+	}
+	str = s;
+	if ( len < 0 )
+	{
+		len = strlen(s);
+	}
+	sz = len;
+}
+
+char *varchar::resize(size_t len, bool keep)
+{
+	if ( len > sz )
+	{
+		char *tmp = (char*)malloc(len+1);
+		ASSERT(tmp!=NULL,"varchar::resize() malloc failed");
+		if ( str != NULL )
+		{
+			if ( keep )
+			{
+				strcpy(tmp,str);
+			}
+			else
+			{
+				memset(tmp,0,len+1);
+			}
+			free(str);
+		}
+		else
+		{
+			memset(tmp,0,len+1);
+		}
+		str = tmp;
+		sz = len;
+	}
+	return str;
+}
+
+void varchar::clear(size_t len, int c)
+{
+	memset(resize(len),c,len);
+}
+
+void varchar::copy(const char *s, size_t len)
+{
+	if ( len < 0 )
+	{
+		len = strlen(s);
+	}
+	resize(len,false);
+	strcpy(str,s);
+}
+
+void varchar::copy(varchar &s)
+{
+	copy(s.str);
+}
+
+size_t varchar::length()
+{
+	return str ? strlen(str) : 0;
+}
+
+int varchar::format(const char *fmt, ...)
+{
+	va_list ptr;
+	va_start(ptr,fmt);
+	size_t len = format(fmt,ptr);
+	va_end(ptr);
+	return len;
+}
+
+int varchar::format(const char *fmt, va_list ptr)
+{
+	char *buf;
+	size_t len = vasprintf(&buf,fmt,ptr);
+	ASSERT(len>=0,"varchar::format() vasprintf failed");
+	_realloc(buf,len);
+	return len;
+}
+
+int varchar::format(size_t size, const char *fmt, va_list ptr)
+{
+	char *buf;
+	size_t len = vasprintf(&buf,fmt,ptr);
+	ASSERT(len>=0,"varchar::format() vasprintf failed");
+	if ( len > size )
+	{
+		buf[len] = '\0';
+	}
+	_realloc(buf,len);
+	return len;
+}
+
+void varchar::append(const char *s)
+{
+	size_t slen = strlen(s);
+	size_t tlen = strlen(str);
+	if ( tlen + slen > sz )
+	{
+		char *tmp = (char*)realloc(str,slen+tlen+1);
+		ASSERT(tmp!=NULL,"varchar::append() realloc failed");
+	}
+	strcpy(str+tlen,s);
+	return;
+}
+
+size_t strlen(varchar &dst)
+{
+	return dst.length();
+}
+void *memset(varchar &dst, int c, size_t len)
+{
+	dst.clear(len,c);
+	return (void*)dst.get_string();
+}
+
+int asprintf(varchar *dst, const char *fmt, ...)
+{
+	*dst = varchar();
+	va_list ptr;
+	va_start(ptr,fmt);
+	size_t len = sprintf(*dst,fmt,ptr);
+	va_end(ptr);
+	return len;
+}
+
+int sprintf(varchar &dst, const char *fmt, ...)
+{
+	va_list ptr;
+	va_start(ptr,fmt);
+	size_t len = dst.format(fmt,ptr);
+	va_end(ptr);
+	return len;
+}
+
+int snprintf(varchar &dst, size_t sz, const char *fmt, ...)
+{
+	va_list ptr;
+	va_start(ptr,fmt);
+	size_t len = dst.format(sz,fmt,ptr);
+	va_end(ptr);
+	return len;
+}
+
+int vsprintf(varchar &dst, const char *fmt, va_list ptr)
+{
+	return dst.format(fmt,ptr);
+}
+
+int vsnprintf(varchar &dst, size_t sz, const char *fmt, va_list ptr)
+{
+	return dst.format(sz,fmt,ptr);
+}
+
+varchar &strcpy(varchar &dst, const char *src)
+{
+	dst.copy(src);
+	return dst;
+}
+
+varchar &strcpy(varchar &dst, const char *src, size_t sz)
+{
+	dst.copy(src);
+	return dst;
+}
+
+varchar &strcat(varchar &dst, const char *src)
+{
+	dst.append(src);
+	return dst;
+}
+
+
+

--- a/gldcore/varchar.cpp
+++ b/gldcore/varchar.cpp
@@ -206,9 +206,17 @@ int sprintf(varchar &dst, const char *fmt, ...)
 
 int snprintf(varchar &dst, size_t sz, const char *fmt, ...)
 {
+	size_t len;
 	va_list ptr;
 	va_start(ptr,fmt);
-	size_t len = dst.format(sz,fmt,ptr);
+	if ( sz < dst.get_size() )
+	{
+		len = vsnprintf(dst.get_string(),sz,fmt,ptr);
+	}
+	else
+	{
+		len = dst.format(sz,fmt,ptr);
+	}
 	va_end(ptr);
 	return len;
 }

--- a/gldcore/varchar.h
+++ b/gldcore/varchar.h
@@ -1,0 +1,65 @@
+// gldcore/string.h
+// Copyright (C) 2021, Regents of the Leland Stanford Junior University
+//
+// The varchar class is designed to serve as a simple replacement for
+// most char[SIZE] declarations.
+//
+
+#ifndef _VARCHAR_H
+#define _VARCHAR_H
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+class varchar
+{
+private:
+	char *str;
+	size_t sz;
+public:
+	varchar();
+	varchar(char *src, size_t len=0);
+	varchar(size_t len);
+	varchar(varchar &s);
+	~varchar();
+private:
+	void _realloc(char *str,size_t len=-1);
+public:
+	inline const char *get_string() { return str; };
+	inline const size_t get_size() { return sz; };
+public:
+	char *resize(size_t len, bool keep=false);
+	void clear(size_t len, int c=0);
+	void copy(const char *s, size_t len=-1);
+	void copy(varchar &s);
+public:
+	inline operator const char *() { return str; };
+	inline operator void *() { return str; };
+	inline operator char *() { return str; };
+	inline char &operator [] (size_t n) { return str[n]; };
+	varchar &operator = (const char *s) { copy(s); return *this; };
+	varchar &operator = (varchar &s) { copy(s); return *this; };
+public:
+	size_t length();
+	int format(const char *fmt, ...);
+	int format(const char *fmt, va_list ptr);
+	int format(size_t size, const char *fmt, va_list ptr);
+	void append(const char *str);
+};
+
+size_t strlen(varchar &dst);
+void *memset(varchar &dst, int c, size_t len);
+
+int asprintf(varchar *dst, const char *fmt, ...);
+int sprintf(varchar &dst, const char *fmt, ...);
+int snprintf(varchar &dst, size_t sz, const char *fmt, ...);
+int vsprintf(varchar &dst, const char *fmt, va_list ptr);
+int vsnprintf(varchar &dst, size_t sz, const char *fmt, va_list ptr);
+
+varchar &strcpy(varchar &dst, const char *src);
+varchar &strcpy(varchar &dst, const char *src, size_t sz);
+varchar &strcat(varchar &dst, const char *src);
+
+#endif

--- a/gldcore/varchar.h
+++ b/gldcore/varchar.h
@@ -1,9 +1,5 @@
 // gldcore/string.h
 // Copyright (C) 2021, Regents of the Leland Stanford Junior University
-//
-// The varchar class is designed to serve as a simple replacement for
-// most char[SIZE] declarations.
-//
 
 #ifndef _VARCHAR_H
 #define _VARCHAR_H
@@ -13,31 +9,59 @@
 #include <string.h>
 #include <stdio.h>
 
+// Class: varchar
+//
+// The varchar class is a simple replacement for most char[SIZE] declarations,
+// e.g., replace "char a[N];" with "varchar a(N);".  In general, most string 
+// functions will work the same.  Some functions needs to use the ".get_string()"
+// and ".get_size()" members to access the buffer pointer and buffer size.
+//
+// Important note: this class is not thread safe. It is primarly intented as an
+// easy replacement for strings allocated on the stack.
+//
 class varchar
 {
 private:
+	// Member: str
+	// The buffer containing the character string
 	char *str;
+
+	// Member: sz
+	// The maximum size of the character string allowed in the buffer
 	size_t sz;
 public:
+
+	// Constructor: varchar
 	varchar();
-	varchar(char *src, size_t len=0);
+	varchar(const char *src, size_t len=0);
 	varchar(size_t len);
 	varchar(varchar &s);
+
+	// Destructor: ~varchar
 	~varchar();
 private:
+
+	// Method: internal reallocation of buffer
 	void _realloc(char *str,size_t len=-1);
 public:
-	inline const char *get_string() { return str; };
+
+	// Method: 
+	inline operator const char *() { return str; };
+	inline char *get_string() { return str; };
 	inline const size_t get_size() { return sz; };
+public:
+	inline bool operator == (const char *s) { return strcmp(s,str)==0; };
+	inline bool operator >= (const char *s) { return strcmp(s,str)>=0; };
+	inline bool operator > (const char *s) { return strcmp(s,str)>0; };
+	inline bool operator != (const char *s) { return strcmp(s,str)!=0; };
+	inline bool operator < (const char *s) { return strcmp(s,str)<0; };
+	inline bool operator <= (const char *s) { return strcmp(s,str)<=0; };
 public:
 	char *resize(size_t len, bool keep=false);
 	void clear(size_t len, int c=0);
 	void copy(const char *s, size_t len=-1);
 	void copy(varchar &s);
 public:
-	inline operator const char *() { return str; };
-	inline operator void *() { return str; };
-	inline operator char *() { return str; };
 	inline char &operator [] (size_t n) { return str[n]; };
 	varchar &operator = (const char *s) { copy(s); return *this; };
 	varchar &operator = (varchar &s) { copy(s); return *this; };
@@ -52,7 +76,6 @@ public:
 size_t strlen(varchar &dst);
 void *memset(varchar &dst, int c, size_t len);
 
-int asprintf(varchar *dst, const char *fmt, ...);
 int sprintf(varchar &dst, const char *fmt, ...);
 int snprintf(varchar &dst, size_t sz, const char *fmt, ...);
 int vsprintf(varchar &dst, const char *fmt, va_list ptr);


### PR DESCRIPTION
This PR fixes issues with buffer size limits on stack strings.

General upgrade rules:

1. declarations of `char str[N]` become `varchar str(N)`.
2. calls to most function taking `const char *` remain unchanged.
3. calls to functions taking `char *, size_t` arguments must use `get_string()` and `get_size()`, e.g., `read(str,sizeof(str)-1)` becomes `read(str.get_string(),str.get_size()-1)`.
4. calls to `sscanf`-style functions must ensure that the string is large enough for the input including the string terminator, e.g., `varchar str[1234]; sscanf(input,"%1233s",str.get_string());`

## Current issues

1. This is not yet implemented in all the core files or modules.

## Code changes

- [x] Just about every source file is affected by this change

## Documentation changes

None

## Test and Validation Notes

None
