### PR TITLE
Update gridlabd.h

### DIFF
--- a/gldcore/gridlabd.h
+++ b/gldcore/gridlabd.h
@@ -2957,7 +2957,7 @@ public:
 	inline void error(const char *msg, ...) { if ( !(my()->flags&OF_QUIET) ) { char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_error("%s",buf);}}
 
 	// Method: warning
-	inline void warning(const char *msg, ...) { if ( my()->flags&OF_WARNING ) { char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_warning("%s",buf);}}
+	inline void warning(const char *msg, ...) { if ( !(my()->flags&OF_WARNING) ) { char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_warning("%s",buf);}}
 
 	// Method: verbose
 	inline void verbose(const char *msg, ...) { if ( my()->flags&OF_VERBOSE ) { char buf[1024]; va_list ptr; va_start(ptr,msg); vsprintf(buf+sprintf(buf,"%s: ",get_name()),msg,ptr); va_end(ptr); gl_verbose("%s",buf);}}


### PR DESCRIPTION
This PR fixes the last change to gridlabd.h

The warning flag sense was inverted. As a result warning messages from modules are suppressed when they are asserted and vice-versa.

## Current issues

None

## Code changes
- [x] Change `gldcore/gridlabd.h`

## Documentation changes

None

## Test and Validation Notes

None
