### PR TITLE
Table CSV to GLM converter for generic objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ openfido.err
 test_*.html
 gldcore/converters/autotest/IEEE-123.html
 gldcore/converters/autotest/solver_nr_profile.csv
+gldcore/converters/autotest/table2glm_input_noclass.glm
+gldcore/converters/autotest/table2glm_input_noname.glm
+gldcore/converters/autotest/table2glm_input.glm

--- a/docs/Converters/Import/Csv_files.md
+++ b/docs/Converters/Import/Csv_files.md
@@ -33,6 +33,7 @@ Weather data can be obtained from many different sources.  The converters curren
   * [[/Converters/Import/Config_data]]
   * [[/Converters/Import/Ica_data]]
   * [[/Converters/Import/Modify_data]]
+  * [[/Converters/Import/Table_data]]  
 * Weather data
   * [[/Converters/Import/Noaa_weather]]
   * [[/Converters/Import/Onpoint_weather]]

--- a/docs/Converters/Import/Table_data.md
+++ b/docs/Converters/Import/Table_data.md
@@ -15,7 +15,7 @@ Seconds | 301 | 283 | 290 | 286 | 289 | 285 | 287 | 287 | 272 | 276 | 269
 
 
 class | name | tilt_angle | tilt_direction | weather | configuration | equipment_area | equipment_height | install_year	| repair_time | latitude | longitude | phases | nominal_voltage | tmyfile
---- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |---
+--- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |--- |---
 pole | pole1 | 5 deg | 270	| weather | WOOD-C-45/5 | | | 1990 | 1 h | 37.4275 | 122.1697 | ABC | 12470
 pole | pole2 | 8 deg | 270	| weather | WOOD-C-45/5 | | | 2000 | 8 h | 37.127 | 122.1646 | ABC | 12470
 climate | weather | | 	|  |  | | |  |  |  |  |  | CA-Chino_Airport.tmy3
@@ -24,6 +24,13 @@ Sample usage within GLM
 ~~~
 #input "input_file.csv" -f "table" -t "object" 
 ~~~
+
+If you'd like to omit the class in the table you can specify it in the input command line instead as 
+
+~~~
+#input "input_file.csv" -f "table" -t "object" -C "pole"
+~~~
+The caveat with doing so is that all the objects specified in the CSV must match the class specified in the input command. The code will overwrite this specification if the class is specified in the file.
 
 This will generate an "input_file.glm" and automatically include the objects within the model. 
 

--- a/docs/Converters/Import/Table_data.md
+++ b/docs/Converters/Import/Table_data.md
@@ -1,0 +1,32 @@
+[[/Converters/Import/Table_data]] -- Table data import
+
+# Synopis
+
+This converter allows for any arbitrary object to be imported via CSV-formatted table. 
+
+# Description
+
+Any arbitrary objects can be listed in a CSV file and convertered to GLM-formatted object. The `class` can either be defined through `options` or specified directly in the CSV. The table format is as below : 
+
+
+class | #1 | #2 | #3 | #4 | #5 | #6 | #7 | #8 | #9 | #10 | #11
+--- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |---
+Seconds | 301 | 283 | 290 | 286 | 289 | 285 | 287 | 287 | 272 | 276 | 269
+
+
+class | name | tilt_angle | tilt_direction | weather | configuration | equipment_area | equipment_height | install_year	| repair_time | latitude | longitude | phases | nominal_voltage | tmyfile
+--- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |---
+pole | pole1 | 5 deg | 270	| weather | WOOD-C-45/5 | | | 1990 | 1 h | 37.4275 | 122.1697 | ABC | 12470
+pole | pole2 | 8 deg | 270	| weather | WOOD-C-45/5 | | | 2000 | 8 h | 37.127 | 122.1646 | ABC | 12470
+climate | weather | | 	|  |  | | |  |  |  |  |  | CA-Chino_Airport.tmy3
+
+Sample usage within GLM
+~~~
+#input "input_file.csv" -f "table" -t "object" 
+~~~
+
+This will generate an "input_file.glm" and automatically include the objects within the model. 
+
+# See also
+
+* [[/Converters/Import/Csv_files]]

--- a/docs/Converters/Import/Table_data.md
+++ b/docs/Converters/Import/Table_data.md
@@ -22,7 +22,7 @@ Sample usage within GLM
 The `class` can either be defined through `options` or specified directly in the CSV. If you'd like to omit the class in the table you can specify it in the input command line instead as 
 
 ~~~
