### PR TITLE
Update tzinfo.txt

### DIFF
--- a/gldcore/tzinfo.txt
+++ b/gldcore/tzinfo.txt
@@ -128,13 +128,22 @@ EST+5EDT,M4.5.0/02:00,M10.5.0/02:00 ; Eastern, DST 2am last Sun/Apr to last Sun/
  US/MA/Boston
  US/MD/Baltimore
  US/NY/New York
+ America/Washington
+ America/Atlanta
+ America/Boston
+ America/New York
+ America/Baltimore
 CST+6CDT,M4.5.0/02:00,M10.5.0/02:00 ; Central, DST 2am last Sun/Apr to last Sun/Oct
  US/IL/Chicago
+ America/Chicago
  US/LA/New Orleans
+ America/New Orleans
  US/MO/St Louis
+ America/St Louis
 MST+7MDT,M4.5.0/02:00,M10.5.0/02:00 ; Mountain, DST 2am last Sun/Apr to last Sun/Oct
  CA/AB/Calgary
  US/CO/Denver
+ America/Denver
 PST+8PDT,M4.5.0/02:00,M10.5.0/02:00 ; Pacific, DST 2am last Sun/Apr to last Sun/Oct
  CA/BC/Vancouver
  US/CA/Los Angeles
@@ -142,10 +151,14 @@ PST+8PDT,M4.5.0/02:00,M10.5.0/02:00 ; Pacific, DST 2am last Sun/Apr to last Sun/
  US/OR/Portland
  US/WA/Seattle
  America/Los_Angeles
+ America/San Francisco
+ America/Seattle
 AST+9ADT,M4.5.0/02:00,M10.5.0/02:00 ; Alaska DST 2am last Sun/Apr to last Sun/Oct
  US/AK/Anchorage
+ America/Anchorage
 HST+10HDT,M4.5.0/02:00,M10.5.0/02:00 ; Hawaii DST 2am last Sun/Apr to last Sun/Oct
  US/HI/Honolulu
+ America/Honolulu
 
 [1986] ; Rules as of 1986
 

--- a/gldcore/tzinfo.txt
+++ b/gldcore/tzinfo.txt
@@ -109,6 +109,7 @@ EST5 ; Eastern no DST
 CST6 ; Central no DST
 MST7 ; Mountain no DST
  US/AZ/Phoenix
+ America/Phoenix
 PST8 ; Pacific no DST
 AST9 ; Alaska no DST
 HST10; Hawaii no DST
@@ -140,6 +141,7 @@ PST+8PDT,M4.5.0/02:00,M10.5.0/02:00 ; Pacific, DST 2am last Sun/Apr to last Sun/
  US/CA/San Francisco
  US/OR/Portland
  US/WA/Seattle
+ America/Los_Angeles
 AST+9ADT,M4.5.0/02:00,M10.5.0/02:00 ; Alaska DST 2am last Sun/Apr to last Sun/Oct
  US/AK/Anchorage
 HST+10HDT,M4.5.0/02:00,M10.5.0/02:00 ; Hawaii DST 2am last Sun/Apr to last Sun/Oct


### PR DESCRIPTION
This PR adds commonly use ISO timezone locations, e.g., using `America` in addition to `US/<state>`.