### PR TITLE
Adding missing module definition to table2csv converter

### DIFF
--- a/docs/Converters/Import/Table_data.md
+++ b/docs/Converters/Import/Table_data.md
@@ -10,8 +10,8 @@ Any arbitrary objects can be listed in a CSV file and convertered to GLM-formatt
 
 class | name | tilt_angle | tilt_direction | weather | configuration | equipment_area | equipment_height | install_year	| repair_time | latitude | longitude | phases | nominal_voltage | tmyfile
 --- | --- | --- | --- |--- |--- |--- |--- |--- |--- |--- |--- |--- |--- |---
-pole | pole1 | 5 deg | 270	| weather | WOOD-C-45/5 | | | 1990 | 1 h | 37.4275 | 122.1697 | ABC | 12470
-pole | pole2 | 8 deg | 270	| weather | WOOD-C-45/5 | | | 2000 | 8 h | 37.127 | 122.1646 | ABC | 12470
+powerflow.pole | pole1 | 5 deg | 270	| weather | WOOD-C-45/5 | | | 1990 | 1 h | 37.4275 | 122.1697 | ABC | 12470
+powerflow.pole | pole2 | 8 deg | 270	| weather | WOOD-C-45/5 | | | 2000 | 8 h | 37.127 | 122.1646 | ABC | 12470
 climate | weather | | 	|  |  | | |  |  |  |  |  | | CA-Chino_Airport.tmy3
 
 Sample usage within GLM
@@ -29,6 +29,12 @@ The function will overwrite the `class` specification if the class is already sp
 The object names can be omitted and the function will autopopulate the object in the format as `<class_name>_<row_number>`
 
 This will generate an "input_file.glm" and automatically include the objects within the model. 
+
+Note, for the module definition to be included in the converter output, the class definition has to contain the module name before the class as 
+~~~
+powerflow.pole
+~~~
+
 
 # See also
 

--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -22,15 +22,14 @@ def convert (p_configuration_in, p_configuration_out, options={} ) :
 					error("No class name found, please edit your CSV to include class or add -C <class name> to your input command")
 				else : 
 					class_index=headers.index("class")
+				if not row[class_index] : 
+					class_name = options['class']
+				if row[class_index] : 
+					class_name = row[class_index]
 				if "." in class_name:
 					class_spec = class_name.split(".")
 					p_config_out.write(f"module {class_spec[0]};\n")
-				if not row[class_index] : 
-					p_config_out.write(f"object {options['class']} ")
-					class_name = options['class']
-				if row[class_index] : 
-					p_config_out.write(f"object {row[class_index]} ")
-					class_name = row[class_index]
+				p_config_out.write(f"object {class_name} ")
 				p_config_out.write("{ \n")
 				for j,value in enumerate (row) : 
 					if j!=class_index and headers[j] : 

--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -22,7 +22,9 @@ def convert (p_configuration_in, p_configuration_out, options={} ) :
 					error("No class name found, please edit your CSV to include class or add -C <class name> to your input command")
 				else : 
 					class_index=headers.index("class")
-
+				if "." in class_name:
+					class_spec = class_name.split(".")
+					p_config_out.write(f"module {class_spec[0]};\n")
 				if not row[class_index] : 
 					p_config_out.write(f"object {options['class']} ")
 					class_name = options['class']

--- a/gldcore/converters/csv-table2glm-object.py
+++ b/gldcore/converters/csv-table2glm-object.py
@@ -13,7 +13,8 @@ def convert (p_configuration_in, p_configuration_out, options={} ) :
 		configurations = csv.reader(csvfile, delimiter=',')
 		p_config_out = open(p_configuration_out, "a")
 		p_config_out.truncate(0)
-		p_config_out.write("// Objects \n")		
+		p_config_out.write("// Objects \n")
+		module_list = []		
 		for i, row in enumerate(configurations):
 			if i == 0 : 
 				headers = row
@@ -26,9 +27,11 @@ def convert (p_configuration_in, p_configuration_out, options={} ) :
 					class_name = options['class']
 				if row[class_index] : 
 					class_name = row[class_index]
-				if "." in class_name:
-					class_spec = class_name.split(".")
-					p_config_out.write(f"module {class_spec[0]};\n")
+				if "." in class_name :
+					class_spec = class_name.split(".")[0]
+					if class_spec not in module_list: 
+						p_config_out.write(f"module {class_spec};\n")
+						module_list.append(class_spec)
 				p_config_out.write(f"object {class_name} ")
 				p_config_out.write("{ \n")
 				for j,value in enumerate (row) : 


### PR DESCRIPTION
This PR fixes issue of missing module definition generated when running table2csv converter

## Current issues
None

## Code changes
- [x] gldcore/converters/csv-table2glm-object.py

## Documentation changes
- [x] [converters/Import/Table_data.md](https://docs.gridlabd.us/_page.html?owner=slacgismo&project=gridlabd&branch=develop-addmoduletable2csv&folder=/Converters/Import&doc=/Converters/Import/Table_data.md)

## Test and Validation Notes
None
