### PR TITLE
Update gridlabd-plot

### DIFF
--- a/gldcore/scripts/gridlabd-plot
+++ b/gldcore/scripts/gridlabd-plot
@@ -75,7 +75,7 @@ def main(args):
     E_NODATA = 2
     E_EXCEPTION = 3
 
-    def exception(msg,code=None):
+    def exception(msg=None,code=None):
         """Print exception message
 
         Exception messages are printed only if the configuration parameter `exception` is false.
@@ -311,6 +311,15 @@ def main(args):
         debug("figure_options = "+json.dumps(figure_options,indent=4),level=1)
     try:
         data = pandas.read_csv(config['input_pathname'])
+        if not plot_options["x"]:
+            plot_options["x"] = data.columns[0]
+            plot_options["rot"] = 90
+            plot_options["figsize"] = (10,7)
+            figure_options["tight_layout"] = True
+            figure_options["dpi"] = 200.0
+        if not plot_options["y"]:
+            plot_options["y"] = data.columns[1:].to_list()
+            plot_options["legend"] = True
         plt = data.plot(**plot_options)
         if plt:
             for key, value in figure_options.items():


### PR DESCRIPTION
This PR simplifies default plotting of recording output.

## Current issues

None

## Code changes

- [x] Add default behaviors with _x_ and _y_ data is not specified.

## Documentation changes

None

## Test and Validation Notes

Generally, the command `#on_exit 0 gridlabd plot --input=recorder_output.csv --show` should plot something visually reasonable not matter what.