### PR TITLE
Add json format output for modhelp

### DIFF
--- a/docs/Command/Modhelp.md
+++ b/docs/Command/Modhelp.md
@@ -3,12 +3,12 @@
 # Synopsis
 
 ~~~
-bash$ gridlabd --modhelp module[:class]                                
+bash$ gridlabd --modhelp[=json] module[:class]                                
 ~~~
 
 # Description
 
-Display structure of a class or all classes in a module.
+Display structure of a class or all classes in a module. If the `=json` option is included, the output is generated in JSON format.
 
 The comment section includes whether the property is a required input, optional, dynamic, output, or deprecated.
 

--- a/gldcore/cmdarg.cpp
+++ b/gldcore/cmdarg.cpp
@@ -1066,9 +1066,17 @@ int GldCmdarg::modhelp(int argc, const char *argv[])
 			*/
 			return FAILED;
 		}
-		if ( options && strcmp(options,"md") == 0 )
+		if ( options )
 		{
-			module_help_md(mod,oclass);
+			if ( strcmp(options,"md") == 0 )
+			{
+				module_help_md(mod,oclass);
+			}
+			else if ( strcmp(options,"json") == 0 )
+			{
+				GldJsonWriter writer("/dev/stdout");
+				return writer.dump_modules() > 0 ? 1 : CMDERR;
+			}
 		}
 		else if ( oclass != NULL )
 		{

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -182,7 +182,7 @@ int GldJsonWriter::write_properties(FILE *fp)
 }
 
 
-int GldJsonWriter::write_classes(FILE *fp)
+int GldJsonWriter::write_classes(FILE *fp,bool noattr)
 {
 	int len = 0;
 
@@ -207,22 +207,25 @@ int GldJsonWriter::write_classes(FILE *fp)
 		if ( oclass != class_get_first_class() )
 			len += write(",");
 		len += write("\n\t\t\"%s\" : {",oclass->name);
-		FIRST("object_size","%u",oclass->size);
-		if ( oclass->parent )
+		if ( ! noattr )
 		{
-			TUPLE("parent","%s",oclass->parent->name );
+			FIRST("object_size","%u",oclass->size);
+			if ( oclass->parent )
+			{
+				TUPLE("parent","%s",oclass->parent->name );
+			}
+			TUPLE("trl","%u",oclass->trl);
+			if ( oclass->module )
+			{
+				TUPLE("module","%s",oclass->module->name);
+			}
+			TUPLE("profiler.numobjs","%u",oclass->profiler.numobjs);
+			TUPLE("profiler.clocks","%llu",oclass->profiler.clocks);
+			TUPLE("profiler.count","%u",oclass->profiler.count);
+			if ( oclass->has_runtime ) TUPLE("runtime","%s",oclass->runtime);
+			if ( oclass->pmap != NULL )
+				len += write(",");
 		}
-		TUPLE("trl","%u",oclass->trl);
-		if ( oclass->module )
-		{
-			TUPLE("module","%s",oclass->module->name);
-		}
-		TUPLE("profiler.numobjs","%u",oclass->profiler.numobjs);
-		TUPLE("profiler.clocks","%llu",oclass->profiler.clocks);
-		TUPLE("profiler.count","%u",oclass->profiler.count);
-		if ( oclass->has_runtime ) TUPLE("runtime","%s",oclass->runtime);
-		if ( oclass->pmap != NULL )
-			len += write(",");
 		for ( prop = oclass->pmap ; prop != NULL && prop->oclass == oclass ; prop=prop->next ) // note: do not output parent classes properties
 		{
 			KEYWORD *key;
@@ -724,6 +727,18 @@ int GldJsonWriter::dump()
 	fclose(fp);
 
 	return len > 0;
+}
+
+int GldJsonWriter::dump_modules()
+{
+	int len = 0;
+	json = stdout;
+	len += write("{\t\"application\": \"gridlabd\",\n");
+	len += write("\t\"version\" : \"%u.%u.%u\"",global_version_major,global_version_minor,global_version_patch);
+	len += write_modules(json);
+	len += write_classes(json,true);
+	len += write("\n}\n");
+	return len;
 }
 
 int json_to_glm(const char *jsonfile, char *glmfile)

--- a/gldcore/json.cpp
+++ b/gldcore/json.cpp
@@ -206,7 +206,14 @@ int GldJsonWriter::write_classes(FILE *fp,bool noattr)
 		PROPERTY *prop;
 		if ( oclass != class_get_first_class() )
 			len += write(",");
-		len += write("\n\t\t\"%s\" : {",oclass->name);
+		if ( ! noattr || oclass->module == NULL )
+		{
+			len += write("\n\t\t\"%s\" : {",oclass->name);
+		}
+		else
+		{
+			len += write("\n\t\t\"%s.%s\" : {",oclass->module->name,oclass->name);
+		}
 		if ( ! noattr )
 		{
 			FIRST("object_size","%u",oclass->size);

--- a/gldcore/json.h
+++ b/gldcore/json.h
@@ -33,11 +33,12 @@ public:
 	~GldJsonWriter(void);
 public:
 	int dump();
+	int dump_modules();
 	int write_output(FILE *fp);
 private:
 	int write_modules(FILE *fp);
 	int write_properties(FILE *fp);
-	int write_classes(FILE *fp);
+	int write_classes(FILE *fp,bool noattr=false);
 	int write_globals(FILE *fp);
 	int write_objects(FILE *fp);
 	int write_schedules(FILE *fp);


### PR DESCRIPTION
This PR fixes issue #994.

## Current issues

1. Need to develop and address full list of command options that should output to JSON if required.

## Code changes

- [x] Add JSON format handling to `gldcore/cmdarg.cpp`.
- [x] Add support for limited output of JSON data to `gldcore/json.cpp`

## Documentation changes

- [x] [/Command/Modhelp](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-add-modhelp-json&doc=/Command/Modhelp.md)

## Test and Validation Notes

None