### PR TITLE
Update setup-Linux-centos-8.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:8
 RUN yum install git -y
-
+RUN yum install nano -y
 WORKDIR /usr/local/src
 
-RUN git clone -b develop-fix-centos-8-setup https://github.com/catzzz/gridlabd.git
+RUN git clone https://github.com/slacgismo/gridlabd.git
 
 WORKDIR /usr/local/src/gridlabd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:8
+RUN yum install git -y
+
+WORKDIR /usr/local/src
+
+RUN git clone https://github.com/slacgismo/gridlabd
+
+WORKDIR /usr/local/src/gridlabd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM centos:8
-RUN yum install git -y
-RUN yum install nano -y
-WORKDIR /usr/local/src
-
-RUN git clone https://github.com/slacgismo/gridlabd.git
-
-WORKDIR /usr/local/src/gridlabd

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ RUN yum install git -y
 
 WORKDIR /usr/local/src
 
-RUN git clone https://github.com/slacgismo/gridlabd
+RUN git clone -b develop-fix-centos-8-setup https://github.com/catzzz/gridlabd.git
 
 WORKDIR /usr/local/src/gridlabd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,49 @@
 FROM centos:8
 # Install needed system tools
-RUN yum clean all
-RUN yum groupinstall "Development Tools" -y
-RUN yum install cmake -y 
-RUN yum install ncurses-devel -y
-RUN yum install epel-release -y
-RUN yum install curl-devel -y
-RUN yum install which -y
-RUN yum install svn -y
+RUN yum install git -y
+# RUN yum clean all
+# RUN yum groupinstall "Development Tools" -y
+# RUN yum install cmake -y 
+# RUN yum install ncurses-devel -y
+# RUN yum install epel-release -y
+# RUN yum install curl-devel -y
+# RUN yum install which -y
+# RUN yum install svn -y
 
 
 
 
 
-RUN yum install 'dnf-command(config-manager)' -y
+# RUN yum install 'dnf-command(config-manager)' -y
 
-#RUN yum config-manager --set-enabled PowerTools # error
-#RUN yum install armadillo-devel -y #error
+# #RUN yum config-manager --set-enabled PowerTools # error
+# #RUN yum install armadillo-devel -y #error
 
-# change directory
-WORKDIR "/usr/local/src"
-RUN yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel  xz-devel  -y
+# # change directory
+# WORKDIR "/usr/local/src"
+# RUN yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel  xz-devel  -y
 
 # Install python 3.9.6
-RUN curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz > Python-3.9.6.tgz
-RUN tar xzf Python-3.9.6.tgz 
-WORKDIR "/usr/local/src/Python-3.9.6"
-RUN ./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
-RUN make -j 10
-RUN make altinstall
-RUN /sbin/ldconfig /usr/local/lib
-RUN ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
-RUN ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
-RUN ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
-RUN ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
-RUN ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
-RUN pip3 install --upgrade pip
+# RUN curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz > Python-3.9.6.tgz
+# RUN tar xzf Python-3.9.6.tgz 
+# WORKDIR "/usr/local/src/Python-3.9.6"
+# RUN ./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
+# RUN make -j 10
+# RUN make altinstall
+# RUN /sbin/ldconfig /usr/local/lib
+# RUN ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
+# RUN ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
+# RUN ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
+# RUN ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
+# RUN ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
+# RUN pip3 install --upgrade pip
 
-RUN /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd boto3
-RUN /usr/local/bin/python3 -m pip install IPython censusdata
-# mac m1
-# RUN /usr/local/bin/python3 -m pip install shapely 
-WORKDIR /usr/local/src
-RUN rm -f Python-3.9.6.tgz
+# RUN /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd boto3
+# RUN /usr/local/bin/python3 -m pip install IPython censusdata
+# # mac m1
+# # RUN /usr/local/bin/python3 -m pip install shapely 
+# WORKDIR /usr/local/src
+# RUN rm -f Python-3.9.6.tgz
 
 # RUN export PYTHONPATH="."
 # RUN export PATH=/usr/local/bin:$PATH
@@ -72,7 +73,7 @@ RUN chmod +rxw ./build-aux/setup-Linux-centos-8.sh
 COPY ./install.sh ./install.sh
 
 # test install.sh
-RUN ./install.sh -v -t --parallel
+# RUN ./install.sh -v -t --parallel
 
 # WORKDIR "/usr/local/src/gridlabd"
 # RUN autoreconf -isf && ./configure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+
+FROM centos:8
+RUN yum install git -y
+RUN yum install nano -y
+WORKDIR /usr/local/src
+
+#RUN git clone -b develop https://github.com/slacgismo/gridlabd.git
+RUN git clone https://github.com/slacgismo/gridlabd.git
+
+WORKDIR /usr/local/src/gridlabd
+RUN rm -rf ./build-aux/setup-Linux-centos-8.sh
+COPY ./build-aux/setup-Linux-centos-8.sh ./build-aux/setup-Linux-centos-8.sh
+COPY ./requirements.txt ./requirements.txt
+RUN chmod +rxw ./requirements.txt
+RUN chmod +rxw ./build-aux/setup-Linux-centos-8.sh
+# RUN ./install.sh -v -t 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,56 @@
-
 FROM centos:8
