### PR TITLE
Fix nsrdb_weather key management

### DIFF
--- a/python_extras/nsrdb_weather.py
+++ b/python_extras/nsrdb_weather.py
@@ -190,7 +190,7 @@ def getemail():
     """Get the default email"""
     global email
     if not email:
-        keys = getkeys().keys()
+        keys = getkeys(new=True).keys()
         if keys:
             email = list(getkeys().keys())[0]
         else:
@@ -235,7 +235,10 @@ def getkey(email=None):
     if not email:
         email = getemail()
     if email:
-        return getkeys()[email]
+        try:
+            return getkeys()[email]
+        except:
+            return {}
     else:
         return None
 
@@ -569,7 +572,7 @@ if __name__ == "__main__":
         elif token == "--signup":
             if not value:
                 error("you must provide an email address for the new credential",1)
-            credentials = getkeys()
+            credentials = getkeys(new=True)
             if getemail() in credentials.keys():
                 error(f"you already have credentials for {value}",1)
             else:

--- a/python_extras/nsrdb_weather.py
+++ b/python_extras/nsrdb_weather.py
@@ -604,10 +604,7 @@ if __name__ == "__main__":
             shutil.rmtree(cachedir)
         else:
             error(f"option '{token}' is not valid",1)
-    if position and year:
-        data = getyears(year,float(position[0]),float(position[1]))
-        writeglm(data,glm,name,csv)
-
+ 
     if position and year:
         try:
             data = getyears(year,float(position[0]),float(position[1]))


### PR DESCRIPTION
This PR fixes problems with NSRDB weather key management.

## Current issues

None

## Code changes

- [x] Update `python_extras/nsrdb_weather.py`

## Documentation changes

None

## Test and Validation Notes

To verify it works:
1. Delete the `$HOME/.nsrdb folder` and `/usr/local/opt/gridlabd/current/share/gridlabd/weather/nsrdb/`
2. Try the command `gridlabd nsrdb_weather -y=2014,2015 -p=45.62,-122.70 -c=/tmp/test.csv -g=/tmp/test.glm`.  If should fail with an error such as `unable to get data`
3. Get a new key using `gridlabd nsrdb_weather --signup=dchassin@slac.stanford.edu`.
4. Save the new key using `gridlabd nsrdb_weather --apikey=YOURKEY`
5. Try the command `gridlabd nsrdb_weather -y=2014,2015 -p=45.62,-122.70 -c=/tmp/test.csv -g=/tmp/test.glm` again and verify the GLM file runs ok.
