### PR TITLE
Add version subcommand list detail

### DIFF
--- a/docs/Subcommand/Version.md
+++ b/docs/Subcommand/Version.md
@@ -5,10 +5,10 @@
 Shell:
 
 ~~~
-	bash$ gridlabd version 
+	bash$ gridlabd version
 	bash$ gridlabd version help
 	bash$ gridlabd version check [-v|-q]
-	bash$ gridlabd version list <PATTERN>
+	bash$ gridlabd version list [-l] <PATTERN>
 	bash$ gridlabd version show
 	bash$ gridlabd version set [<PATTERN>]
 	bash$ gridlabd version source
@@ -55,10 +55,10 @@ The `help` command displays the available command options.
 ## `list`
 
 ~~~
-	gridlabd version list [<pattern>]
+	gridlabd version list [-l] [<pattern>]
 ~~~
 
-The `list` command displays the available versions that can be made available to all users on the system.
+The `list` command displays the available versions that can be made available to all users on the system. The `-l` option causes the output to be in long form and include version size on disk.
 
 ## `set`
 

--- a/gldcore/scripts/gridlabd-version
+++ b/gldcore/scripts/gridlabd-version
@@ -9,7 +9,7 @@ function error()
 }
 
 case "$1" in
---dryrun) 
+--dryrun)
 	ACTION="echo"
 	shift 1
 	;;
@@ -140,10 +140,40 @@ function version-delete()
 function version-list()
 {
 	if [ $# -eq 0 ]; then
-		basename /usr/local/opt/gridlabd/* | grep -v '^current$'
-	else
-		basename /usr/local/opt/gridlabd/*$1*
+        for D in $(basename /usr/local/opt/gridlabd/*); do
+            if [ "$D" != "current" -a -x "/usr/local/opt/gridlabd/$D/bin/gridlabd.bin" ]; then
+                echo $D
+            fi
+        done
+	elif [ "$1" == "-l" ]; then
+        longlist $2
+    else
+        for D in $(basename /usr/local/opt/gridlabd/*$1*); do
+            if [ "$D" != "current" -a -x "/usr/local/opt/gridlabd/$D/bin/gridlabd.bin" ]; then
+                echo $D
+            fi
+        done
 	fi
+}
+
+function longlist()
+{
+    if [ $# -eq 0 ]; then
+		LIST=$(basename /usr/local/opt/gridlabd/* | grep -v '^current$')
+	else
+		LIST=$(basename /usr/local/opt/gridlabd/*$1*)
+	fi
+    echo "total$(du -sh /usr/local/opt/gridlabd | cut -c1-4)"
+    for D in $LIST; do
+        if [ -x "/usr/local/opt/gridlabd/$D/bin/gridlabd.bin" ]; then
+            NAME=$(basename $D)
+            VERSION=$(echo $NAME | cut -f1 -d-)
+            BUILD=$(echo $NAME | cut -f2 -d-)
+            BRANCH=$(echo $NAME | cut -f3 -d-)
+            SIZE=$(du -sh /usr/local/opt/gridlabd/$D | cut -c1-4)
+            echo "$VERSION $BUILD $SIZE $BRANCH"
+        fi
+    done
 }
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
Add support for '-l' option on 'gridlabd version list'. This displays the version information is a tabular form with install size included.

## Current issues

None

## Code changes
- [x] Add `longlist` function to `gldcore/scripts/gridlabd-version`.
- [x] Add support for `-l` option on `version-list` function. 

## Documentation changes
- [x] [/Subcommand/Version](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-add-version-list-details&doc=/Subcommand/Version.md)

## Test and Validation Notes

The command `gridlabd version list -l PATTERN` is now supported.