-RUN yum install git -y
-RUN yum install nano -y
+# Install needed system tools
+RUN yum clean all
+RUN yum groupinstall "Development Tools" -y
+RUN yum install cmake -y 
+RUN yum install ncurses-devel -y
+RUN yum install epel-release -y
+RUN yum install curl-devel -y
+RUN yum install which -y
+RUN yum install svn -y
+
+
+
+
+
+RUN yum install 'dnf-command(config-manager)' -y
+
+#RUN yum config-manager --set-enabled PowerTools # error
+#RUN yum install armadillo-devel -y #error
+
+# change directory
+WORKDIR "/usr/local/src"
+RUN yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel  xz-devel  -y
+
+# Install python 3.9.6
+RUN curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz > Python-3.9.6.tgz
+RUN tar xzf Python-3.9.6.tgz 
+WORKDIR "/usr/local/src/Python-3.9.6"
+RUN ./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
+RUN make -j 10
+RUN make altinstall
+RUN /sbin/ldconfig /usr/local/lib
+RUN ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
+RUN ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
+RUN ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
+RUN ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
+RUN ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
+RUN pip3 install --upgrade pip
+
+RUN /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd boto3
+RUN /usr/local/bin/python3 -m pip install IPython censusdata
+# mac m1
+RUN /usr/local/bin/python3 -m pip install shapely 
 WORKDIR /usr/local/src
+RUN rm -f Python-3.9.6.tgz
 
-#RUN git clone -b develop https://github.com/slacgismo/gridlabd.git
-RUN git clone https://github.com/slacgismo/gridlabd.git
-
+# RUN export PYTHONPATH="."
+# RUN export PATH=/usr/local/bin:$PATH
+# RUN export MAKEFLAGS=-j20
+# RUN export PYTHONSETUPFLAGS="-j 20"
+# clone gridlabd 
+WORKDIR /usr/local/src
+RUN git clone https://github.com/slacgismo/gridlabd
 WORKDIR /usr/local/src/gridlabd
 RUN rm -rf ./build-aux/setup-Linux-centos-8.sh
 COPY ./build-aux/setup-Linux-centos-8.sh ./build-aux/setup-Linux-centos-8.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN pip3 install --upgrade pip
 RUN /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd boto3
 RUN /usr/local/bin/python3 -m pip install IPython censusdata
 # mac m1
-RUN /usr/local/bin/python3 -m pip install shapely 
+# RUN /usr/local/bin/python3 -m pip install shapely 
 WORKDIR /usr/local/src
 RUN rm -f Python-3.9.6.tgz
 
@@ -55,6 +55,25 @@ WORKDIR /usr/local/src/gridlabd
 RUN rm -rf ./build-aux/setup-Linux-centos-8.sh
 COPY ./build-aux/setup-Linux-centos-8.sh ./build-aux/setup-Linux-centos-8.sh
 COPY ./requirements.txt ./requirements.txt
+COPY ./gldcore/scripts/autotest/test_matrix.glm ./gldcore/scripts/autotest/test_matrix.glm
+RUN   chmod +rxw ./gldcore/scripts/autotest/test_matrix.glm
+COPY ./gldcore/scripts/autotest/test_matrix_linalg.glm ./gldcore/scripts/autotest/test_matrix_linalg.glm
+RUN   chmod +rxw ./gldcore/scripts/autotest/test_matrix_linalg.glm
+COPY ./gldcore/scripts/autotest/test_matrix_matlib.glm ./gldcore/scripts/autotest/test_matrix_matlib.glm
+RUN   chmod +rxw ./gldcore/scripts/autotest/test_matrix_matlib.glm
+COPY ./gldcore/scripts/autotest/test_matrix_matrix.glm ./gldcore/scripts/autotest/test_matrix_matrix.glm
+RUN   chmod +rxw ./gldcore/scripts/autotest/test_matrix_matrix.glm
+COPY ./gldcore/scripts/autotest/test_matrix_random.glm ./gldcore/scripts/autotest/test_matrix_random.glm
+RUN   chmod +rxw ./gldcore/scripts/autotest/test_matrix_random.glm
 RUN chmod +rxw ./requirements.txt
 RUN chmod +rxw ./build-aux/setup-Linux-centos-8.sh
-# RUN ./install.sh -v -t 
+
+
+COPY ./install.sh ./install.sh
+
+# test install.sh
+RUN ./install.sh -v -t --parallel
+
+# WORKDIR "/usr/local/src/gridlabd"
+# RUN autoreconf -isf && ./configure
+# RUN make -j6 system

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -31,6 +31,8 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	/usr/local/bin/python3 pip -m install numpy 
 	/usr/local/bin/python3 pip -m install pandas
 	/usr/local/bin/python3 pip -m install Pillow
+	/usr/local/bin/python3 -m pip install IPython 
+	/usr/local/bin/python3 -m pip install censusdata
 
 
 	# remove tgz

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -37,6 +37,8 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	/usr/local/bin/python3 -m pip install IPython 
 	/usr/local/bin/python3 -m pip install wheel 
 	/usr/local/bin/python3 -m pip install censusdata
+	# update numpy
+	/usr/local/bin/python3 -m pip install --upgrade numpy
 	# remove tgz
 	rm -f /usr/local/src/Python-3.9.6.tgz
 fi

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -25,8 +25,16 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
 	ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
-	/usr/local/bin/python3 pip -m install mysql-connector matplotlib numpy pandas Pillow
-	
+	# install python packages
+	/usr/local/bin/python3 pip -m install mysql-connector 
+	/usr/local/bin/python3 pip -m install matplotlib 
+	/usr/local/bin/python3 pip -m install numpy 
+	/usr/local/bin/python3 pip -m install pandas
+	/usr/local/bin/python3 pip -m install Pillow
+
+
+	# remove tgz
+	rm -f Python-3.9.6.tgz
 fi
 
 # latex

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -12,11 +12,11 @@ yum -q install which -y
 yum -q install svn -y
 
 # python3 support needed as of 4.2
-if [ ! -x /usr/local/bin/python3 -o $(/usr/local/bin/python3 --version) != "Python 3.9.0" ]; then
+if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
 	yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
 	cd /usr/local/src
