### PR TITLE
Add csv-geodata to KML converter

### DIFF
--- a/converters/Makefile.mk
+++ b/converters/Makefile.mk
@@ -8,6 +8,7 @@ python_requirements += converters/requirements.txt
 dist_pkgdata_DATA += converters/csv-ami2glm-ceus.py
 dist_pkgdata_DATA += converters/csv-ami2glm-rbsa.py
 dist_pkgdata_DATA += converters/csv-ceus2glm-ceus.py
+dist_pkgdata_DATA += converters/csv-geodata2kml.py
 dist_pkgdata_DATA += converters/csv-ica2glm-ica.py
 dist_pkgdata_DATA += converters/csv-noaa-weather2glm-weather.py
 dist_pkgdata_DATA += converters/csv-onpoint-weather2glm-weather.py

--- a/converters/autotest/test_csvgeodata2kml.csv
+++ b/converters/autotest/test_csvgeodata2kml.csv
@@ -1,0 +1,11 @@
+class,pole_length,pole_depth,ground_diameter,fiber_strength,name,tilt_angle,tilt_direction,latitude,longitude,configuration,weather,flags
+pole_configuration,40.0 ft,5.5 ft,9.87 in,8000 psi,pole_configuration_267462S,,,,,,,
+pole_configuration,50.0 ft,7.5 ft,,8000 psi,pole_configuration_280565E,,,,,,,
+pole_configuration,45.0 ft,6.5 ft,12.41 in,8000 psi,pole_configuration_306771E,,,,,,,
+pole_configuration,50.0 ft,8.5 ft,,8000 psi,pole_configuration_311032S,,,,,,,
+pole_configuration,45.0 ft,7.67 ft,12.41 in,8000 psi,pole_configuration_312148E,,,,,,,
+pole,,,,,pole_267462S,0 deg,0 deg,34.4002833340685,-116.962349732192,pole_configuration_267462S,weather,NONE
+pole,,,,,pole_280565E,0 deg,0 deg,33.9459351039498,-117.896961270715,pole_configuration_280565E,weather,NONE
+pole,,,,,pole_306771E,0 deg,0 deg,33.5318268108841,-117.767614658085,pole_configuration_306771E,weather,NONE
+pole,,,,,pole_311032S,0 deg,0 deg,33.84445388,-117.28241728,pole_configuration_311032S,weather,NONE
+pole,,,,,pole_312148E,0 deg,0 deg,36.1926329370634,-119.158966357457,pole_configuration_312148E,weather,NONE

--- a/converters/autotest/test_csvgeodata2kml.glm
+++ b/converters/autotest/test_csvgeodata2kml.glm
@@ -1,0 +1,9 @@
+#ifexist ../test_csvgeodata2kml.csv
+#define DIR=..
+#endif
+
+#convert ${DIR:-.}/test_csvgeodata2kml.csv -f csv-geodata -t kml -o test_csvgeodata2kml.kml
+
+#ifexist ../test_csvgeodata2kml.kml
+#on_exit 0 diff ../test_csvgeodata2kml.kml test_csvgeodata2kml.kml
+#endif

--- a/converters/autotest/test_csvgeodata2kml.kml
+++ b/converters/autotest/test_csvgeodata2kml.kml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+    <Document id="1">
+        <Placemark id="3">
+            <name>pole_267462S</name>
+            <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_267462S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;34.4002833340685&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-116.962349732192&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_267462S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
+            <Point id="2">
+                <coordinates>-116.96235,34.400283,0.0</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark id="5">
+            <name>pole_280565E</name>
+            <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_280565E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;33.9459351039498&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-117.89696127071501&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_280565E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
+            <Point id="4">
+                <coordinates>-117.896961,33.945935,0.0</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark id="7">
+            <name>pole_306771E</name>
+            <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_306771E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;33.531826810884105&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-117.76761465808501&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_306771E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
+            <Point id="6">
+                <coordinates>-117.767615,33.531827,0.0</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark id="9">
+            <name>pole_311032S</name>
+            <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_311032S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;33.84445388&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-117.28241728&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_311032S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
+            <Point id="8">
+                <coordinates>-117.282417,33.844454,0.0</coordinates>
+            </Point>
+        </Placemark>
+        <Placemark id="11">
+            <name>pole_312148E</name>
+            <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_312148E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;36.1926329370634&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-119.158966357457&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_312148E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
+            <Point id="10">
+                <coordinates>-119.158966,36.192633,0.0</coordinates>
+            </Point>
+        </Placemark>
+    </Document>
+</kml>

--- a/converters/autotest/test_csvgeodata2kml.kml
+++ b/converters/autotest/test_csvgeodata2kml.kml
@@ -5,35 +5,35 @@
             <name>pole_267462S</name>
             <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_267462S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;34.4002833340685&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-116.962349732192&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_267462S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
             <Point id="2">
-                <coordinates>-116.96235,34.400283,0.0</coordinates>
+                <coordinates>-116.962349732192,34.4002833340685,0.0</coordinates>
             </Point>
         </Placemark>
         <Placemark id="5">
             <name>pole_280565E</name>
             <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_280565E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;33.9459351039498&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-117.89696127071501&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_280565E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
             <Point id="4">
