### PR TITLE
Fix deferred name resolution

### DIFF
--- a/gldcore/autotest/deferred1.glm
+++ b/gldcore/autotest/deferred1.glm
@@ -1,0 +1,10 @@
+class test
+{
+	double x;
+}
+
+object test
+{
+	name test1;
+	parent test2;
+}

--- a/gldcore/autotest/deferred2.glm
+++ b/gldcore/autotest/deferred2.glm
@@ -1,0 +1,4 @@
+object test
+{
+	name test2;
+}

--- a/gldcore/autotest/test_deferred_name_resolution.glm
+++ b/gldcore/autotest/test_deferred_name_resolution.glm
@@ -1,0 +1,5 @@
+#ifexist ../deferred1.glm
+#define DIR=..
+#endif
+
+#gridlabd ${DIR:-.}/deferred1.glm ${DIR:-.}/deferred2.glm 

--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -793,7 +793,7 @@ GldLoader::UNRESOLVED *GldLoader::add_unresolved(OBJECT *by, PROPERTYTYPE ptype,
 	return item;
 }
 
-int GldLoader::resolve_object(UNRESOLVED *item, const char *filename)
+int GldLoader::resolve_object(UNRESOLVED *item, const char *filename, bool deferred)
 {
 	OBJECT *obj;
 	char classname[65];
@@ -873,6 +873,7 @@ int GldLoader::resolve_object(UNRESOLVED *item, const char *filename)
 		}
 		if ( obj == NULL )
 		{
+			if ( deferred ) return SUCCESS;
 			syntax_error(filename,item->line,"cannot resolve explicit reference from %s to %s",
 				format_object(item->by).c_str(), item->id);
 			return FAILED;
@@ -890,6 +891,7 @@ int GldLoader::resolve_object(UNRESOLVED *item, const char *filename)
 		obj = get_next_unlinked(oclass);
 		if ( obj == NULL )
 		{
+			if ( deferred ) return SUCCESS;
 			syntax_error(filename,item->line,"cannot resolve last reference from %s to %s",
 				format_object(item->by).c_str(), item->id);
 			return FAILED;
@@ -901,6 +903,7 @@ int GldLoader::resolve_object(UNRESOLVED *item, const char *filename)
 	}
 	else
 	{
+		if ( deferred ) return SUCCESS;
 		syntax_error(filename,item->line,"'%s' not found", item->id);
 		return FAILED;
 	}
@@ -912,7 +915,7 @@ int GldLoader::resolve_object(UNRESOLVED *item, const char *filename)
 	return SUCCESS;
 }
 
-int GldLoader::resolve_double(UNRESOLVED *item, const char *context)
+int GldLoader::resolve_double(UNRESOLVED *item, const char *context, bool deferred)
 {
 	char oname[65];
 	char pname[65];
@@ -956,6 +959,7 @@ int GldLoader::resolve_double(UNRESOLVED *item, const char *context)
 			}
 			if ( ref == NULL )
 			{
+				if ( deferred ) return SUCCESS;
 				syntax_error(filename,item->line,"transform reference not found");
 				return FAILED;
 			}
@@ -995,7 +999,7 @@ int GldLoader::resolve_double(UNRESOLVED *item, const char *context)
 	return FAILED;
 }
 
-STATUS GldLoader::resolve_list(UNRESOLVED *item)
+STATUS GldLoader::resolve_list(UNRESOLVED *item, bool deferred)
 {
 	UNRESOLVED *next;
 	const char *filename = NULL;
@@ -1017,14 +1021,14 @@ STATUS GldLoader::resolve_list(UNRESOLVED *item)
 		// handle different reference types
 		switch (item->ptype) {
 		case PT_object:
-			if (resolve_object(item, filename)==FAILED)
+			if (resolve_object(item, filename, deferred)==FAILED)
 				return FAILED;
 			break;
 		case PT_double:
 		case PT_complex:
 		case PT_loadshape:
 		case PT_enduse:
-			if (resolve_double(item, filename)==FAILED)
+			if (resolve_double(item, filename, deferred)==FAILED)
 				return FAILED;
 			break;
 		default:
@@ -1040,9 +1044,9 @@ STATUS GldLoader::resolve_list(UNRESOLVED *item)
 	return SUCCESS;
 }
 
-STATUS GldLoader::load_resolve_all(void)
+STATUS GldLoader::load_resolve_all(bool deferred)
 {
-	STATUS result = resolve_list(first_unresolved);
+	STATUS result = resolve_list(first_unresolved,deferred);
 	first_unresolved = NULL;
 	return result;
 }
@@ -8144,7 +8148,7 @@ STATUS GldLoader::loadall_glm(const char *fname) /**< a pointer to the first cha
 			output_error("%s doesn't appear to be a GLM file", file);
 		goto Failed;
 	}
-	else if ((status=load_resolve_all())==FAILED)
+	else if ((status=load_resolve_all(true))==FAILED)
 		goto Failed;
 
 	/* establish ranks */

--- a/gldcore/load.h
+++ b/gldcore/load.h
@@ -235,10 +235,12 @@ private:
 	OBJECT *get_next_unlinked(CLASS *oclass);
 	void free_index(void);	
 	UNRESOLVED *add_unresolved(OBJECT *by, PROPERTYTYPE ptype, void *ref, CLASS *oclass, char *id, char *file, unsigned int line, int flags);
-	int resolve_object(UNRESOLVED *item, const char *filename);
-	int resolve_double(UNRESOLVED *item, const char *context);
-	STATUS resolve_list(UNRESOLVED *item);
-	STATUS load_resolve_all(void);
+	int resolve_object(UNRESOLVED *item, const char *filename, bool deferred);
+	int resolve_double(UNRESOLVED *item, const char *context, bool deferred);
+	STATUS resolve_list(UNRESOLVED *item, bool deferred);
+public:
+	STATUS load_resolve_all(bool deferred=false);
+private:
 	void start_parse(int &mm, int &m, int &n, int &l, int linenum);
 	void syntax_error_here(const char *p);
 	int white(PARSER);

--- a/gldcore/main.cpp
+++ b/gldcore/main.cpp
@@ -140,11 +140,22 @@ GldMain::GldMain(int argc, const char *argv[])
 	IN_MYCONTEXT output_verbose("using %d helper thread(s)", global_threadcount);
 
 	/* process command line arguments */
-	if (cmdarg.load(argc,argv)==FAILED)
+	if ( cmdarg.load(argc,argv) == FAILED )
 	{
 		output_fatal("shutdown after command line rejected");
 		/*	TROUBLESHOOT
 			The command line is not valid and the system did not
+			complete its startup procedure.  Correct the problem
+			with the command line and try again.
+		 */
+		exec.mls_done();
+		return;
+	}
+	if ( loader.load_resolve_all() == FAILED )
+	{
+		output_fatal("shutdown after command loader name resolution failed");
+		/*	TROUBLESHOOT
+			The loaded files are not valid and the system did not
 			complete its startup procedure.  Correct the problem
 			with the command line and try again.
 		 */


### PR DESCRIPTION
This PR fixes issue #946 

## Current issues

None

## Code changes

- [x] Add support for deferred object resolution in `gldcore/load.{h,cpp}`
- [x] Add call to resolve deferred object names in `gldcore/main.cpp` 

## Documentation changes

None

## Test and Validation Notes

- [x] Add `gldcore/autotest/test_deferred_names.glm` and supporting files `gldcore/autotest/deferred[12].glm`
