### PR TITLE
Update setup-Linux-centos-8.sh file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:8
+RUN yum install git -y
+WORKDIR /usr/local/src
+RUN git clone -b develop-fix-centos8-setup https://github.com/slacgismo/gridlabd.git
+WORKDIR /usr/local/src/gridlabd
+RUN ./install.sh -t -v --parallel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM centos:8
-RUN yum install git -y
-WORKDIR /usr/local/src
-RUN git clone -b develop-fix-centos8-setup https://github.com/slacgismo/gridlabd.git
-WORKDIR /usr/local/src/gridlabd
-RUN ./install.sh -t -v --parallel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM centos:8
-
-RUN yum install git -y
-
-WORKDIR /usr/local/src
-
-RUN git clone -b develop-fix-centos8-setup https://github.com/slacgismo/gridlabd.git
-
-WORKDIR /usr/local/src/gridlabd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:8
+
+RUN yum install git -y
+
+WORKDIR /usr/local/src
+
+RUN git clone -b develop-fix-centos8-setup https://github.com/slacgismo/gridlabd.git
+
+WORKDIR /usr/local/src/gridlabd

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -12,20 +12,28 @@ yum -q install which -y
 yum -q install svn -y
 
 # python3 support needed as of 4.2
-if [ ! -x /usr/local/bin/python3 -o $(/usr/local/bin/python3 --version) != "Python 3.9.0" ]; then
-	yum -q install openssl-devel bzip2-devel libffi-devel zlib-devel -y
+if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Python 3.9.6" ]; then
+	echo "install python 3.9.6"	
+	
 	cd /usr/local/src
-	curl https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz | tar xz
-	cd Python-3.9.0
+	yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel  xz-devel  -y
+	curl https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz | tar xz
+	cd Python-3.9.6
 	./configure --prefix=/usr/local --enable-optimizations --with-system-ffi --with-computed-gotos --enable-loadable-sqlite-extensions CFLAGS="-fPIC"
 	make -j $(nproc)
 	make altinstall
+	
 	ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3
 	ln -sf /usr/local/bin/python3.9-config /usr/local/bin/python3-config
 	ln -sf /usr/local/bin/pydoc3.9 /usr/local/bin/pydoc
 	ln -sf /usr/local/bin/idle3.9 /usr/local/bin/idle
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
-	/usr/local/bin/python3 pip -m install mysql-connector matplotlib numpy pandas Pillow
+	# install python packages
+	/usr/local/bin/python3 -m pip install --upgrade pip
+	/usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
+	/usr/local/bin/python3 -m pip install IPython censusdata
+
+
 fi
 
 # latex

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -30,7 +30,7 @@ if [ ! -x /usr/local/bin/python3 -o "$(/usr/local/bin/python3 --version)" != "Py
 	ln -sf /usr/local/bin/pip3.9 /usr/local/bin/pip3
 	# install python packages
 	/usr/local/bin/python3 -m pip install --upgrade pip
-	/usr/local/bin/python3 -m pip install matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
+	/usr/local/bin/python3 -m pip install mysql-connector matplotlib Pillow pandas numpy networkx pytz pysolar PyGithub scikit-learn xlrd 
 	/usr/local/bin/python3 -m pip install IPython censusdata
 
 

--- a/build-aux/setup-Linux-centos-8.sh
+++ b/build-aux/setup-Linux-centos-8.sh
@@ -57,8 +57,8 @@ fi
 
 # mono
 if [ ! -f /usr/bin/mono ]; then
-	rpmkeys --import "http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x3fa7e0328081bff6a14da29aa6a19b38d3d831ef"
-	curl -s https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo
+	rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"
+	su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'
 	yum -q install mono-devel -y
 fi
 

--- a/gldcore/scripts/autotest/test_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // matrix operations test
 #assert $(gridlabd matrix -f copy "1,2;3,4") == '1,2;3,4'

--- a/gldcore/scripts/autotest/test_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) == '1.22.0'
+#assert ! $(gridlabd matrix version) '<' '1.21.0'
 
 // matrix operations test
 #assert $(gridlabd matrix -f copy "1,2;3,4") == '1,2;3,4'

--- a/gldcore/scripts/autotest/test_matrix_linalg.glm
+++ b/gldcore/scripts/autotest/test_matrix_linalg.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // linalg.cholesky <matrix>
 #assert $(gridlabd matrix -f linalg.cholesky "1,2;-2,5") == '1,0;-2,1'

--- a/gldcore/scripts/autotest/test_matrix_linalg.glm
+++ b/gldcore/scripts/autotest/test_matrix_linalg.glm
@@ -1,5 +1,5 @@
 // check numpy version (must be exactly the same to pass these tests)
-#assert $(gridlabd matrix version) == '1.22.0'
+#assert ! $(gridlabd matrix version) '<' '1.21.0'
 
 // linalg.cholesky <matrix>
 #assert $(gridlabd matrix -f linalg.cholesky "1,2;-2,5") == '1,0;-2,1'

--- a/gldcore/scripts/autotest/test_matrix_matlib.glm
+++ b/gldcore/scripts/autotest/test_matrix_matlib.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.22.0'
+#assert ! $(gridlabd matrix version) '<' '1.21.0'
 
 // matlib.rand <intlist_args>
 #assert ! -z "$(gridlabd matrix -f matlib.rand 1)"

