### PR TITLE
Add Big Sur setup

### DIFF
--- a/build-aux/setup-Darwin-20.sh
+++ b/build-aux/setup-Darwin-20.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
+brew update || ruby -e "$(curl -fsSL https://raw.githubusercontent.com/HomeBrew/install/master/install)"
+brew doctor
+
+# build tools
+brew install autoconf automake libtool gnu-sed gawk
+[ ! -L /usr/local/bin/sed -o ! "$(readlink /usr/local/bin/sed)" == "/usr/local/bin/gsed" ] && mv /usr/local/bin/sed /usr/local/bin/sed-old
+[ ! -e /usr/local/bin/sed ] && ln -s /usr/local/bin/gsed /usr/local/bin/sed
+[ ! -e /usr/local/bin/libtoolize ] && ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
+
+# install python3
+brew install python3
+
+# docs generators
+brew install mono
+brew install naturaldocs
+ln -s /usr/local/bin/naturaldocs /usr/local/bin/natural_docs
+brew install doxygen
+
+# influxdb
+brew install influxdb
+brew services start influxdb
+
+# subversion cli
+brew install svn

--- a/gldcore/autotest/test_python_property.glm
+++ b/gldcore/autotest/test_python_property.glm
@@ -1,6 +1,8 @@
 
 #ifexist ../test_python_property.py
-#system cp ../test_python_property.py .
+#set pythonpath=..
+#else
+#set pythonpath=.
 #endif
 
 clock {


### PR DESCRIPTION
This PR add support for `install.sh` on Big Sur.

## Current issues

None

## Code changes

- [x] Copy `build-aux/setup-Darwin-19.sh` to `build-aux/setup-Darwin-20.sh`

## Documentation changes

None

## Test and Validation Notes

- [x] Fix `gldcore/autotest/test_python_property.glm`.