### PR TITLE
Add docker enable/fix for docker performance

### DIFF
--- a/source/gridlabd.in
+++ b/source/gridlabd.in
@@ -280,7 +280,7 @@ HAS_DOCKER="no"
 which docker > /dev/null 2>&1 && HAS_DOCKER="yes"
 if test "x$1" = "xdocker" ; then :
   if test "x$HAS_DOCKER" = "xno"; then :
-    echo "ERROR: docker is not installed"
+    echo "ERROR: docker is not installed" > /dev/stderr
     exit 1
   elif test "x$2" = "xhelp"; then :
     echo "Syntax: gridlabd docker <command>"
@@ -289,12 +289,13 @@ if test "x$1" = "xdocker" ; then :
     echo "  enable <image>   enable a docker image as the active image"
     echo "  disable          disable the active image"
     echo "  status           list the gridlabd images (active image is called 'gridlabd')"
+    echo "  fix-tsc          fix the docker configuration TSC performance option"
     exit 0
   elif test "x$2" = "xenable"; then :
     if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
       TSC=`grep '^tsc=' /Applications/Docker.app/Contents/Resources/linuxkit/cmdline | cut -f2 -d=`
       if test "x$TSC" != "xreliable"; then :
-        echo "WARNING: docker performance is poor if TSC is not 'reliable'. Use 'gridlabd docker fix' to correct this problem."
+        echo "WARNING: docker performance is poor if TSC is not 'reliable'. Use 'gridlabd docker fix-tsc' to correct this problem." > /dev/stderr
       fi
     fi
     if test $# -eq 3; then :
@@ -304,15 +305,15 @@ if test "x$1" = "xdocker" ; then :
       docker images | grep gridlabd
       exit 0
     else
-      echo "ERROR: missing docker image name"
+      echo "ERROR: missing docker image name" > /dev/stderr
       exit 1
     fi
-  elif test "x$2" = "xfix"; then :
+  elif test "x$2" = "xfix-tsc"; then :
     if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
       echo "tsc=reliable" >> "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"
       exit 0
     else
-      echo "ERROR: /Applications/Docker.app/Contents/Resources/linuxkit/cmdline does not exist"
+      echo "ERROR: /Applications/Docker.app/Contents/Resources/linuxkit/cmdline does not exist" > /dev/stderr
       exit 1
     fi
   elif test "x$2" = "xdisable" ; then :
@@ -325,7 +326,7 @@ if test "x$1" = "xdocker" ; then :
     docker images | grep gridlabd
     exit 0
   else
-    echo "Syntax: gridlabd --docker <command>|help"
+    echo "Syntax: gridlabd --docker <command>|help" > /dev/stderr
     exit 1
   fi
 fi

--- a/source/gridlabd.in
+++ b/source/gridlabd.in
@@ -1,19 +1,21 @@
 #! /bin/sh
-# Generated from gridlabd.m4sh by GNU Autoconf 2.69.
+# Generated from gridlabd.m4sh by GNU Autoconf 2.71.
 ## -------------------- ##
 ## M4sh Initialization. ##
 ## -------------------- ##
 
 # Be more Bourne compatible
 DUALCASE=1; export DUALCASE # for MKS sh
-if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
+as_nop=:
+if test ${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
+then :
   emulate sh
   NULLCMD=:
   # Pre-4.2 versions of Zsh do word splitting on ${1+"$@"}, which
   # is contrary to our usage.  Disable this feature.
   alias -g '${1+"$@"}'='"$@"'
   setopt NO_GLOB_SUBST
-else
+else $as_nop
   case `(set -o) 2>/dev/null` in #(
   *posix*) :
     set -o posix ;; #(
@@ -23,46 +25,46 @@ esac
 fi
 
 
+
+# Reset variables that may have inherited troublesome values from
+# the environment.
+
+# IFS needs to be set, to space, tab, and newline, in precisely that order.
+# (If _AS_PATH_WALK were called with IFS unset, it would have the
+# side effect of setting IFS to empty, thus disabling word splitting.)
+# Quoting is to prevent editors from complaining about space-tab.
 as_nl='
 '
 export as_nl