-#input "input_file.csv" -f "table" -t "object" -C "pole"
+#input "input_file.csv" -f "table" -t "object" -C "powerflow.pole"
 ~~~
 The function will overwrite the `class` specification if the class is already specified in the file. 
 

--- a/docs/Converters/Import/Table_data.md
+++ b/docs/Converters/Import/Table_data.md
@@ -6,7 +6,7 @@ This converter allows for any arbitrary object to be imported via CSV-formatted 
 
 # Description
 
-Any arbitrary objects can be listed in a CSV file and convertered to GLM-formatted object. The `class` can either be defined through `options` or specified directly in the CSV. The table format is as below : 
+Any arbitrary objects can be listed in a CSV file and convertered to GLM-formatted object. The table format is as below : 
 
 class | name | tilt_angle | tilt_direction | weather | configuration | equipment_area | equipment_height | install_year	| repair_time | latitude | longitude | phases | nominal_voltage | tmyfile
 --- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |--- |---
@@ -19,12 +19,14 @@ Sample usage within GLM
 #input "input_file.csv" -f "table" -t "object" 
 ~~~
 
-If you'd like to omit the class in the table you can specify it in the input command line instead as 
+The `class` can either be defined through `options` or specified directly in the CSV. If you'd like to omit the class in the table you can specify it in the input command line instead as 
 
 ~~~
 #input "input_file.csv" -f "table" -t "object" -C "pole"
 ~~~
-The caveat with doing so is that all the objects specified in the CSV must match the class specified in the input command. The code will overwrite this specification if the class is specified in the file. You can also omit the names and the function will autopopulate the object in the format as `<class_name>_<row_number>`
+The function will overwrite the `class` specification if the class is already specified in the file. 
+
+The object names can be omitted and the function will autopopulate the object in the format as `<class_name>_<row_number>`
 
 This will generate an "input_file.glm" and automatically include the objects within the model. 
 

--- a/docs/Converters/Import/Table_data.md
+++ b/docs/Converters/Import/Table_data.md
@@ -12,7 +12,7 @@ class | name | tilt_angle | tilt_direction | weather | configuration | equipment
 --- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |--- |---
 pole | pole1 | 5 deg | 270	| weather | WOOD-C-45/5 | | | 1990 | 1 h | 37.4275 | 122.1697 | ABC | 12470
 pole | pole2 | 8 deg | 270	| weather | WOOD-C-45/5 | | | 2000 | 8 h | 37.127 | 122.1646 | ABC | 12470
-climate | weather | | 	|  |  | | |  |  |  |  |  | CA-Chino_Airport.tmy3
+climate | weather | | 	|  |  | | |  |  |  |  |  | | CA-Chino_Airport.tmy3
 
 Sample usage within GLM
 ~~~
@@ -24,7 +24,7 @@ If you'd like to omit the class in the table you can specify it in the input com
 ~~~
 #input "input_file.csv" -f "table" -t "object" -C "pole"
 ~~~
-The caveat with doing so is that all the objects specified in the CSV must match the class specified in the input command. The code will overwrite this specification if the class is specified in the file.
+The caveat with doing so is that all the objects specified in the CSV must match the class specified in the input command. The code will overwrite this specification if the class is specified in the file. You can also omit the names and the function will autopopulate the object in the format as `<class_name>_<row_number>`
 
 This will generate an "input_file.glm" and automatically include the objects within the model. 
 

--- a/docs/Converters/Import/Table_data.md
+++ b/docs/Converters/Import/Table_data.md
@@ -8,12 +8,6 @@ This converter allows for any arbitrary object to be imported via CSV-formatted 
 
 Any arbitrary objects can be listed in a CSV file and convertered to GLM-formatted object. The `class` can either be defined through `options` or specified directly in the CSV. The table format is as below : 
 
-
-class | #1 | #2 | #3 | #4 | #5 | #6 | #7 | #8 | #9 | #10 | #11
---- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |---
-Seconds | 301 | 283 | 290 | 286 | 289 | 285 | 287 | 287 | 272 | 276 | 269
-
-
 class | name | tilt_angle | tilt_direction | weather | configuration | equipment_area | equipment_height | install_year	| repair_time | latitude | longitude | phases | nominal_voltage | tmyfile
 --- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |--- |---
 pole | pole1 | 5 deg | 270	| weather | WOOD-C-45/5 | | | 1990 | 1 h | 37.4275 | 122.1697 | ABC | 12470

