### PR TITLE
Fix geodata address autotest due to change in response from provider

### DIFF
--- a/gldcore/scripts/autotest/test_geodata_address.glm
+++ b/gldcore/scripts/autotest/test_geodata_address.glm
@@ -8,7 +8,7 @@
 
 #setenv REQ=37.4155,-122.2012
 #define RES=${SHELL gridlabd geodata merge -D address "$REQ" -f RAW:address}
-#define ANS=Stanford Linear Accelerator Center National Accelerator Laboratory, Sand Hill Road, Menlo Park, San Mateo County, California, 94028, United States
+#define ANS=54 - Stanford Research Computing Facility, 2575, Sand Hill Road, Stanford Hills, Menlo Park, San Mateo County, California, 94305, United States
 #if ${RES} != ${ANS}
     #error "geodata -D address location ${REQ}" is incorrect: expected ${ANS} but got ${RES} instead
 #endif


### PR DESCRIPTION
This PR fixes failed autotests.

## Current issues

None

## Code changes

None

## Documentation changes

None

## Test and Validation Notes

- [x] Change expected response for `gldcore/scripts/autotest/test_geodata_address.glm`
