### PR TITLE
Update docker build to oraclelinux

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM slacgismo/gridlabd_dockerhub_base:211105
+FROM slacgismo/gridlabd_dockerhub_base:220217
 
 
 ENV container docker
@@ -14,7 +14,8 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 
 VOLUME [ "/sys/fs/cgroup" ]
 WORKDIR /tmp
-RUN yum update -y 
+RUN yum clean all 
+RUN yum update -y
 RUN yum install git -y
 COPY gridlabd.sh /tmp/
 RUN chmod +wx *.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM slacgismo/gridlabd_dockerhub_base:220217
+FROM slacgismo/gridlabd_dockerhub_base:220223
 
 
 ENV container docker


### PR DESCRIPTION
This PR fixes issue of docker base image upgrade from centos linux 8 to oraclelinux.

## Current issues
OracleLinux results in a larger image 4.19GB (oracle) vs 3.47GB (centos)

## Code changes
- [x] docker/Dockerfile

## Documentation changes
None

## Test and Validation Notes
Build image via `docker build .` in `docker/`
Check that validation passes