-	curl https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz | tar xz
-	cd Python-3.9.0
+	curl https://www.python.org/ftp/python/3.9.0/Python-3.9.6.tgz | tar xz
+	cd Python-3.9.6
 	./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
 	make -j $(nproc)
 	make altinstall
@@ -26,6 +26,7 @@ if [ ! -x /usr/local/bin/python3 -o $(/usr/local/bin/python3 --version) != "Pyth
 	ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 	/usr/local/bin/python3 pip -m install mysql-connector matplotlib numpy pandas Pillow
+	
 fi
 
 # latex

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 
 # Install needed system tools
+localectl set-locale LANG=en_US.UTF-8
+nproc=6
+echo "start centos:8 installation, nproc=$nproc"
+# yum -q update -y ; 
+# yum -q clean all
+# yum -q groupinstall "Development Tools" -y
+# yum -q install cmake -y 
+# yum -q install ncurses-devel -y
+# yum -q install epel-release -y
+# yum -q install curl-devel -y
+# yum -q install which -y
+# yum -q install svn -y
 
-yum -q update -y ; 
-yum -q clean all
-yum -q groupinstall "Development Tools" -y
-yum -q install cmake -y 
-yum -q install ncurses-devel -y
-yum -q install epel-release -y
-yum -q install curl-devel -y
-yum -q install which -y
-yum -q install svn -y
-
-# python3 support needed as of 4.2
+# # python3 support needed as of 4.2
 if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
+	echo "install python 3.9.6"	
 	yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
 	cd /usr/local/src
 	curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz | tar xz
@@ -27,6 +30,7 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 	# install python packages
+	/usr/local/bin/python3 -m pip install --upgrade pip
 	/usr/local/bin/python3 pip -m install mysql-connector 
 	/usr/local/bin/python3 pip -m install matplotlib 
 	/usr/local/bin/python3 pip -m install numpy 
@@ -35,44 +39,51 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	/usr/local/bin/python3 -m pip install IPython 
 	/usr/local/bin/python3 -m pip install censusdata
 	# remove tgz
-	rm -f Python-3.9.6.tgz
+	echo "remove python tgz"
+	rm -f /usr/local/src/Python-3.9.6.tgz
 fi
 
 # latex
-if [ ! -x /usr/bin/tex ]; then
-	yum -q install tex -y
-fi
+# if [ ! -x /usr/bin/tex ]; then
+# 	echo "install latex"
+# 	yum -q install tex -y
+# fi
 
-# doxygen
-if [ ! -x /usr/bin/doxygen ]; then
-	if [ ! -d /usr/local/src/doxygen ]; then
-		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
-	fi
-	if [ ! -d /usr/local/src/doxygen/build ]; then
-		mkdir /usr/local/src/doxygen/build
-	fi
-	cd /usr/local/src/doxygen/build
-	cmake -G "Unix Makefiles" ..
-	make
-	make install
-fi
+# # doxygen
+#vaild
+# if [ ! -x /usr/bin/doxygen ]; then
+# 	echo "install doxygen"
+# 	if [ ! -d /usr/local/src/doxygen ]; then
+# 		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
+# 	fi
+# 	if [ ! -d /usr/local/src/doxygen/build ]; then
+# 		mkdir /usr/local/src/doxygen/build
+# 	fi
+	
+# 	cd /usr/local/src/doxygen/build
+# 	cmake -G "Unix Makefiles" ..
+# 	make
+# 	make install
+# fi
 
 # mono
-if [ ! -f /usr/bin/mono ]; then
-	rpmkeys --import "http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x3fa7e0328081bff6a14da29aa6a19b38d3d831ef"
-	curl -s https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo
-	yum -q install mono-devel -y
-fi
+# if [ ! -f /usr/bin/mono ]; then
+# 	echo "install mono"	
+# 	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+# 	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
+# 	yum -q install mono-devel -y
+# fi
 
-# natural_docs
-if [ ! -x /usr/local/bin/natural_docs ]; then
-	cd /usr/local
-	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
-	unzip -qq natural_docs
-	rm -f natural_docs.zip
-	mv Natural\ Docs natural_docs
-	echo '#!/bin/bash
-mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
-	chmod a+x /usr/local/bin/natural_docs
-fi
+# # natural_docs
+# if [ ! -x /usr/local/bin/natural_docs ]; then
+# 	echo "install natural_docs"	
+# 	cd /usr/local
+# 	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
+# 	unzip -qq natural_docs
+# 	rm -f natural_docs.zip
+# 	mv Natural\ Docs natural_docs
+# 	echo '#!/bin/bash
+# mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
+# 	chmod a+x /usr/local/bin/natural_docs
+# fi
 

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -48,7 +48,7 @@ fi
 # doxygen
 vaild
 if [ ! -x /usr/bin/doxygen ]; then
-	echo "install doxygen"
+
 	if [ ! -d /usr/local/src/doxygen ]; then
 		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
 	fi
@@ -64,7 +64,7 @@ fi
 
 mono
 if [ ! -f /usr/bin/mono ]; then
-	echo "install mono"	
+
 	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
 	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
 	yum -q install mono-devel -y
@@ -72,7 +72,7 @@ fi
 
 # natural_docs
 if [ ! -x /usr/local/bin/natural_docs ]; then
-	echo "install natural_docs"	
+	
 	cd /usr/local
 	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
 	unzip -qq natural_docs

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 
-# Install needed system tools
-localectl set-locale LANG=en_US.UTF-8
-nproc=6
-echo "start centos:8 installation, nproc=$nproc"
-# yum -q update -y ; 
-# yum -q clean all
-# yum -q groupinstall "Development Tools" -y
-# yum -q install cmake -y 
-# yum -q install ncurses-devel -y
-# yum -q install epel-release -y
-# yum -q install curl-devel -y
-# yum -q install which -y
-# yum -q install svn -y
+#Install needed system tools
+yum -q update -y ; 
+yum -q clean all
+yum -q groupinstall "Development Tools" -y
+yum -q install cmake -y 
+yum -q install ncurses-devel -y
+yum -q install epel-release -y
+yum -q install curl-devel -y
+yum -q install which -y
+yum -q install svn -y
 
 # # python3 support needed as of 4.2
 if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
@@ -39,51 +36,49 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	/usr/local/bin/python3 -m pip install IPython 
 	/usr/local/bin/python3 -m pip install censusdata
 	# remove tgz
-	echo "remove python tgz"
 	rm -f /usr/local/src/Python-3.9.6.tgz
 fi
 
 # latex
-# if [ ! -x /usr/bin/tex ]; then
-# 	echo "install latex"
-# 	yum -q install tex -y
-# fi
+if [ ! -x /usr/bin/tex ]; then
+	yum -q install tex -y
+fi
 
-# # doxygen
-#vaild
-# if [ ! -x /usr/bin/doxygen ]; then
-# 	echo "install doxygen"
-# 	if [ ! -d /usr/local/src/doxygen ]; then
-# 		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
-# 	fi
-# 	if [ ! -d /usr/local/src/doxygen/build ]; then
-# 		mkdir /usr/local/src/doxygen/build
-# 	fi
+# doxygen
+vaild
+if [ ! -x /usr/bin/doxygen ]; then
+	echo "install doxygen"
+	if [ ! -d /usr/local/src/doxygen ]; then
+		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
+	fi
+	if [ ! -d /usr/local/src/doxygen/build ]; then
+		mkdir /usr/local/src/doxygen/build
+	fi
 	
-# 	cd /usr/local/src/doxygen/build
-# 	cmake -G "Unix Makefiles" ..
-# 	make
-# 	make install
-# fi
+	cd /usr/local/src/doxygen/build
+	cmake -G "Unix Makefiles" ..
+	make
+	make install
+fi
 
-# mono
-# if [ ! -f /usr/bin/mono ]; then
-# 	echo "install mono"	
-# 	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
-# 	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
-# 	yum -q install mono-devel -y
-# fi
+mono
+if [ ! -f /usr/bin/mono ]; then
+	echo "install mono"	
+	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
+	yum -q install mono-devel -y
+fi
 
-# # natural_docs
-# if [ ! -x /usr/local/bin/natural_docs ]; then
-# 	echo "install natural_docs"	
-# 	cd /usr/local
-# 	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
-# 	unzip -qq natural_docs
-# 	rm -f natural_docs.zip
-# 	mv Natural\ Docs natural_docs
-# 	echo '#!/bin/bash
-# mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
-# 	chmod a+x /usr/local/bin/natural_docs
-# fi
+# natural_docs
+if [ ! -x /usr/local/bin/natural_docs ]; then
+	echo "install natural_docs"	
+	cd /usr/local
+	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
+	unzip -qq natural_docs
+	rm -f natural_docs.zip
+	mv Natural\ Docs natural_docs
+	echo '#!/bin/bash
+mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
+	chmod a+x /usr/local/bin/natural_docs
+fi
 

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -41,51 +41,45 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 fi
 
 # # latex
-# if [ ! -x /usr/bin/tex ]; then
-# 	yum -q install tex -y
-# fi
+if [ ! -x /usr/bin/tex ]; then
+	yum -q install tex -y
+fi
 
 # # doxygen
 
-# if [ ! -x /usr/bin/doxygen ]; then
-# 	echo "install doxygen"
-# 	if [ ! -d /usr/local/src/doxygen ]; then
-# 		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
-# 	fi
-# 	if [ ! -d /usr/local/src/doxygen/build ]; then
-# 		mkdir /usr/local/src/doxygen/build
-# 	fi
+if [ ! -x /usr/bin/doxygen ]; then
+	echo "install doxygen"
+	if [ ! -d /usr/local/src/doxygen ]; then
+		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
+	fi
+	if [ ! -d /usr/local/src/doxygen/build ]; then
+		mkdir /usr/local/src/doxygen/build
+	fi
 	
-# 	cd /usr/local/src/doxygen/build
-# 	cmake -G "Unix Makefiles" ..
-# 	make
-# 	make install
-# fi
+	cd /usr/local/src/doxygen/build
+	cmake -G "Unix Makefiles" ..
+	make
+	make install
+fi
 
 # mono
-# if [ ! -f /usr/bin/mono ]; then
+if [ ! -f /usr/bin/mono ]; then
 
-# 	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
-# 	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
-# 	yum -q install mono-devel -y
-# fi
+	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
+	yum -q install mono-devel -y
+fi
 
 # # natural_docs
-# if [ ! -x /usr/local/bin/natural_docs ]; then
+if [ ! -x /usr/local/bin/natural_docs ]; then
 	
-# 	cd /usr/local
-# 	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
-# 	unzip -qq natural_docs
-# 	rm -f natural_docs.zip
-# 	mv Natural\ Docs natural_docs
-# 	echo '#!/bin/bash
-# mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
-# 	chmod a+x /usr/local/bin/natural_docs
-# fi
+	cd /usr/local
+	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
+	unzip -qq natural_docs
+	rm -f natural_docs.zip
+	mv Natural\ Docs natural_docs
+	echo '#!/bin/bash
+mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
+	chmod a+x /usr/local/bin/natural_docs
+fi
 
-# test code 
-echo "build gridlabd"
-cd /usr/local/src/gridlabd
-autoreconf -isf && ./configure
-make -j6 system
-/usr/local/bin/python3 -m pip install --upgrade numpy

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -44,61 +44,50 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	/usr/local/bin/python3 -m pip install --upgrade pip
 	/usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
 	/usr/local/bin/python3 -m pip install IPython censusdata
-	# # /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
-	# # /usr/local/bin/python3 -m pip install IPython 
-	# # /usr/local/bin/python3 -m pip install censusdata
-	# /usr/local/bin/python3 -m pip install --upgrade pip
-	# /usr/local/bin/python3 -m pip install mysql-connector 
-	# /usr/local/bin/python3 -m pip install matplotlib 
-	# /usr/local/bin/python3 -m pip install numpy 
-	# /usr/local/bin/python3 -m pip install pandas
-	# /usr/local/bin/python3 -m pip install Pillow
-	# /usr/local/bin/python3 -m pip install IPython 
-	# /usr/local/bin/python3 -m pip install wheel 
-	# /usr/local/bin/python3 -m pip install censusdata
+
 
 fi
 
-# # latex
-# if [ ! -x /usr/bin/tex ]; then
-# 	yum -q install tex -y
-# fi
+# latex
+if [ ! -x /usr/bin/tex ]; then
+	yum -q install tex -y
+fi
 
-# # # doxygen
+# # doxygen
 
-# if [ ! -x /usr/bin/doxygen ]; then
-# 	echo "install doxygen"
-# 	if [ ! -d /usr/local/src/doxygen ]; then
-# 		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
-# 	fi
-# 	if [ ! -d /usr/local/src/doxygen/build ]; then
-# 		mkdir /usr/local/src/doxygen/build
-# 	fi
+if [ ! -x /usr/bin/doxygen ]; then
+	echo "install doxygen"
+	if [ ! -d /usr/local/src/doxygen ]; then
+		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
+	fi
+	if [ ! -d /usr/local/src/doxygen/build ]; then
+		mkdir /usr/local/src/doxygen/build
+	fi
 	
-# 	cd /usr/local/src/doxygen/build
-# 	cmake -G "Unix Makefiles" ..
-# 	make
-# 	make install
-# fi
+	cd /usr/local/src/doxygen/build
+	cmake -G "Unix Makefiles" ..
+	make
+	make install
+fi
 
-# # mono
-# if [ ! -f /usr/bin/mono ]; then
+# mono
+if [ ! -f /usr/bin/mono ]; then
 
-# 	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
-# 	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
-# 	yum -q install mono-devel -y
-# fi
+	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
+	yum -q install mono-devel -y
+fi
 
-# # # # natural_docs
-# if [ ! -x /usr/local/bin/natural_docs ]; then
+# # # natural_docs
+if [ ! -x /usr/local/bin/natural_docs ]; then
 	
-# 	cd /usr/local
-# 	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
-# 	unzip -qq natural_docs
-# 	rm -f natural_docs.zip
-# 	mv Natural\ Docs natural_docs
-# 	echo '#!/bin/bash
-# mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
-# 	chmod a+x /usr/local/bin/natural_docs
-# fi
+	cd /usr/local
+	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
+	unzip -qq natural_docs
+	rm -f natural_docs.zip
+	mv Natural\ Docs natural_docs
+	echo '#!/bin/bash
+mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
+	chmod a+x /usr/local/bin/natural_docs
+fi
 

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -28,12 +28,13 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 	# install python packages
 	/usr/local/bin/python3 -m pip install --upgrade pip
-	/usr/local/bin/python3 pip -m install mysql-connector 
-	/usr/local/bin/python3 pip -m install matplotlib 
-	/usr/local/bin/python3 pip -m install numpy 
-	/usr/local/bin/python3 pip -m install pandas
-	/usr/local/bin/python3 pip -m install Pillow
+	/usr/local/bin/python3 -m pip install mysql-connector 
+	/usr/local/bin/python3 -m pip install matplotlib 
+	/usr/local/bin/python3 -m pip install numpy 
+	/usr/local/bin/python3 -m pip install pandas
+	/usr/local/bin/python3 -m pip install Pillow
 	/usr/local/bin/python3 -m pip install IPython 
+	/usr/local/bin/python3 -m pip install wheel 
 	/usr/local/bin/python3 -m pip install censusdata
 	# remove tgz
 	rm -f /usr/local/src/Python-3.9.6.tgz

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Install needed system tools
+
 yum -q update -y ; 
 yum -q clean all
 yum -q groupinstall "Development Tools" -y
@@ -15,7 +16,7 @@ yum -q install svn -y
 if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
 	yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
 	cd /usr/local/src
-	curl https://www.python.org/ftp/python/3.9.0/Python-3.9.6.tgz | tar xz
+	curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz | tar xz
 	cd Python-3.9.6
 	./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
 	make -j $(nproc)
@@ -33,8 +34,6 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	/usr/local/bin/python3 pip -m install Pillow
 	/usr/local/bin/python3 -m pip install IPython 
 	/usr/local/bin/python3 -m pip install censusdata
-
-
 	# remove tgz
 	rm -f Python-3.9.6.tgz
 fi

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -40,46 +40,52 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	rm -f /usr/local/src/Python-3.9.6.tgz
 fi
 
-# latex
-if [ ! -x /usr/bin/tex ]; then
-	yum -q install tex -y
-fi
+# # latex
+# if [ ! -x /usr/bin/tex ]; then
+# 	yum -q install tex -y
+# fi
 
-# doxygen
-vaild
-if [ ! -x /usr/bin/doxygen ]; then
+# # doxygen
 
-	if [ ! -d /usr/local/src/doxygen ]; then
-		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
-	fi
-	if [ ! -d /usr/local/src/doxygen/build ]; then
-		mkdir /usr/local/src/doxygen/build
-	fi
+# if [ ! -x /usr/bin/doxygen ]; then
+# 	echo "install doxygen"
+# 	if [ ! -d /usr/local/src/doxygen ]; then
+# 		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
+# 	fi
+# 	if [ ! -d /usr/local/src/doxygen/build ]; then
+# 		mkdir /usr/local/src/doxygen/build
+# 	fi
 	
-	cd /usr/local/src/doxygen/build
-	cmake -G "Unix Makefiles" ..
-	make
-	make install
-fi
+# 	cd /usr/local/src/doxygen/build
+# 	cmake -G "Unix Makefiles" ..
+# 	make
+# 	make install
+# fi
 
-mono
-if [ ! -f /usr/bin/mono ]; then
+# mono
+# if [ ! -f /usr/bin/mono ]; then
 
-	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
-	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
-	yum -q install mono-devel -y
-fi
+# 	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+# 	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
+# 	yum -q install mono-devel -y
+# fi
 
-# natural_docs
-if [ ! -x /usr/local/bin/natural_docs ]; then
+# # natural_docs
+# if [ ! -x /usr/local/bin/natural_docs ]; then
 	
-	cd /usr/local
-	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
-	unzip -qq natural_docs
-	rm -f natural_docs.zip
-	mv Natural\ Docs natural_docs
-	echo '#!/bin/bash
-mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
-	chmod a+x /usr/local/bin/natural_docs
-fi
+# 	cd /usr/local
+# 	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
+# 	unzip -qq natural_docs
+# 	rm -f natural_docs.zip
+# 	mv Natural\ Docs natural_docs
+# 	echo '#!/bin/bash
+# mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
+# 	chmod a+x /usr/local/bin/natural_docs
+# fi
 
+# test code 
+echo "build gridlabd"
+cd /usr/local/src/gridlabd
+autoreconf -isf && ./configure
+make -j6 system
+/usr/local/bin/python3 -m pip install --upgrade numpy

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -71,7 +71,7 @@ if [ ! -f /usr/bin/mono ]; then
 	yum -q install mono-devel -y
 fi
 
-# # natural_docs
+# # # natural_docs
 if [ ! -x /usr/local/bin/natural_docs ]; then
 	
 	cd /usr/local

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -10,11 +10,12 @@ yum -q install epel-release -y
 yum -q install curl-devel -y
 yum -q install which -y
 yum -q install svn -y
+yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
 
 # # python3 support needed as of 4.2
 if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
 	echo "install python 3.9.6"	
-	yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
+	
 	cd /usr/local/src
 	curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz | tar xz
 	cd Python-3.9.6

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -10,24 +10,30 @@ yum -q install epel-release -y
 yum -q install curl-devel -y
 yum -q install which -y
 yum -q install svn -y
-yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
+
 
 # # python3 support needed as of 4.2
 if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
 	echo "install python 3.9.6"	
 	
 	cd /usr/local/src
+	yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel  xz-devel  -y
 	curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz | tar xz
 	cd Python-3.9.6
 	./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
 	make -j $(nproc)
 	make altinstall
+	
 	ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
 	ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
 	ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
 	ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 	# install python packages
+	/usr/local/bin/python3 -m pip install --upgrade pip
+	# /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
+	# /usr/local/bin/python3 -m pip install IPython 
+	# /usr/local/bin/python3 -m pip install censusdata
 	/usr/local/bin/python3 -m pip install --upgrade pip
 	/usr/local/bin/python3 -m pip install mysql-connector 
 	/usr/local/bin/python3 -m pip install matplotlib 
@@ -37,52 +43,51 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	/usr/local/bin/python3 -m pip install IPython 
 	/usr/local/bin/python3 -m pip install wheel 
 	/usr/local/bin/python3 -m pip install censusdata
-	# update numpy
-	/usr/local/bin/python3 -m pip install --upgrade numpy
+
 	# remove tgz
 	rm -f /usr/local/src/Python-3.9.6.tgz
 fi
 
 # # latex
-if [ ! -x /usr/bin/tex ]; then
-	yum -q install tex -y
-fi
+# if [ ! -x /usr/bin/tex ]; then
+# 	yum -q install tex -y
+# fi
 
-# # doxygen
+# # # doxygen
 
-if [ ! -x /usr/bin/doxygen ]; then
-	echo "install doxygen"
-	if [ ! -d /usr/local/src/doxygen ]; then
-		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
-	fi
-	if [ ! -d /usr/local/src/doxygen/build ]; then
-		mkdir /usr/local/src/doxygen/build
-	fi
+# if [ ! -x /usr/bin/doxygen ]; then
+# 	echo "install doxygen"
+# 	if [ ! -d /usr/local/src/doxygen ]; then
+# 		git clone https://github.com/doxygen/doxygen.git /usr/local/src/doxygen --depth 1
+# 	fi
+# 	if [ ! -d /usr/local/src/doxygen/build ]; then
+# 		mkdir /usr/local/src/doxygen/build
+# 	fi
 	
-	cd /usr/local/src/doxygen/build
-	cmake -G "Unix Makefiles" ..
-	make
-	make install
-fi
+# 	cd /usr/local/src/doxygen/build
+# 	cmake -G "Unix Makefiles" ..
+# 	make
+# 	make install
+# fi
 
-# mono
-if [ ! -f /usr/bin/mono ]; then
+# # mono
+# if [ ! -f /usr/bin/mono ]; then
 
-	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
-	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
-	yum -q install mono-devel -y
-fi
+# 	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+# 	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
+# 	yum -q install mono-devel -y
+# fi
 
-# # # natural_docs
-if [ ! -x /usr/local/bin/natural_docs ]; then
+# # # # natural_docs
+# if [ ! -x /usr/local/bin/natural_docs ]; then
 	
-	cd /usr/local
-	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
-	unzip -qq natural_docs
-	rm -f natural_docs.zip
-	mv Natural\ Docs natural_docs
-	echo '#!/bin/bash
-mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
-	chmod a+x /usr/local/bin/natural_docs
-fi
+# 	cd /usr/local
+# 	curl -s https://www.naturaldocs.org/download/natural_docs/2.0.2/Natural_Docs_2.0.2.zip > natural_docs.zip
+# 	unzip -qq natural_docs
+# 	rm -f natural_docs.zip
+# 	mv Natural\ Docs natural_docs
+# 	echo '#!/bin/bash
+# mono /usr/local/natural_docs/NaturalDocs.exe \$*' > /usr/local/bin/natural_docs
+# 	chmod a+x /usr/local/bin/natural_docs
+# fi
 

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 
+# chmod -R 775 /usr/local
+# chown -R root:adm /usr/local
+
 #Install needed system tools
-yum -q update -y ; 
-yum -q clean all
-yum -q groupinstall "Development Tools" -y
-yum -q install cmake -y 
-yum -q install ncurses-devel -y
-yum -q install epel-release -y
-yum -q install curl-devel -y
-yum -q install which -y
-yum -q install svn -y
+yum clean all
+yum groupinstall "Development Tools" -y
+yum install cmake -y 
+yum install ncurses-devel -y
+yum install epel-release -y
+yum install curl-devel -y
+yum install which -y
+yum install svn -y
+
+yum install 'dnf-command(config-manager)' -y
 
 
-# # python3 support needed as of 4.2
+
+
+# change directory
+# cd /usr/local/src
+yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel  xz-devel  -y
+
+
+# python3 support needed as of 4.2
 if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
-	echo "install python 3.9.6"	
+	# echo "install python 3.9.6"	
 	
 	cd /usr/local/src
 	yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel  xz-devel  -y
@@ -31,21 +42,21 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 	# install python packages
 	/usr/local/bin/python3 -m pip install --upgrade pip
-	# /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
+	/usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
+	/usr/local/bin/python3 -m pip install IPython censusdata
+	# # /usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
+	# # /usr/local/bin/python3 -m pip install IPython 
+	# # /usr/local/bin/python3 -m pip install censusdata
+	# /usr/local/bin/python3 -m pip install --upgrade pip
+	# /usr/local/bin/python3 -m pip install mysql-connector 
+	# /usr/local/bin/python3 -m pip install matplotlib 
+	# /usr/local/bin/python3 -m pip install numpy 
+	# /usr/local/bin/python3 -m pip install pandas
+	# /usr/local/bin/python3 -m pip install Pillow
 	# /usr/local/bin/python3 -m pip install IPython 
+	# /usr/local/bin/python3 -m pip install wheel 
 	# /usr/local/bin/python3 -m pip install censusdata
-	/usr/local/bin/python3 -m pip install --upgrade pip
-	/usr/local/bin/python3 -m pip install mysql-connector 
-	/usr/local/bin/python3 -m pip install matplotlib 
-	/usr/local/bin/python3 -m pip install numpy 
-	/usr/local/bin/python3 -m pip install pandas
-	/usr/local/bin/python3 -m pip install Pillow
-	/usr/local/bin/python3 -m pip install IPython 
-	/usr/local/bin/python3 -m pip install wheel 
-	/usr/local/bin/python3 -m pip install censusdata
 
-	# remove tgz
-	rm -f /usr/local/src/Python-3.9.6.tgz
 fi
 
 # # latex

--- a/gldcore/scripts/autotest/test_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) >= '1.21.4'
 
 // matrix operations test
 #assert $(gridlabd matrix -f copy "1,2;3,4") == '1,2;3,4'