-# Printing a long string crashes Solaris 7 /usr/bin/printf.
-as_echo='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
-as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo
-as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo$as_echo
-# Prefer a ksh shell builtin over an external printf program on Solaris,
-# but without wasting forks for bash or zsh.
-if test -z "$BASH_VERSION$ZSH_VERSION" \
-    && (test "X`print -r -- $as_echo`" = "X$as_echo") 2>/dev/null; then
-  as_echo='print -r --'
-  as_echo_n='print -rn --'
-elif (test "X`printf %s $as_echo`" = "X$as_echo") 2>/dev/null; then
-  as_echo='printf %s\n'
-  as_echo_n='printf %s'
-else
-  if test "X`(/usr/ucb/echo -n -n $as_echo) 2>/dev/null`" = "X-n $as_echo"; then
-    as_echo_body='eval /usr/ucb/echo -n "$1$as_nl"'
-    as_echo_n='/usr/ucb/echo -n'
-  else
-    as_echo_body='eval expr "X$1" : "X\\(.*\\)"'
-    as_echo_n_body='eval
-      arg=$1;
-      case $arg in #(
-      *"$as_nl"*)
-	expr "X$arg" : "X\\(.*\\)$as_nl";
-	arg=`expr "X$arg" : ".*$as_nl\\(.*\\)"`;;
-      esac;
-      expr "X$arg" : "X\\(.*\\)" | tr -d "$as_nl"
-    '
-    export as_echo_n_body
-    as_echo_n='sh -c $as_echo_n_body as_echo'
-  fi
-  export as_echo_body
-  as_echo='sh -c $as_echo_body as_echo'
-fi
+IFS=" ""	$as_nl"
+
+PS1='$ '
+PS2='> '
+PS4='+ '
+
+# Ensure predictable behavior from utilities with locale-dependent output.
+LC_ALL=C
+export LC_ALL
+LANGUAGE=C
+export LANGUAGE
+
+# We cannot yet rely on "unset" to work, but we need these variables
+# to be unset--not just set to an empty or harmless value--now, to
+# avoid bugs in old shells (e.g. pre-3.0 UWIN ksh).  This construct
+# also avoids known problems related to "unset" and subshell syntax
+# in other old shells (e.g. bash 2.01 and pdksh 5.2.14).
+for as_var in BASH_ENV ENV MAIL MAILPATH CDPATH
+do eval test \${$as_var+y} \
+  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
+done
+
+# Ensure that fds 0, 1, and 2 are open.
+if (exec 3>&0) 2>/dev/null; then :; else exec 0</dev/null; fi
+if (exec 3>&1) 2>/dev/null; then :; else exec 1>/dev/null; fi
+if (exec 3>&2)            ; then :; else exec 2>/dev/null; fi
 
 # The user is always right.
-if test "${PATH_SEPARATOR+set}" != set; then
+if ${PATH_SEPARATOR+false} :; then
   PATH_SEPARATOR=:
   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
     (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 ||
@@ -70,13 +72,6 @@ if test "${PATH_SEPARATOR+set}" != set; then
   }
 fi
 
-
-# IFS
-# We need space, tab and new line, in precisely that order.  Quoting is
-# there to prevent editors from complaining about space-tab.
-# (If _AS_PATH_WALK were called with IFS unset, it would disable word
-# splitting by setting IFS to empty value.)
-IFS=" ""	$as_nl"
 
 # Find who we are.  Look in the path if we contain no directory separator.
 as_myself=
@@ -86,8 +81,12 @@ case $0 in #((
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    test -r "$as_dir/$0" && as_myself=$as_dir/$0 && break
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    test -r "$as_dir$0" && as_myself=$as_dir$0 && break
   done
 IFS=$as_save_IFS
 
@@ -99,40 +98,22 @@ if test "x$as_myself" = x; then
   as_myself=$0
 fi
 if test ! -f "$as_myself"; then
-  $as_echo "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
+  printf "%s\n" "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
   exit 1
 fi
 
-# Unset variables that we do not need and which cause bugs (e.g. in
-# pre-3.0 UWIN ksh).  But do not cause bugs in bash 2.01; the "|| exit 1"
-# suppresses any "Segmentation fault" message there.  '((' could
-# trigger a bug in pdksh 5.2.14.
-for as_var in BASH_ENV ENV MAIL MAILPATH
-do eval test x\${$as_var+set} = xset \
-  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
-done
-PS1='$ '
-PS2='> '
-PS4='+ '
-
-# NLS nuisances.
-LC_ALL=C
-export LC_ALL
-LANGUAGE=C
-export LANGUAGE
-
-# CDPATH.
-(unset CDPATH) >/dev/null 2>&1 && unset CDPATH
 
 if test "x$CONFIG_SHELL" = x; then