--- a/gldcore/converters/Makefile.mk
+++ b/gldcore/converters/Makefile.mk
@@ -13,6 +13,7 @@ dist_pkgdata_DATA += gldcore/converters/csv-ica2glm-ica.py
 dist_pkgdata_DATA += gldcore/converters/csv-noaa-weather2glm-weather.py
 dist_pkgdata_DATA += gldcore/converters/csv-onpoint-weather2glm-weather.py
 dist_pkgdata_DATA += gldcore/converters/csv-visualcrossing-weather2glm-weather.py
+dist_pkgdata_DATA += gldcore/converters/csv-table2glm-object.py
 
 # mdb -> glm
 dist_pkgdata_DATA += gldcore/converters/mdb2glm.py

--- a/gldcore/converters/autotest/table2glm_input.csv
+++ b/gldcore/converters/autotest/table2glm_input.csv
@@ -1,0 +1,2 @@
+class,name ,wind_speed,temperature
+climate,weather,4 m/s,95 degF

--- a/gldcore/converters/autotest/table2glm_input_noclass.csv
+++ b/gldcore/converters/autotest/table2glm_input_noclass.csv
@@ -1,0 +1,2 @@
+class,name ,wind_speed,temperature
+,weather,4 m/s,95 degF

--- a/gldcore/converters/autotest/table2glm_input_noname.csv
+++ b/gldcore/converters/autotest/table2glm_input_noname.csv
@@ -1,0 +1,2 @@
+class,name ,wind_speed,temperature
+climate,,4 m/s,95 degF

--- a/gldcore/converters/autotest/test_table2glm.glm
+++ b/gldcore/converters/autotest/test_table2glm.glm
@@ -1,0 +1,24 @@
+module assert;
+
+clock 
+{
+	starttime "2019-01-01 00:00:00";
+	stoptime "2020-01-01 00:00:00";
+}
+
+module powerflow;
+module climate;
+
+#input "../table2glm_input.csv" -f "table" -t "object"
+
+object assert {
+	parent "weather";
+	target "wind_speed";
+	value 4 m/s;
+}
+
+object assert {
+	parent "weather";
+	target "temperature";
+	value 95 degF;
+}

--- a/gldcore/converters/autotest/test_table2glm_err.glm
+++ b/gldcore/converters/autotest/test_table2glm_err.glm
@@ -1,0 +1,24 @@
+module assert;
+
+clock 
+{
+	starttime "2019-01-01 00:00:00";
+	stoptime "2020-01-01 00:00:00";
+}
+
+module powerflow;
+module climate;
+
+#input "../table2glm_input_noclass.csv" -f "table" -t "object"
+
+object assert {
+	parent "weather";
+	target "wind_speed";
+	value 4 m/s;
+}
+
+object assert {
+	parent "weather";
+	target "temperature";
+	value 95 degF;
+}

--- a/gldcore/converters/autotest/test_table2glm_noclass.glm
+++ b/gldcore/converters/autotest/test_table2glm_noclass.glm
@@ -1,0 +1,24 @@
+module assert;
+
+clock 
+{
+	starttime "2019-01-01 00:00:00";
+	stoptime "2020-01-01 00:00:00";
+}
+
+module powerflow;
+module climate;
+
+#input "../table2glm_input_noclass.csv" -f "table" -t "object" -C "climate"
+
+object assert {
+	parent "weather";
+	target "wind_speed";
+	value 4 m/s;
+}
+
+object assert {
+	parent "weather";
+	target "temperature";
+	value 95 degF;
+}

--- a/gldcore/converters/autotest/test_table2glm_noname.glm
+++ b/gldcore/converters/autotest/test_table2glm_noname.glm
@@ -1,0 +1,24 @@
+module assert;
+
+clock 
+{
+	starttime "2019-01-01 00:00:00";
+	stoptime "2020-01-01 00:00:00";
+}
+
+module powerflow;
+module climate;
+
+#input "../table2glm_input_noname.csv" -f "table" -t "object"
+
+object assert {
+	parent "climate_1";
+	target "wind_speed";
+	value 4 m/s;
+}
+
+object assert {
+	parent "climate_1";
+	target "temperature";
+	value 95 degF;
+}

--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -14,16 +14,22 @@ def convert (p_configuration_in, p_configuration_out, options={} ) :
 				headers = row
 			else : 
 				if not row[0] : 
+					print(options)
 					p_config_out.write(f"object {options['class']} ")
+					class_name = options['class']
 				if row[0] : 
 					p_config_out.write(f"object {row[0]} ")