--- a/gldcore/scripts/autotest/test_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) >= '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // matrix operations test
 #assert $(gridlabd matrix -f copy "1,2;3,4") == '1,2;3,4'

--- a/gldcore/scripts/autotest/test_matrix_linalg.glm
+++ b/gldcore/scripts/autotest/test_matrix_linalg.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) >= '1.21.4'
 
 // linalg.cholesky <matrix>
 #assert $(gridlabd matrix -f linalg.cholesky "1,2;-2,5") == '1,0;-2,1'

--- a/gldcore/scripts/autotest/test_matrix_linalg.glm
+++ b/gldcore/scripts/autotest/test_matrix_linalg.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) >= '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // linalg.cholesky <matrix>
 #assert $(gridlabd matrix -f linalg.cholesky "1,2;-2,5") == '1,0;-2,1'

--- a/gldcore/scripts/autotest/test_matrix_matlib.glm
+++ b/gldcore/scripts/autotest/test_matrix_matlib.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) >= '1.21.4'
 
 // matlib.rand <intlist_args>
 #assert ! -z "$(gridlabd matrix -f matlib.rand 1)"

--- a/gldcore/scripts/autotest/test_matrix_matlib.glm
+++ b/gldcore/scripts/autotest/test_matrix_matlib.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) >= '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // matlib.rand <intlist_args>
 #assert ! -z "$(gridlabd matrix -f matlib.rand 1)"