-  as_bourne_compatible="if test -n \"\${ZSH_VERSION+set}\" && (emulate sh) >/dev/null 2>&1; then :
+  as_bourne_compatible="as_nop=:
+if test \${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
+then :
   emulate sh
   NULLCMD=:
   # Pre-4.2 versions of Zsh do word splitting on \${1+\"\$@\"}, which
   # is contrary to our usage.  Disable this feature.
   alias -g '\${1+\"\$@\"}'='\"\$@\"'
   setopt NO_GLOB_SUBST
-else
+else \$as_nop
   case \`(set -o) 2>/dev/null\` in #(
   *posix*) :
     set -o posix ;; #(
@@ -152,36 +133,46 @@ as_fn_success || { exitcode=1; echo as_fn_success failed.; }
 as_fn_failure && { exitcode=1; echo as_fn_failure succeeded.; }
 as_fn_ret_success || { exitcode=1; echo as_fn_ret_success failed.; }
 as_fn_ret_failure && { exitcode=1; echo as_fn_ret_failure succeeded.; }
-if ( set x; as_fn_ret_success y && test x = \"\$1\" ); then :
+if ( set x; as_fn_ret_success y && test x = \"\$1\" )
+then :
 
-else
+else \$as_nop
   exitcode=1; echo positional parameters were not saved.
 fi
 test x\$exitcode = x0 || exit 1
+blah=\$(echo \$(echo blah))
+test x\"\$blah\" = xblah || exit 1
 test -x / || exit 1"
   as_suggested=""
-  if (eval "$as_required") 2>/dev/null; then :
+  if (eval "$as_required") 2>/dev/null
+then :
   as_have_required=yes
-else
+else $as_nop
   as_have_required=no
 fi
-  if test x$as_have_required = xyes && (eval "$as_suggested") 2>/dev/null; then :
+  if test x$as_have_required = xyes && (eval "$as_suggested") 2>/dev/null
+then :
 
-else
+else $as_nop
   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 as_found=false
 for as_dir in /bin$PATH_SEPARATOR/usr/bin$PATH_SEPARATOR$PATH
 do
   IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
   as_found=:
   case $as_dir in #(
 	 /*)
 	   for as_base in sh bash ksh sh5; do
 	     # Try only shells that exist, to save several forks.
-	     as_shell=$as_dir/$as_base
+	     as_shell=$as_dir$as_base
 	     if { test -f "$as_shell" || test -f "$as_shell.exe"; } &&
-		    { $as_echo "$as_bourne_compatible""$as_required" | as_run=a "$as_shell"; } 2>/dev/null; then :
+		    as_run=a "$as_shell" -c "$as_bourne_compatible""$as_required" 2>/dev/null
+then :
   CONFIG_SHELL=$as_shell as_have_required=yes
 		   break 2
 fi
@@ -189,14 +180,21 @@ fi
        esac
   as_found=false
 done
-$as_found || { if { test -f "$SHELL" || test -f "$SHELL.exe"; } &&
-	      { $as_echo "$as_bourne_compatible""$as_required" | as_run=a "$SHELL"; } 2>/dev/null; then :
-  CONFIG_SHELL=$SHELL as_have_required=yes
-fi; }
 IFS=$as_save_IFS
+if $as_found
+then :
+
+else $as_nop
+  if { test -f "$SHELL" || test -f "$SHELL.exe"; } &&
+	      as_run=a "$SHELL" -c "$as_bourne_compatible""$as_required" 2>/dev/null
+then :
+  CONFIG_SHELL=$SHELL as_have_required=yes
+fi
+fi
 
 
-      if test "x$CONFIG_SHELL" != x; then :
+      if test "x$CONFIG_SHELL" != x
+then :
   export CONFIG_SHELL
              # We cannot yet assume a decent shell, so we have to provide a
 # neutralization value for shells without unset; and this also
@@ -214,18 +212,19 @@ esac
 exec $CONFIG_SHELL $as_opts "$as_myself" ${1+"$@"}
 # Admittedly, this is quite paranoid, since all the known shells bail
 # out after a failed `exec'.
-$as_echo "$0: could not re-execute with $CONFIG_SHELL" >&2
+printf "%s\n" "$0: could not re-execute with $CONFIG_SHELL" >&2
 exit 255
 fi
 
-    if test x$as_have_required = xno; then :
-  $as_echo "$0: This script requires a shell more modern than all"
-  $as_echo "$0: the shells that I found on your system."
-  if test x${ZSH_VERSION+set} = xset ; then
-    $as_echo "$0: In particular, zsh $ZSH_VERSION has bugs and should"
-    $as_echo "$0: be upgraded to zsh 4.3.4 or later."
+    if test x$as_have_required = xno
+then :
+  printf "%s\n" "$0: This script requires a shell more modern than all"
+  printf "%s\n" "$0: the shells that I found on your system."
+  if test ${ZSH_VERSION+y} ; then
+    printf "%s\n" "$0: In particular, zsh $ZSH_VERSION has bugs and should"
+    printf "%s\n" "$0: be upgraded to zsh 4.3.4 or later."
   else
-    $as_echo "$0: Please tell bug-autoconf@gnu.org about your system,
+    printf "%s\n" "$0: Please tell bug-autoconf@gnu.org about your system,
 $0: including any error possibly output before this
 $0: message. Then install a modern shell, or manually run
 $0: the script under such a shell if you do have one."
@@ -251,6 +250,16 @@ as_fn_unset ()
   { eval $1=; unset $1;}
 }
 as_unset=as_fn_unset