-                <coordinates>-117.896961,33.945935,0.0</coordinates>
+                <coordinates>-117.89696127071501,33.9459351039498,0.0</coordinates>
             </Point>
         </Placemark>
         <Placemark id="7">
             <name>pole_306771E</name>
             <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_306771E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;33.531826810884105&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-117.76761465808501&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_306771E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
             <Point id="6">
-                <coordinates>-117.767615,33.531827,0.0</coordinates>
+                <coordinates>-117.76761465808501,33.531826810884105,0.0</coordinates>
             </Point>
         </Placemark>
         <Placemark id="9">
             <name>pole_311032S</name>
             <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_311032S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;33.84445388&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-117.28241728&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_311032S&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
             <Point id="8">
-                <coordinates>-117.282417,33.844454,0.0</coordinates>
+                <coordinates>-117.28241728,33.84445388,0.0</coordinates>
             </Point>
         </Placemark>
         <Placemark id="11">
             <name>pole_312148E</name>
             <description>&lt;TABLE&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Class&lt;/TH&gt;&lt;TD&gt;pole&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Length&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Pole Depth&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Ground Diameter&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Fiber Strength&lt;/TH&gt;&lt;TD&gt;-&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Name&lt;/TH&gt;&lt;TD&gt;pole_312148E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Angle&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Tilt Direction&lt;/TH&gt;&lt;TD&gt;0 deg&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Latitude&lt;/TH&gt;&lt;TD&gt;36.1926329370634&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Longitude&lt;/TH&gt;&lt;TD&gt;-119.158966357457&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Configuration&lt;/TH&gt;&lt;TD&gt;pole_configuration_312148E&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Weather&lt;/TH&gt;&lt;TD&gt;weather&lt;/TD&gt;&lt;/TR&gt;&lt;TR&gt;&lt;TH ALIGN=LEFT&gt;Flags&lt;/TH&gt;&lt;TD&gt;NONE&lt;/TD&gt;&lt;/TR&gt;&lt;/TABLE&gt;</description>
             <Point id="10">
-                <coordinates>-119.158966,36.192633,0.0</coordinates>
+                <coordinates>-119.158966357457,36.1926329370634,0.0</coordinates>
             </Point>
         </Placemark>
     </Document>

--- a/converters/csv-geodata2kml.py
+++ b/converters/csv-geodata2kml.py
@@ -1,0 +1,57 @@
+"""Convert CSV geodata to KML
+"""
+import sys, os, getopt
+import pandas
+import simplekml
+
+EXENAME = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+LATITUDE = "latitude"
+LONGITUDE = "longitude"
+NAME = "name"
+CLASS = "class"
+
+def error(msg):
+    print(f'ERROR [{EXENAME}]: {msg}',file=sys.stderr)
+    sys.exit(1)
+
+def warning(msg):
+    print(f'WARNING [{EXENAME}]: {msg}',file=sys.stderr)
+
+def to_label(field):
+	return field.replace("_"," ").title()
+
+def to_data(value):
+	result = str(value)
+	if result == 'nan':
+		return "-"
+	else:
+		return result
+
+def convert (input_name, output_name=None, options={} ) : 
+
+	if not output_name:
+		output_name = os.path.basename(input_name) + ".kml"
+
+	data = pandas.read_csv(input_name)
+
+	if LATITUDE not in data.columns or LONGITUDE not in data.columns:
+		error("CSV does not include latitude and longitude fields")
+
+	kml = simplekml.Kml()
+
+	hidden = [LATITUDE,LONGITUDE,NAME,CLASS]
+
+	for n, row in data.iterrows():
+		lat = row[LATITUDE]
+		lon = row[LONGITUDE]
+		if -90 <= lat <= 90 and -180 <= lon <= 180:
+			try:
+				name = row[NAME]
+			except:
+				name = n
+			desc = "<TABLE>"
+			for field in data.columns:
+				desc += f"<TR><TH ALIGN=LEFT>{to_label(field)}</TH><TD>{to_data(row[field])}</TD></TR>"
+			desc += "</TABLE>"
+			pt = kml.newpoint(name=str(name),coords=[(lon,lat)],description=desc)
+	kml.save(output_name)

--- a/converters/requirements.txt
+++ b/converters/requirements.txt
@@ -2,3 +2,4 @@ folium==0.12.1
 pandas==1.1.4
 pysolar==0.9
 Pillow==9.0.0
+simplekml==1.3.6


### PR DESCRIPTION
This PR adds support for converting geodata CSV file to KML for use with Google Earth.

## Current issues

None

## Code changes

- [x] Add `converters/csv-geodata2kml.py`

## Documentation changes

See general converter docs

## Test and Validation Notes

- [x] Add `converters/autotest/test_csvgeodata2kml.{glm,csv,kml}`

Use https://earth.google.com/ [Projects] [Open] to load output KML files and view data.