--- a/gldcore/scripts/autotest/test_matrix_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix_matrix.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) >= '1.21.4'
 
 // matrix.all <matrix> axis=<int>
 #assert $(gridlabd matrix -f matrix.all "1,2,3;4,5,6;") == '1'

--- a/gldcore/scripts/autotest/test_matrix_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix_matrix.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) >= '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // matrix.all <matrix> axis=<int>
 #assert $(gridlabd matrix -f matrix.all "1,2,3;4,5,6;") == '1'

--- a/gldcore/scripts/autotest/test_matrix_random.glm
+++ b/gldcore/scripts/autotest/test_matrix_random.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) >= '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // random.choice <arrayorint> size=<intlist> replace=<boolstr> p=<array>
 #assert ! -z $(gridlabd matrix -f random.choice "1,2,3,4,5")

--- a/gldcore/scripts/autotest/test_matrix_random.glm
+++ b/gldcore/scripts/autotest/test_matrix_random.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) >= '1.21.4'
 
 // random.choice <arrayorint> size=<intlist> replace=<boolstr> p=<array>
 #assert ! -z $(gridlabd matrix -f random.choice "1,2,3,4,5")

--- a/install.sh
+++ b/install.sh
@@ -315,7 +315,7 @@ if [ ! -f "configure" -o "$QUICK" == "no" ]; then
 fi
 
 NPROC=1