+
+# as_fn_nop
+# ---------
+# Do nothing but, unlike ":", preserve the value of $?.
+as_fn_nop ()
+{
+  return $?
+}
+as_nop=as_fn_nop
+
 ## -------------------- ##
 ## Main body of script. ##
 ## -------------------- ##
@@ -282,6 +291,12 @@ if test "x$1" = "xdocker" ; then :
     echo "  status           list the gridlabd images (active image is called 'gridlabd')"
     exit 0
   elif test "x$2" = "xenable"; then :
+    if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
+      TSC=`grep '^tsc=' /Applications/Docker.app/Contents/Resources/linuxkit/cmdline | cut -f2 -d=`
+      if test "x$TSC" != "xreliable"; then :
+        echo "WARNING: docker performance is poor if TSC is not 'reliable'. Use 'gridlabd docker fix' to correct this problem."
+      fi
+    fi
     if test $# -eq 3; then :
       docker inspect $3 > /dev/null 2>&1 || docker pull $3
       docker tag $3 gridlabd
@@ -290,6 +305,14 @@ if test "x$1" = "xdocker" ; then :
       exit 0
     else
       echo "ERROR: missing docker image name"
+      exit 1
+    fi
+  elif test "x$2" = "xfix"; then :
+    if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
+      echo "tsc=reliable" >> "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"
+      exit 0
+    else
+      echo "ERROR: /Applications/Docker.app/Contents/Resources/linuxkit/cmdline does not exist"
       exit 1
     fi
   elif test "x$2" = "xdisable" ; then :
@@ -330,9 +353,10 @@ export LIB="-L$libdir -L/usr/local/lib -L/usr/lib"
 export LDFLAGS="${LIB} ${PYLDFLAGS} ${LDFLAGS}"
 export PYTHONPATH=.:${GLD_ETC}${PYTHONPATH:+:}${PYTHONPATH}
 
-if test "x$GLPATH" = x; then :
+if test "x$GLPATH" = x
+then :
   export GLPATH="$pkglibdir:$pkgdatadir"
-else
+else $as_nop
   export GLPATH="$pkglibdir:$pkgdatadir:$GLPATH"
 fi
 
@@ -355,16 +379,19 @@ elif test "x$1" = "xvalgrind" ; then :
   exit 0
 fi
 
-if test -f "${pkgdatadir}/gridlabd.rc"; then :
+if test -f "${pkgdatadir}/gridlabd.rc"
+then :
   . ${pkgdatadir}/gridlabd.rc
 fi
 
-if test -f "${GLD_ETC}/$1.py"; then :
+if test -f "${GLD_ETC}/$1.py"
+then :
   export PYTHONPATH=$GLD_ETC; /usr/local/bin/python3 -m "$@" ; exit $?
 fi
 
-if test -x "${bindir}/gridlabd-$1"; then :
+if test -x "${bindir}/gridlabd-$1"
+then :
   "${bindir}/gridlabd"-"$@"
-else
+else $as_nop
   "${bindir}/gridlabd.bin" "$@" && "${bindir}/gridlabd-version" check -w
 fi

