### PR TITLE
Fix parallel validation errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -295,7 +295,7 @@ install-exec-hook: index python-requirements docs
 
 python-requirements: $(python_requirements)
 	@echo "Updating python requirements..."
-	@for REQ in $(python_requirements) ; do python3 -m pip install -q -r $$REQ ; done
+	@python3 -m pip install -q -r $(subst $(subst ,, ), -r ,$(python_requirements))
 
 reconfigure: distclean
 	autoreconf -isf && $(PWD)/configure --quiet

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ bin_PROGRAMS =
 bin_SCRIPTS =
 dist_doc_DATA =
 
-python_requirements = requirements.txt
+python_requirements = $(shell find $(top_srcdir) -name requirements.txt -print)
 
 docs_targets =
 
@@ -295,7 +295,7 @@ install-exec-hook: index python-requirements docs
 
 python-requirements: $(python_requirements)
 	@echo "Updating python requirements..."
-	@cat $(shell find $(top_srcdir) -name requirements.txt -print) | python3 -m pip install -q -r /dev/stdin
+	@for REQ in $(python_requirements) ; do python3 -m pip install -q -r $$REQ ; done
 
 reconfigure: distclean
 	autoreconf -isf && $(PWD)/configure --quiet

--- a/Makefile.am
+++ b/Makefile.am
@@ -295,7 +295,7 @@ install-exec-hook: index python-requirements docs
 
 python-requirements: $(python_requirements)
 	@echo "Updating python requirements..."
-	@cat $(addprefix $(top_srcdir)/,$(python_requirements)) | python3 -m pip install -q -r /dev/stdin
+	@cat $(shell find $(top_srcdir) -name requirements.txt -print) | python3 -m pip install -q -r /dev/stdin
 
 reconfigure: distclean
 	autoreconf -isf && $(PWD)/configure --quiet

--- a/gldcore/autotest/test_config.glm
+++ b/gldcore/autotest/test_config.glm
@@ -1,8 +1,8 @@
 #ifexist "../config.csv"
-#define DIR=..
+#system cp ../config.csv .
 #endif
 
-#input "${DIR:-.}/config.csv" -f config -t config
+#input "config.csv" -f config -t config
 
 #if ${TEST1:-X} == A
 #print ok

--- a/gldcore/autotest/test_config_prefix.glm
+++ b/gldcore/autotest/test_config_prefix.glm
@@ -1,8 +1,8 @@
 #ifexist "../config.csv"
-#define DIR=..
+#system cp ../config.csv .
 #endif
 
-#input "${DIR:-.}/config.csv" -f config -t config -p prefix=MY_
+#input "config.csv" -f config -t config -p prefix=MY_
 
 #if ${MY_TEST1:-X} == A
 #print ok

--- a/gldcore/autotest/test_config_relax.glm
+++ b/gldcore/autotest/test_config_relax.glm
@@ -1,9 +1,8 @@
 #ifexist "../config.csv"
-#define DIR=..
+#system cp ../config.csv .
 #endif
 
-#define TEST1=X
-#input "${DIR:-.}/config.csv" -f config -t config -p relax=FALSE
+#input "config.csv" -f config -t config relax=FALSE
 
 #if ${TEST1:-X} == A
 #print ok

--- a/gldcore/autotest/test_library_include.glm
+++ b/gldcore/autotest/test_library_include.glm
@@ -1,7 +1,7 @@
-#library config set CACHEDIR /tmp
-#library config set DATADIR /tmp
+#library config set CACHEDIR .
+#library config set DATADIR .
 #library get pole_configuration.glm