-
+SYSTEM=$(uname -s)
 if [ "$PARALLEL" == "yes" ]; then
 	if [ "$SYSTEM" == "Linux" ]; then
 		NPROC=$(lscpu | grep '^CPU(s):' | cut -f2- -d' ')

--- a/install.sh
+++ b/install.sh
@@ -327,6 +327,8 @@ fi
 export PATH=/usr/local/bin:/usr/bin:/bin
 run make -j$((3*$NPROC))
 run make install
+# update numpy after make install
+# /usr/local/bin/python3 -m pip install --upgrade numpy
 if [ "$DOCS" == "yes" ]; then
 	run make html 
 	run cp -r "documents/html" "$INSTALL"

--- a/install.sh
+++ b/install.sh
@@ -328,8 +328,7 @@ fi
 export PATH=/usr/local/bin:/usr/bin:/bin
 run make -j$((3*$NPROC))
 run make install
-# upgrade numpy after make install
- /usr/local/bin/python3 -m pip install --upgrade numpy
+
 if [ "$DOCS" == "yes" ]; then
 	run make html 
 	run cp -r "documents/html" "$INSTALL"

--- a/install.sh
+++ b/install.sh
@@ -315,6 +315,7 @@ if [ ! -f "configure" -o "$QUICK" == "no" ]; then
 fi
 
 NPROC=1