--- a/source/gridlabd.m4sh
+++ b/source/gridlabd.m4sh
@@ -25,12 +25,13 @@ if test "x$1" = "xdocker" ; then :
     echo "  enable <image>   enable a docker image as the active image"
     echo "  disable          disable the active image"
     echo "  status           list the gridlabd images (active image is called 'gridlabd')"
+    echo "  fix-tsc          fix the docker configuration TSC performance option"
     exit 0
   elif test "x$2" = "xenable"; then :
     if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
       TSC=`grep '^tsc=' /Applications/Docker.app/Contents/Resources/linuxkit/cmdline | cut -f2 -d=`
       if test "x$TSC" != "xreliable"; then :
-        echo "WARNING: docker performance is poor if TSC is not 'reliable'. Use 'gridlabd docker fix' to correct this problem." > /dev/stderr
+        echo "WARNING: docker performance is poor if TSC is not 'reliable'. Use 'gridlabd docker fix-tsc' to correct this problem." > /dev/stderr
       fi
     fi
     if test $# -eq 3; then :
@@ -43,7 +44,7 @@ if test "x$1" = "xdocker" ; then :
       echo "ERROR: missing docker image name" > /dev/stderr
       exit 1
     fi
-  elif test "x$2" = "xfix"; then :
+  elif test "x$2" = "xfix-tsc"; then :
     if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
       echo "tsc=reliable" >> "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"
       exit 0

--- a/source/gridlabd.m4sh
+++ b/source/gridlabd.m4sh
@@ -16,7 +16,7 @@ HAS_DOCKER="no"
 which docker > /dev/null 2>&1 && HAS_DOCKER="yes"
 if test "x$1" = "xdocker" ; then :
   if test "x$HAS_DOCKER" = "xno"; then :
-    echo "ERROR: docker is not installed"
+    echo "ERROR: docker is not installed" > /dev/stderr
     exit 1
   elif test "x$2" = "xhelp"; then :
     echo "Syntax: gridlabd docker <command>"
@@ -27,6 +27,12 @@ if test "x$1" = "xdocker" ; then :
     echo "  status           list the gridlabd images (active image is called 'gridlabd')"
     exit 0
   elif test "x$2" = "xenable"; then :
+    if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
+      TSC=`grep '^tsc=' /Applications/Docker.app/Contents/Resources/linuxkit/cmdline | cut -f2 -d=`
+      if test "x$TSC" != "xreliable"; then :
+        echo "WARNING: docker performance is poor if TSC is not 'reliable'. Use 'gridlabd docker fix' to correct this problem." > /dev/stderr
+      fi
+    fi
     if test $# -eq 3; then :
       docker inspect $3 > /dev/null 2>&1 || docker pull $3
       docker tag $3 gridlabd
@@ -34,7 +40,15 @@ if test "x$1" = "xdocker" ; then :
       docker images | grep gridlabd
       exit 0
     else
-      echo "ERROR: missing docker image name"
+      echo "ERROR: missing docker image name" > /dev/stderr
+      exit 1
+    fi
+  elif test "x$2" = "xfix"; then :
+    if test -f "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"; then :
+      echo "tsc=reliable" >> "/Applications/Docker.app/Contents/Resources/linuxkit/cmdline"
+      exit 0
+    else
+      echo "ERROR: /Applications/Docker.app/Contents/Resources/linuxkit/cmdline does not exist" > /dev/stderr
       exit 1
     fi
   elif test "x$2" = "xdisable" ; then :
@@ -47,7 +61,7 @@ if test "x$1" = "xdocker" ; then :
     docker images | grep gridlabd
     exit 0
   else
-    echo "Syntax: gridlabd --docker <command>|help"
+    echo "Syntax: gridlabd --docker <command>|help" > /dev/stderr
     exit 1
   fi
 fi


### PR DESCRIPTION
This PR fixes docker enable so that it considers whether docker is configured correctly.

## Current issues

None

## Code changes

- [x] Update `source/gridlabd.m4sh` to detect the missing configuration and add it.

## Documentation changes

None

## Test and Validation Notes

The fix for docker performance problem on Darwin requires the addition of the line `tsc=reliable` in the file `/Applications/Docker.app/Contents/Resources/linuxkit/cmdline`. 

Use `gridlabd docker enable slacgismo/gridlabd:latest` to detect whether the line is missing.  

Use `gridlabd docker fix-tic` to correct the performance problem. This may require restarting docker.
