### PR TITLE
Updating GitHub workflow to new base

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: slacgismo/gridlabd_dockerhub_base:211105
+    container: slacgismo/gridlabd_dockerhub_base:220223
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: slacgismo/gridlabd_dockerhub_base:211105
+    container: slacgismo/gridlabd_dockerhub_base:220223
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Since centos linux 8 is depreciated now using a new base image based on oracle linux.