### PR TITLE
Update gridlabd-version

### DIFF
--- a/gldcore/scripts/gridlabd-version
+++ b/gldcore/scripts/gridlabd-version
@@ -11,6 +11,11 @@ function error()
 	exit $RC
 }
 
+function warning()
+{
+	echo "WARNING [$EXE] $*" > /dev/stderr
+}
+
 case "$1" in
 --dryrun)
 	ACTION="echo"
@@ -49,8 +54,8 @@ function version-check()
 	branch=$(${BIN} --version=git-branch)
 	remote=$( (curl -sL "https://raw.githubusercontent.com/slacgismo/gridlabd/$branch/gldcore/version.h" | grep '#define REV_' | cut -f3 -d' ' | tr '\n' . | cut -f-3 -d.) || echo "none" )
 	if [ "$remote" == "none" -o -z "$remote" ]; then
-		[ "$1" != "-q" -a "$1" != "-w" ] && error 2 "$version ($branch) remote not found"
-		[ "$1" != "-q" ] && warning "$version ($branch) remote not found"
+		[ "$1" != "-q" -a "$1" != "-w" ] && error 2 "$version ($branch) branch not found on github"
+		[ "$1" != "-q" ] && warning "$version ($branch) branch not found on github"
 		exit 0
 	fi
 	[ "$1" == "-v" ] && echo "REMOTE/$branch $remote"


### PR DESCRIPTION
This PR fixes `command not found` error in `gridlabd-version subcommand`.

## Current issues

None

## Code changes

- [x] Add `warning()` function for `gldcore/scripts/gridlabd-weather` and improve clarity of warning message

## Documentation changes

None

## Test and Validation Notes

None