+SYSTEM=$(uname -s)
 if [ "$PARALLEL" == "yes" ]; then
 	if [ "$SYSTEM" == "Linux" ]; then
 		NPROC=$(lscpu | grep '^CPU(s):' | cut -f2- -d' ')

--- a/install.sh
+++ b/install.sh
@@ -328,7 +328,7 @@ export PATH=/usr/local/bin:/usr/bin:/bin
 run make -j$((3*$NPROC))
 run make install
 # update numpy after make install
-# /usr/local/bin/python3 -m pip install --upgrade numpy
+/usr/local/bin/python3 -m pip install --upgrade numpy
 if [ "$DOCS" == "yes" ]; then
 	run make html 
 	run cp -r "documents/html" "$INSTALL"

--- a/install.sh
+++ b/install.sh
@@ -315,7 +315,7 @@ if [ ! -f "configure" -o "$QUICK" == "no" ]; then
 fi
 
 NPROC=1
-SYSTEM=$(uname -s)
+
 if [ "$PARALLEL" == "yes" ]; then
 	if [ "$SYSTEM" == "Linux" ]; then
 		NPROC=$(lscpu | grep '^CPU(s):' | cut -f2- -d' ')
@@ -328,8 +328,8 @@ fi
 export PATH=/usr/local/bin:/usr/bin:/bin
 run make -j$((3*$NPROC))
 run make install