-#include "/tmp/pole_configuration.glm"
+#include "./pole_configuration.glm"
 
 class test {
 	object lib;

--- a/gldcore/geodata/requirements.txt
+++ b/gldcore/geodata/requirements.txt
@@ -1,7 +1,6 @@
 haversine==2.3.0
 Fiona==1.8.19
 pandas==1.1.4
-scipy==1.6.0
 Shapely==1.7.1
 geopandas==0.9.0
 CensusData==1.13

--- a/gldcore/scripts/Makefile.mk
+++ b/gldcore/scripts/Makefile.mk
@@ -10,6 +10,7 @@ bin_SCRIPTS += gldcore/scripts/gridlabd-help
 bin_SCRIPTS += gldcore/scripts/gridlabd-json-get
 bin_SCRIPTS += gldcore/scripts/gridlabd-job
 bin_SCRIPTS += gldcore/scripts/gridlabd-library
+bin_SCRIPTS += gldcore/scripts/gridlabd-lock
 bin_SCRIPTS += gldcore/scripts/gridlabd-manual
 bin_SCRIPTS += gldcore/scripts/gridlabd-matrix
 bin_SCRIPTS += gldcore/scripts/gridlabd-openfido

--- a/gldcore/scripts/gridlabd-library
+++ b/gldcore/scripts/gridlabd-library
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# ensure only one weather call runs at a time
+. $(dirname $0)/gridlabd-lock
+
 # check environment
 if [ ${GLD_ETC:-none} == none ]; then
 	echo "ERROR: GLD_ETC is not exported from the shell environment"

--- a/gldcore/scripts/gridlabd-lock
+++ b/gldcore/scripts/gridlabd-lock
@@ -1,0 +1,8 @@
+# enable locking of the current executable to ensure only one runs at a time
+PIDFILE="/tmp/$(basename $0).pid"
+trap "rm -f ${PIDFILE}; exit" INT TERM EXIT
+if [ -e $PIDFILE ]; then
+    PID=$(cat $PIDFILE)
+    while (ps -p $PID >/dev/null); do sleep 1; done
+fi 
+echo $$ >$PIDFILE

--- a/gldcore/scripts/gridlabd-template
+++ b/gldcore/scripts/gridlabd-template
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# ensure only one template call runs at a time
+. $(dirname $0)/gridlabd-lock
+
 # check environment
 if [ ${GLD_ETC:-none} == none ]; then
     export GLD_ETC=${gridlabd --version=install}/shared/gridlabd

--- a/gldcore/scripts/gridlabd-weather
+++ b/gldcore/scripts/gridlabd-weather
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# ensure only one weather call runs at a time
+. $(dirname $0)/gridlabd-lock
+
 # check environment
 if [ ${GLD_ETC:-none} == none ]; then
 	echo "$0: ERROR: GLD_ETC is not exported from the shell environment" > /dev/stderr

--- a/gldcore/scripts/requirements.txt
+++ b/gldcore/scripts/requirements.txt
@@ -1,6 +1,5 @@
 haversine==2.3.0
 pandas==1.1.4
-scipy==1.6.0
 Shapely==1.7.1
 geopandas==0.9.0
 PyGithub==1.54.1

--- a/module/optimize/autotest/test_extremum_opt.glm
+++ b/module/optimize/autotest/test_extremum_opt.glm
@@ -1,3 +1,4 @@
+#set tmp=.
 module optimize;
 module tape
 {

--- a/module/optimize/autotest/test_maximum_err.glm
+++ b/module/optimize/autotest/test_maximum_err.glm
@@ -1,3 +1,4 @@
+#set tmp=.
 module optimize;
 module tape
 {

--- a/module/optimize/autotest/test_minimum.glm
+++ b/module/optimize/autotest/test_minimum.glm
@@ -1,3 +1,4 @@
+#set tmp=.
 module optimize;
 module tape
 {

--- a/module/resilience/docs/requirements.txt
+++ b/module/resilience/docs/requirements.txt
@@ -1,6 +1,5 @@
 Pillow==8.3.2
 ipython==7.22.0
 pandas==1.1.4
-scipy==1.6.2
 ipyplot==1.1.0
 elevation==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ docker==4.4.4
 folium==0.12.1
 scikit-learn==0.24.2
 xlrd==2.0.1
+scipy==1.6.2


### PR DESCRIPTION
This PR fixes issue #1056 

## Current issues

Not all modes of failure appear to have been identified.  All those found should be documented below in the comments.

## Code changes

- [x] Changed `python-requirements` target in `Makefile.am`
- [x] Removed conflicting requirements

## Documentation changes

None

## Test and Validation Notes

- [x] Fixed `gldcore/autotest/test_library_include.glm` to not use `/tmp` folder.
- [x] Fixed `gldcore/autotest/test_config*.glm` to not use the same test files at the same time.
- [x] Fixed `gldcore/autotest/test_optimize*.glm` so they do not share the same object files.
- [x] Add locking to subcommands that manipulate the shared data folders (template, weather, and library).