+					class_name = row[0]
 				p_config_out.write("{ \n")
 				for j,value in enumerate (row) : 
 					if j>0 : 
-						if value : 
-							if re.findall('^\d+',value) or value.startswith('(') or ' ' in value: 
-								p_config_out.write("\t" + headers[j].strip() + " " + value + ";\n")
-							else : 
-								p_config_out.write("\t" + headers[j].strip() + " " + "\"" +value + "\"" + ";\n")
+						if not value and headers[j].strip()=="name" : 
+							p_config_out.write("\t" + headers[j].strip() + " " + class_name +"_" + str(i) + ";\n")
+						else : 
+							if value : 
+								if re.findall('^\d+',value) or value.startswith('(') or ' ' in value: 
+									p_config_out.write("\t" + headers[j].strip() + " " + value + ";\n")
+								else : 
+									p_config_out.write("\t" + headers[j].strip() + " " + "\"" +value + "\"" + ";\n")
 				p_config_out.write("}\n")
 		p_config_out.close()

--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -2,6 +2,11 @@
 """
 import csv
 import re
+import sys, getopt
+
+def error(msg):
+    print(f'ERROR   {msg}')
+    sys.exit(1)
 
 def convert (p_configuration_in, p_configuration_out, options={} ) : 
 	with open(p_configuration_in, newline='') as csvfile:
@@ -13,8 +18,9 @@ def convert (p_configuration_in, p_configuration_out, options={} ) :
 			if i == 0 : 
 				headers = row
 			else : 
+				if not row[0] and not options : 
+					error("No class name found, please edit your CSV to include class or add -C <class name> to your input command")
 				if not row[0] : 
-					print(options)
 					p_config_out.write(f"object {options['class']} ")
 					class_name = options['class']
 				if row[0] : 

--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -1,0 +1,25 @@
+"""Convert Anticipation data sheet in CSV to an pole vulnerability GLM template parameter set
+"""
+# TODO: Strings only should be in ""
+import csv
+
+def pole_configuration_converter (p_configuration_in, p_configuration_out, options={} ) : 
+	with open(p_configuration_in, newline='') as csvfile:
+		configurations = csv.reader(csvfile, delimiter=',')
+		p_config_out = open(p_configuration_out, "a")
+		p_config_out.truncate(0)
+		p_config_out.write("// Objects \n")		
+		for i, row in enumerate(configurations):
+			if i == 0 : 
+				headers = row
+			else : 
+				if not row[0] : 
+					p_config_out.write(f"object {options['class']} ")
+				p_config_out.write("{ \n")
+				for j,value in enumerate (row) : 
+					if value : 
+						p_config_out.write("\t" + headers[j] + " " + value + ";\n")
+				p_config_out.write("}\n")
+		p_config_out.close()
+
+

--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -1,9 +1,9 @@
 """Convert Anticipation data sheet in CSV to an pole vulnerability GLM template parameter set
 """
-# TODO: Strings only should be in ""
 import csv
+import re
 
-def pole_configuration_converter (p_configuration_in, p_configuration_out, options={} ) : 
+def convert (p_configuration_in, p_configuration_out, options={} ) : 
 	with open(p_configuration_in, newline='') as csvfile:
 		configurations = csv.reader(csvfile, delimiter=',')
 		p_config_out = open(p_configuration_out, "a")
@@ -15,11 +15,15 @@ def pole_configuration_converter (p_configuration_in, p_configuration_out, optio
 			else : 
 				if not row[0] : 
 					p_config_out.write(f"object {options['class']} ")
+				if row[0] : 
+					p_config_out.write(f"object {row[0]} ")
 				p_config_out.write("{ \n")
 				for j,value in enumerate (row) : 
-					if value : 
-						p_config_out.write("\t" + headers[j] + " " + value + ";\n")
+					if j>0 : 
+						if value : 
+							if re.findall('^\d+',value) or value.startswith('(') or ' ' in value: 
+								p_config_out.write("\t" + headers[j].strip() + " " + value + ";\n")
+							else : 
+								p_config_out.write("\t" + headers[j].strip() + " " + "\"" +value + "\"" + ";\n")
 				p_config_out.write("}\n")
 		p_config_out.close()
-
-

--- a/gldcore/converters/csv2glm.py
+++ b/gldcore/converters/csv2glm.py
@@ -50,11 +50,11 @@ for opt, arg in opts:
     elif opt in ("-o", "--ofile"):
         output_file = arg.strip()
     elif opt in ("-f","--from"):
-        input_type = arg.strip();
+        input_type = arg.strip()
     elif opt in ("-t","--type"):
-        output_type = arg.strip();
+        output_type = arg.strip()
     elif opt in ("-C","--class"):
-        options["class"] = arg
+        options["class"] = arg.strip()
     else:
         error(f"{opt}={arg} is not a valid option");
 

--- a/gldcore/converters/csv2glm.py
+++ b/gldcore/converters/csv2glm.py
@@ -8,8 +8,8 @@ from importlib import util
 config = {
     "input" : "csv",
     "output" : "glm",
-    "from" : ["ami","scada","onpoint-weather"],
-    "type" : ["ceus","rbsa","climate"],
+    "from" : ["ami","scada","onpoint-weather", "table"],
+    "type" : ["ceus","rbsa","climate", "object"],
     }
 
 def help():
@@ -20,7 +20,7 @@ def help():
     print(f'  -o|--ofile     : [REQUIRED] {config["output"]} output file name')
     print(f'  -f|--from      : [REQUIRED] input {config["input"]} data type')
     print(f'  -t|--type      : [REQUIRED] output {config["output"]} data type')
-    print(f'  -p|--property  : [OPTIONAL] property option')
+    print(f'  -C|--class     : [OPTIONAL] optional specification for class definition in the table converter')
 
 def error(msg):
     print(f'ERROR    [{config["input"]}2{config["output"]}]: {msg}')
@@ -32,7 +32,7 @@ output_file = None
 output_type = None
 options = {}
 
-opts, args = getopt.getopt(sys.argv[1:],"hci:o:f:t:p:",["help","config","ifile=","ofile=","from=","type=","property="])
+opts, args = getopt.getopt(sys.argv[1:],"hci:o:f:t:C:",["help","config","ifile=","ofile=","from=","type=","class="])
 
 if not opts : 
     help()
@@ -53,9 +53,8 @@ for opt, arg in opts:
         input_type = arg.strip();
     elif opt in ("-t","--type"):
         output_type = arg.strip();
-    elif opt in ("-p","--property"):
-        prop = arg.split("=")
-        options[prop[0]] = prop[1]
+    elif opt in ("-C","--class"):
+        options["class"] = arg
     else:
         error(f"{opt}={arg} is not a valid option");
 

--- a/gldcore/converters/csv2glm.py
+++ b/gldcore/converters/csv2glm.py
@@ -20,6 +20,7 @@ def help():
     print(f'  -o|--ofile     : [REQUIRED] {config["output"]} output file name')
     print(f'  -f|--from      : [REQUIRED] input {config["input"]} data type')
     print(f'  -t|--type      : [REQUIRED] output {config["output"]} data type')
+    print(f'  -p|--property  : [OPTIONAL] property option')
     print(f'  -C|--class     : [OPTIONAL] optional specification for class definition in the table converter')
 
 def error(msg):
@@ -32,7 +33,7 @@ output_file = None
 output_type = None
 options = {}
 
-opts, args = getopt.getopt(sys.argv[1:],"hci:o:f:t:C:",["help","config","ifile=","ofile=","from=","type=","class="])
+opts, args = getopt.getopt(sys.argv[1:],"hci:o:f:t:p:C:",["help","config","ifile=","ofile=","from=","type=","property=","class="])
 
 if not opts : 
     help()
@@ -53,6 +54,9 @@ for opt, arg in opts:
         input_type = arg.strip()
     elif opt in ("-t","--type"):
         output_type = arg.strip()
+    elif opt in ("-p","--property"):
+        prop = arg.split("=")
+        options[prop[0]] = prop[1]
     elif opt in ("-C","--class"):
         options["class"] = arg.strip()
     else:


### PR DESCRIPTION
This PR allows to define a CSV with objects to be converted to GLM format.

## Current issues
N/A

## Code changes
- [x] gldcore/converters/Makefile.mk
- [x] gldcore/converters/csv-table2glm-object.py
- [x] gldcore/converters/csv2glm.py

## Documentation changes
- [x] [Converters/Table_data](https://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-polecsv2glm&folder=/Converters/Import&doc=/Converters/Import/Table_data.md)

## Test and Validation Notes
Try commands 
~~~
#input "pole_library_config.csv" -f "table" -t "object" 
#input "pole_vulnerability_config.csv" -f "table" -t "object" -C powerflow.pole
~~~
files for testing attached by running `gridlabd model.glm anticipation.glm`. 

[Archive.zip](https://github.com/slacgismo/gridlabd/files/6518579/Archive.zip)
