### PR TITLE
Add covered conductor

### DIFF
--- a/module/powerflow/overhead_line.cpp
+++ b/module/powerflow/overhead_line.cpp
@@ -32,6 +32,9 @@ overhead_line::overhead_line(MODULE *mod) : line(mod)
             PT_double, "ice_thickness[in]", get_ice_thickness_offset(),
                 PT_DESCRIPTION, "thickness of ice build-up on lines",
 
+            PT_bool, "is_covered", get_is_covered_offset(),
+            	PT_DESCRIPTION, "flag to indicate whether conductor is covered",
+
 			NULL) < 1) GL_THROW("unable to publish overhead_line properties in %s",__FILE__);
 
 		if (gl_publish_function(oclass,	"create_fault", (FUNCTIONADDR)create_fault_ohline)==NULL)

--- a/module/powerflow/overhead_line.h
+++ b/module/powerflow/overhead_line.h
@@ -17,6 +17,7 @@ public:
     static overhead_line *defaults;
 public:
     GL_ATOMIC(double,ice_thickness);
+    GL_ATOMIC(bool,is_covered);
 public:
 	void recalc(void);
 public:


### PR DESCRIPTION
This PR add support for covered conductors on overhead lines.

## Current issues

1. This is ignored by fault analysis for now.

## Code changes

- [x] Add `is_covered` property to `module/powerflow/overhead_line.{h, cpp}`.

## Documentation changes

None

## Test and Validation Notes

None
