### PR TITLE
Update load.cpp

### DIFF
--- a/gldcore/load.cpp
+++ b/gldcore/load.cpp
@@ -8029,7 +8029,7 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 	{
 		int xc;
 		char cmd[1024];
-		if ( sscanf(line+8,"%d %1023[^\n]",&xc,cmd) < 2 )
+		if ( sscanf(line+8,"%d %1023[^\r\n]",&xc,cmd) < 2 )
 		{
 			syntax_error(filename,linenum,"#on_exit syntax error");
 			return FALSE;


### PR DESCRIPTION
This PR fixes issue #984.

## Current issues

None

## Code changes

- [x] Fix sscanf pattern to include `\r`.

## Documentation changes

None

## Test and Validation Notes

The command

~~~
#on_exit 0 echo ok
~~~

should work ok when it is not the last line in an unterminated DOS-format file (i.e., CRLF) rather than a Unix-format file (LF).