### PR TITLE
Generalizing class location for table converter

### DIFF
--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -18,22 +18,25 @@ def convert (p_configuration_in, p_configuration_out, options={} ) :
 			if i == 0 : 
 				headers = row
 			else : 
-				if not row[0] and not options : 
+				if "class" not in headers and not options: 
 					error("No class name found, please edit your CSV to include class or add -C <class name> to your input command")
-				if not row[0] : 
+				else : 
+					class_index=headers.index("class")
+
+				if not row[class_index] : 
 					p_config_out.write(f"object {options['class']} ")
 					class_name = options['class']
-				if row[0] : 
-					p_config_out.write(f"object {row[0]} ")
-					class_name = row[0]
+				if row[class_index] : 
+					p_config_out.write(f"object {row[class_index]} ")
+					class_name = row[class_index]
 				p_config_out.write("{ \n")
 				for j,value in enumerate (row) : 
-					if j>0 : 
+					if j!=class_index and headers[j] : 
 						if not value and headers[j].strip()=="name" : 
 							p_config_out.write("\t" + headers[j].strip() + " " + class_name +"_" + str(i) + ";\n")
 						else : 
 							if value : 
-								if re.findall('^\d+',value) or value.startswith('(') or ' ' in value: 
+								if re.findall('^\d+',value) or value.startswith('(') or '([0-9]*\ [*a-zA-Z+]*){0,1}?' in value and ',' not in value: 
 									p_config_out.write("\t" + headers[j].strip() + " " + value + ";\n")
 								else : 
 									p_config_out.write("\t" + headers[j].strip() + " " + "\"" +value + "\"" + ";\n")


### PR DESCRIPTION
This PR fixes issue of `class` having to be in the first column in table2csv converter.

## Current issues
N/A

## Code changes
- [x] gldcore/converters/csv-table2glm-object.py 

## Documentation changes
- [x] N/A

## Test and Validation Notes
Convert table2csv with class being in first column and last column
