### PR TITLE
Add config info to mdb2glm converter

### DIFF
--- a/gldcore/converters/mdb2glm.py
+++ b/gldcore/converters/mdb2glm.py
@@ -5,9 +5,17 @@ from datetime import datetime
 import importlib, copy
 from importlib import util
 
+config = {
+    "input" : "mdb",
+    "output" : "glm",
+    "type" : ["cyme"],
+    "options" : {},
+}
+
 def help():
     print('Syntax:')
     print('mdb2glm.py -i|--ifile <input-file> -o|--ofile <output-file> -t|--type <input-type>')
+    print('  -c|--config    : [OPTIONAL] print converter configuration')
     print('  -i|--ifile     : [REQUIRED] mdb input file name.')
     print('  -o|--ofile     : [REQUIRED] glm output file name.')
     print('  -t|--type      : [REQUIRED] specify input type')
@@ -20,7 +28,7 @@ input_type = None
 options = []
 
 try : 
-    opts, args = getopt.getopt(sys.argv[1:],"hi:o:t:",["help","ifile=","ofile=","type="])
+    opts, args = getopt.getopt(sys.argv[1:],"hi:o:t:c",["help","ifile=","ofile=","type=","config"])
 except getopt.GetoptError:
     print("ERROR    [mdb2glm.py]: command line options not valid")
     sys.exit(2)
@@ -31,6 +39,9 @@ if not opts :
 for opt, arg in opts:
     if opt in ("-h","--help"):
         help()
+        sys.exit(0)
+    elif opt in ("-c","--config"):
+        print(json.dumps(config))
         sys.exit(0)
     elif opt in ("-i", "--ifile"):
         input_name = arg.strip()


### PR DESCRIPTION
This PR fixes issue with missing config info in `mdb2glm` converter

## Current issues

None

## Code changes

- [x] Add `config` info to `gldcore/converters/mdb2glm.py`

## Documentation changes

None

## Test and Validation Notes

1. The command `python3 /usr/local/opt/gridlabd/current/share/gridlabd/mdb2glm.py -c` now returns the correct information.