### PR TITLE
Add commercial electrification

### DIFF
--- a/docs/Module/Commercial/CEUS.md
+++ b/docs/Module/Commercial/CEUS.md
@@ -23,7 +23,7 @@
   }
   object ceus {
     filename "<file-name>";
-    floor_area "<real-value> sf>";
+    floor_area "<real-value> sf";
     composition "<enduse>:{<parameter>:<value>;...}";
     weather "<object-name>";
     total_power_A "<complex-value> VA";
@@ -69,7 +69,14 @@ The load composition determines how much power is consumed by each end-use speci
 
 In general the sum the real power fractions should be 1.0 and the sum of the reactive power fractions should be less of 0.1.
 
-The `Area` term of the fraction of the `floor_area` affected by the enduse specified.
+The `Area` term of the fraction of the `floor_area` affected by the enduse specified. The default area fraction is `1.0`. The `Electric` term specifies that fraction of the end-use that is electrified. The default is `1.0`.
+
+In addition, the composition can represent load sensitivities to temperature, price, and occupancy.  The composition parameters are
+* `Th`, `Thb`, `Thc`, `Th0`, `Th1`: the enduse heating mode temperature sensitivity slope, base, intercept, domain min and max, respectively
+* `Tc`, `Tcb`, `Tcc`, `Tc0`, `Tc1`: the enduse cooling mode sensitivity slope, base, intercept, domain min and max, respectively
+* `S`, `Sb`, `Sc`, `S0`, `S1`: the enduse solar gain sensitivity slope, base, intercept, domain min and max, respectively
+* `E`, `Eb`, `Ec`, `E0`, `E1`: the enduse price sensitivity slope, base, intercept, domain min and max, respectively
+* `Oh`, `Ob`, `Oc`, `O0`, `O1`: the enduse occupancy sensitivity slope, base, intercept, domain min and max, respectively
 
 ### `filename`
 

--- a/module/commercial/autotest/test_ceus_gasheat.glm
+++ b/module/commercial/autotest/test_ceus_gasheat.glm
@@ -1,0 +1,75 @@
+// run 1 year simulation
+clock {
+	timezone US/CA/Los Angeles;
+	starttime '2018-01-01 00:00:00 PST';
+	stoptime '2019-01-01 00:00:00 PST';
+}
+
+// generate plots when done
+script on_term "python3 ../test_ceus_saveplots.py";
+
+// make sure csv files have no comments
+module tape {
+	csv_data_only 1;
+}
+
+// power flow
+module powerflow;
+object meter {
+	name main;
+	bustype SWING;
+	nominal_voltage 120.0;
+	phases ABCN;
+	object recorder {
+		file test_ceus_main.csv;
+		property measured_power_A,measured_power_B,measured_power_C,measured_real_power,measured_reactive_power;
+		interval 1h;
+	};
+}
+
+// climate data
+module climate;
+#weather get WA-Yakima_Air_Terminal.tmy3
+object climate {
+	name yakima;
+	tmyfile "WA-Yakima_Air_Terminal.tmy3";
+}
+
+// tariff data
+schedule tou_prices {
+	* 8-17 1-5 * * 0.25;
+	* 18-7 6-0 * * 0.15;
+}
+class tariff {
+	double energy_price[$/MWh];
+}
+object tariff {
+	name tou;
+	energy_price tou_prices;
+}
+
+// commercial buildings
+module commercial;
+object ceus {
+	parent main;
+	name small_office;
+	filename "../FCZ01_SOFF.csv";
+	floor_area 10 ksf;
+	tariff tou;
+	weather yakima;
+	composition "Heating:{ZR:0.9;PR:0.1;PI:0.01;Th:-100;Th0:50;Th1:20;Electric:0}";
+	composition "Cooling:{ZR:0.9;PR:0.1;PI:0.01;Tc:100;Tc0:70;Tc1:100;}";
+	composition "Ventilation:{ZR:0.9;PR:0.1;PI:0.01}";
+	composition "Water_Heating:{ZR:0.9;PR:0.1;PI:0.01;Electric:0}";
+	composition "Refrigeration:{ZR:0.9;PR:0.1;PI:0.01}";
+	composition "Exterior_Lighting:{ZR:0.9;PR:0.1;PI:0.01}";
+	composition "Interior_Lighting:{ZR:0.9;PR:0.1;PI:0.01}";
+	composition "Office_Equipment:{ZR:0.9;PR:0.1;PI:0.01}";
+	composition "Miscellaneous:{ZR:0.9;PR:0.1;PI:0.01}";
+	composition "Motors:{ZR:0.9;PR:0.1;PI:0.01}";
+	object recorder {
+		file test_ceus_small_office.csv;
+		property total_power_A,total_power_B,total_power_C,total_real_power,total_reactive_power;
+		interval 1h;
+	};
+}

--- a/module/commercial/ceus.cpp
+++ b/module/commercial/ceus.cpp
@@ -207,6 +207,7 @@ ceus::COMPONENT *ceus::add_component(const char *enduse, const char *composition
 	COMPONENT *c = (COMPONENT*)malloc(sizeof(COMPONENT));
 	memset(c,0,sizeof(COMPONENT));
 	c->fraction = 1.0;
+	c->electric = 1.0;
 	c->data = data;
 	char *buffer = strdup(composition);
 	char *item, *last = NULL;
@@ -291,6 +292,7 @@ bool ceus::set_component(COMPONENT *component, const char *term, double value)
 		{"O1", component->occupancy.domain.max},
 
 		{"Area", component->fraction},
+		{"Electric", component->electric},
 	};
 	size_t n;
 	for ( n = 0 ; n < sizeof(map)/sizeof(map[0]) ; n++ )
@@ -539,7 +541,7 @@ TIMESTAMP ceus::sync(TIMESTAMP t1)
 			{
 				continue;
 			}
-			double scalar = load * c->fraction / 3.0 ;
+			double scalar = load * c->fraction / 3.0 * c->electric ;
 			scalar += apply_sensitivity(c->cooling,temperature);
 			scalar += apply_sensitivity(c->heating,temperature);
 			scalar += apply_sensitivity(c->solar,solar);

--- a/module/commercial/ceus.h
+++ b/module/commercial/ceus.h
@@ -96,6 +96,7 @@ public:
 		double Ir, Ii; // constant current factors (real, imaginary)
 		double Pr, Pi; // constant power factors (real, imaginary)
 		double fraction; // fraction of total floor area affected by this component
+		double electric; // fraction of total enduse that is electrified
 		SENSITIVITY heating; // heating temperature sensitivity
 		SENSITIVITY cooling; // cooling temperature sensitivity
 		SENSITIVITY solar; // solar gain sensitivity


### PR DESCRIPTION
This PR fixes issue #1000.

## Current issues

The solution only applies to CEUS (i.e., data driven) commercial building load models.  The physics-based models are not yet fully developed. This requirement will have to added to their specifications before implementation can be completed.

## Code changes

- [x] Add `Electric` load composition parameter to component model in `module/commercial/ceus.cpp`

## Documentation changes

- [x] Update [/Module/Commercial/Ceus](https://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-add-commercial-electrification&folder=/Module/Commercial&doc=/Module/Commercial/CEUS.md)

## Test and Validation Notes

- [x] Add `module/commercial/autotest/test_ceus_gasheat.glm` to show difference from `module/commercial/autotest/test_ceus.glm` small office load.