-# update numpy after make install
-/usr/local/bin/python3 -m pip install --upgrade numpy
+# upgrade numpy after make install
+ /usr/local/bin/python3 -m pip install --upgrade numpy
 if [ "$DOCS" == "yes" ]; then
 	run make html 
 	run cp -r "documents/html" "$INSTALL"

--- a/install.sh
+++ b/install.sh
@@ -326,8 +326,8 @@ fi
 
 # build everything
 export PATH=/usr/local/bin:/usr/bin:/bin
-run make -j$((3*$NPROC))
-run make install
+run make -j$((3*$NPROC)) system
+# run make install
 
 if [ "$DOCS" == "yes" ]; then
 	run make html 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.3.3
-numpy==1.21.5
+numpy==1.19.4
 pytz==2020.4
 PyGithub==1.54.1
 docker==4.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.3.3
-numpy==1.19.4
+numpy==1.21.5
 pytz==2020.4
 PyGithub==1.54.1
 docker==4.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.3.3
-numpy==1.21.4
+numpy>=1.21.4
 pytz==2020.4
 PyGithub==1.54.1
 docker==4.4.4


### PR DESCRIPTION
This PR fixes 
1) setup-Linux-centos-8.sh issue #1046.
2) Missing $SYSTEM variable in install.sh #1044.

## Current issues


## Code changes
1) In setup-Linux-centos-8.sh 
- [x] Add  `/usr/local/bin/python3 -m pip install IPython` , `/usr/local/bin/python3 -m pip install wheel`  and `/usr/local/bin/python3 -m pip install censusdata`.
- [x] Modify mono installation:`rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"` and `su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'`
- [x] fix typo `"$(/usr/local/bin/python3 --version)"` 
- [x] upgrade Python to 3.9.6
2)In install.sh
- [x] add `SYSTEM=$(uname -s)`


## Documentation changes
None

## Test and Validation Notes
None