--- a/gldcore/scripts/autotest/test_matrix_matlib.glm
+++ b/gldcore/scripts/autotest/test_matrix_matlib.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // matlib.rand <intlist_args>
 #assert ! -z "$(gridlabd matrix -f matlib.rand 1)"

--- a/gldcore/scripts/autotest/test_matrix_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix_matrix.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.22.0'
+#assert ! $(gridlabd matrix version) '<' '1.21.0'
 
 // matrix.all <matrix> axis=<int>
 #assert $(gridlabd matrix -f matrix.all "1,2,3;4,5,6;") == '1'

--- a/gldcore/scripts/autotest/test_matrix_matrix.glm
+++ b/gldcore/scripts/autotest/test_matrix_matrix.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.21.4'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // matrix.all <matrix> axis=<int>
 #assert $(gridlabd matrix -f matrix.all "1,2,3;4,5,6;") == '1'

--- a/gldcore/scripts/autotest/test_matrix_random.glm
+++ b/gldcore/scripts/autotest/test_matrix_random.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.21.4'
+'1.22.0'
 
 // random.choice <arrayorint> size=<intlist> replace=<boolstr> p=<array>
 #assert ! -z $(gridlabd matrix -f random.choice "1,2,3,4,5")

--- a/gldcore/scripts/autotest/test_matrix_random.glm
+++ b/gldcore/scripts/autotest/test_matrix_random.glm
@@ -1,4 +1,4 @@
-'1.22.0'
+#assert $(gridlabd matrix version) == '1.22.0'
 
 // random.choice <arrayorint> size=<intlist> replace=<boolstr> p=<array>
 #assert ! -z $(gridlabd matrix -f random.choice "1,2,3,4,5")

--- a/gldcore/scripts/autotest/test_matrix_random.glm
+++ b/gldcore/scripts/autotest/test_matrix_random.glm
@@ -1,4 +1,4 @@
-#assert $(gridlabd matrix version) == '1.22.0'
+#assert ! $(gridlabd matrix version) '<' '1.21.0'
 
 // random.choice <arrayorint> size=<intlist> replace=<boolstr> p=<array>
 #assert ! -z $(gridlabd matrix -f random.choice "1,2,3,4,5")

--- a/install.sh
+++ b/install.sh
@@ -325,8 +325,8 @@ fi
 
 # build everything
 export PATH=/usr/local/bin:/usr/bin:/bin
-run make -j$((3*$NPROC))
-run make install
+run make -j$((3*$NPROC)) system
+
 if [ "$DOCS" == "yes" ]; then
 	run make html 
 	run cp -r "documents/html" "$INSTALL"

--- a/install.sh
+++ b/install.sh
@@ -315,6 +315,7 @@ if [ ! -f "configure" -o "$QUICK" == "no" ]; then
 fi
 
 NPROC=1
+SYSTEM=$(uname -s)
 if [ "$PARALLEL" == "yes" ]; then
 	if [ "$SYSTEM" == "Linux" ]; then
 		NPROC=$(lscpu | grep '^CPU(s):' | cut -f2- -d' ')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.3.3
-numpy==1.21.4
+numpy>=1.21.4
 pytz==2020.4
 PyGithub==1.54.1
 docker==4.4.4


### PR DESCRIPTION
This PR fixes issue 
1). Fix setup-Linux-centos-8.sh issue Fix setup-Linux-centos-8 #1046.
2). Fix missing $SYSTEM variable in install.sh Parallel option is not working in install.sh #1044.
3). Fix make install in install.sh causes python validation error #1056. 
4). Fix assert numPy and matrix version not match latest version #1045.
## Current issues
None
## Code changes
- [x] Update python to 3.9.6 
- [x] Add python packages `networkx` ,`pytz`,`PyGithub`,`pysolar`,`PyGithub`,`scikit-learn`, `xlrd`, `IPython` ,`censusdata`.
- [x] Updat mono installation `rpmkeys --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF"` and `su -c 'curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-centos8-stable.repo'`.
- [x] Change requirements.txt `numpy>=1.21.4`
- [x] Change `#assert ! $(gridlabd matrix version) '<' '1.21.0'` in `gldcore/scripts/autotest/test_matrix.glm` 
- [x] Change `#assert ! $(gridlabd matrix version) '<' '1.21.0'` in `gldcore/scripts/autotest/test_matrix_linalg.glm` 
- [x] Change `#assert ! $(gridlabd matrix version) '<' '1.21.0'` in `gldcore/scripts/autotest/test_matrix_matlib.glm` 
- [x] Change `#assert ! $(gridlabd matrix version) '<' '1.21.0'` in `gldcore/scripts/autotest/test_matrix_random.glm` 
- [x] Change `#assert ! $(gridlabd matrix version) '<' '1.21.0'` in `gldcore/scripts/autotest/test_matrix_random.glm`
- [x] Change `#assert ! $(gridlabd matrix version) '<' '1.21.0'` in `gldcore/scripts/autotest/test_matrix_matrix.glm` 
- [x] Remove `make install` , add `run make -j$((3*$NPROC)) system`
- [x] Add `SYSTEM=$(uname -s)`

## Documentation changes
None
## Test and Validation Notes



