### PR TITLE
Update sublime package to support new update

### DIFF
--- a/utilities/sublime/gridlabd.sublime-syntax
+++ b/utilities/sublime/gridlabd.sublime-syntax
@@ -29,7 +29,7 @@ contexts:
       scope: keyword.directive.glm
 
   names:
-    - match: '\b[A-Za-z_]+[A-Za-z_-:.]\b'
+    - match: '\b[A-Za-z_]+[-A-Za-z_:.]\b'
       scope: constant.name.glm
 
   numbers:


### PR DESCRIPTION
This PR fixes issue with Sublime's latest update unable to parse package for colored syntax.

## Current issues
None

## Code changes
- [x] sublime/gridlabd.sublime-syntax

## Documentation changes
None

## Test and Validation Notes
Install gridlabd package in new Sublime Build 4107
