### PR TITLE
Fix forloop nesting error

### DIFF
--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -6559,9 +6559,9 @@ const char *GldLoader::for_replay(void)
 	{
 		output_verbose("forloop in var '%s' replay complete", forvar, forloop);
 		if ( forloop ) free(forloop);
-		lastfor = NULL;
+		lastfor = forloop = NULL;
 		if ( forvar ) free(forvar);
-		forvalue = NULL;
+		forvalue = forvar = NULL;
 		forbuffer.clear();
 		forbufferline = forbuffer.end();
 		for_set_state(FOR_NONE);


### PR DESCRIPTION
This PR fixes forloop nesting error messages.

## Current issues

None

## Code changes

- [x] Fix for loop replay end in `gldcore/load.cpp`

## Documentation changes

None

## Test and Validation Notes

None
