### PR TITLE
Fix repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ _Note_: When a merge is performed, the PR is automatically closed and the branch
 
 ## Documentation changes
 
-All documentation changes arising from new features and capabilities should be made to this repository's wiki pages at https://github.com/slacgismo/gridlabd/wiki. Fixes or correction to GridLAB-D's online documentation should be made to https://gridlab-d.shoutwiki.org/, subject to review and approval by the PNNL team.
+All documentation changes arising from new features and capabilities should be made to this repository's wiki pages at https://source.gridlabd.us/wiki. Fixes or correction to GridLAB-D's online documentation should be made to https://gridlab-d.shoutwiki.org/, subject to review and approval by the PNNL team.
 
 # Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![master](https://github.com/slacgismo/gridlabd/actions/workflows/master.yml/badge.svg?branch=master) 
-![develop](https://github.com/slacgismo/gridlabd/workflows/develop/badge.svg?branch=develop)
+![master](https://source.gridlabd.us/actions/workflows/master.yml/badge.svg?branch=master) 
+![develop](https://source.gridlabd.us/workflows/develop/badge.svg?branch=develop)
 
 The documentation for this project is located at http://docs.gridlabd.us/.
 
@@ -21,15 +21,15 @@ The following projects are actively contributing to HiPAS GridLAB-D at this time
 
 # User quick start
 
-The preferred method for running HiPAS GridLAB-D is to download the SLAC master image from docker hub (see https://hub.docker.com/repository/docker/slacgismo/gridlabd).  You must install the docker daemon to use docker images.  See https://www.docker.com/get-started for details.
+The preferred method for running HiPAS GridLAB-D is to download the SLAC master image from docker hub (see https://hub.docker.com/repository/docker/hipas/gridlabd).  You must install the docker daemon to use docker images.  See https://www.docker.com/get-started for details.
 
 Once you have installed docker, you may issue the following commands to run GridLAB-D at the command line:
 ~~~
-  host% docker run -it -v $PWD:/model slacgismo/gridlabd:latest gridlabd -W /model [load-options] [filename.glm] [run-options] 
+  host% docker run -it -v $PWD:/model hipas/gridlabd:latest gridlabd -W /model [load-options] [filename.glm] [run-options] 
 ~~~ 
 On many systems, an alias can be used to make this a simple command that resembles the command you would normally issue to run a host-based installation:
 ~~~
-  host% alias gridlabd='docker run -it -v $PWD:/tmp slacgismo/gridlabd:latest gridlabd'
+  host% alias gridlabd='docker run -it -v $PWD:/tmp hipas/gridlabd:latest gridlabd'
 ~~~
 Note that this alias will interfere with any host-based installation. You should use the `gridlabd docker` command to manage the use of docker images concurrently with host-based installations.
 
@@ -37,7 +37,7 @@ Windows users can accomplish something similar using a small batch file named `g
 ~~~
 @echo off
 for /f "delims=" %%i in ('cd') do set PWD=%%i
-docker run -it -v "%PWD%:/tmp" slacgismo/gridlabd:latest gridlabd %*
+docker run -it -v "%PWD%:/tmp" hipas/gridlabd:latest gridlabd %*
 ~~~
 
 # Developer quick start
@@ -46,7 +46,7 @@ docker run -it -v "%PWD%:/tmp" slacgismo/gridlabd:latest gridlabd %*
 
 Normally on Linux and Mac OS X developers should use the `install.sh` script to setup the system, perform the initial build, and install GridLAB-D for all users on the system. 
 ~~~
-host% git clone https://github.com/slacgismo/gridlabd gridlabd
+host% git clone https://source.gridlabd.us/ gridlabd
 host% gridlabd/install.sh
 ~~~
 ### AWS EC2 Installation 
@@ -58,7 +58,7 @@ host% export PATH=/usr/local/bin:$PATH
 2) Change work dictionary and clone GitHub repository
 ~~~
 host% cd /usr/local/src
-host% git clone https://github.com/slacgismo/gridlabd gridlabd
+host% git clone https://source.gridlabd.us/ gridlabd
 ~~~
 3) Run installation 
 ~~~ 
@@ -70,7 +70,7 @@ If you have modified the branch name or version information, you must reconfigur
 
 Each build of HiPAS GridLAB-D will be installed in `/usr/local/opt/gridlabd`. Links to the active version are added to the `/usr/local/bin` folder, so this folder must be included in the path for all users, e.g., as specified in `/etc/profile` or `/etc/profile.d`. Additional links are created in `/usr/local/lib` and `/usr/local/share`, as needed. 
 
-You may use the `gridlabd version` command to manage which version is active on the system. See the [`gridlabd version`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Version.md) command for details.
+You may use the `gridlabd version` command to manage which version is active on the system. See the [`gridlabd version`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Version.md) command for details.
 
 You use `make install` to build only. To use an inactive build run the `gridlabd` command of that build instead of running the active version.  For example, if you only built `4.2.13-201019-develop` then you can run `/usr/local/opt/gridlabd/4.2.13-201019-develop/bin/gridlabd` to run it instead of running `/usr/local/bin/gridlabd`.
 
@@ -112,7 +112,7 @@ Generally, running HiPAS GridLAB-D on Docker is preferred because it is usually 
 
 ## Building and Debugging
 
-You can configure a debugging version using `make reconfigure-debug`.  When debugging is enabled you can use the [`gridlabd trace`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Trace.md) command and the [`gridlabd gdb`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Gdb.md) (for linux) or [`gridlabd lldb`](http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Lldb.md) (for Mac OSX) commands to debug a simulation.
+You can configure a debugging version using `make reconfigure-debug`.  When debugging is enabled you can use the [`gridlabd trace`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Trace.md) command and the [`gridlabd gdb`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Gdb.md) (for linux) or [`gridlabd lldb`](http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Lldb.md) (for Mac OSX) commands to debug a simulation.
 
 ## Notes
 - The version number should contain the _branch-name_.  If not, use the `which gridlabd` command to check that the path is correct.
@@ -136,10 +136,10 @@ Chassin, D.P., et al., "GridLAB-D Version _major_._minor_._patch_-_build_ (_bran
 You may use the `--cite` command option to obtain the correct citation for your version:
 ~~~
 host% gridlabd --cite
-Chassin, D.P., et al. "GridLAB-D 4.2.0-191008 (fix_python_validate) DARWIN", (2019) [online]. Available at https://github.com/slacgismo/gridlabd/commit/dfc392dc0208419ce9be0706f699fdd9a11e3f5b, Accessed on: Oct. 8, 2019.
+Chassin, D.P., et al. "GridLAB-D 4.2.0-191008 (fix_python_validate) DARWIN", (2019) [online]. Available at https://source.gridlabd.us/commit/dfc392dc0208419ce9be0706f699fdd9a11e3f5b, Accessed on: Oct. 8, 2019.
 ~~~
 This will allow anyone to identify the exact version you are using to obtain it from GitHub.
 
 ## Contributions
 
-Please see https://github.com/slacgismo/gridlabd/blob/master/CONTRIBUTING.md for information on making contributions to this repository.
+Please see https://source.gridlabd.us/blob/master/CONTRIBUTING.md for information on making contributions to this repository.

--- a/cloud/websites/code.gridlabd.us/index.html
+++ b/cloud/websites/code.gridlabd.us/index.html
@@ -1,8 +1,8 @@
 <HTML>
 <HEAD>
-<META HTTP-EQUIV="refresh" CONTENT="0,url=https://github.com/slacgismo/gridlabd" />
+<META HTTP-EQUIV="refresh" CONTENT="0,url=https://source.gridlabd.us" />
 </HEAD>
 <BODY>
-Redirecting to <A HREF="https://github.com/slacgismo/gridlabd">https://github.com/slacgismo/gridlabd</A>...
+Redirecting to <A HREF="https://source.gridlabd.us/">https://source.gridlabd.us/</A>...
 </BODY>
 </HTML>

--- a/cloud/websites/docs.gridlabd.us/index.html
+++ b/cloud/websites/docs.gridlabd.us/index.html
@@ -1,8 +1,8 @@
 <HTML>
 <HEAD>
-<META HTTP-EQUIV="refresh" CONTENT="0,url=http://docs.slacgismo.org/index.html?owner=slacgismo&project=gridlabd" />
+<META HTTP-EQUIV="refresh" CONTENT="0,url=http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd" />
 </HEAD>
 <BODY>
-Redirecting to <A HREF="http://docs.slacgismo.org/index.html?owner=slacgismo&project=gridlabd">http://docs.slacgismo.org/index.html?owner=slacgismo&project=gridlabd</A>...
+Redirecting to <A HREF="http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd">http://docs.hipas.org/index.html?owner=hipas&project=gridlabd</A>...
 </BODY>
 </HTML>

--- a/cloud/websites/geodata.gridlabd.us/index.html
+++ b/cloud/websites/geodata.gridlabd.us/index.html
@@ -1,6 +1,6 @@
 <HTML>
 <HEAD>
-    <META HTTP-EQUIV="refresh" CONTENT="0;URL=https://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Geodata.md"
+    <META HTTP-EQUIV="refresh" CONTENT="0;URL=https://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Subcommand&doc=/Subcommand/Geodata.md"
 </HEAD>
 <BODY>
     Redirecting...

--- a/cloud/websites/status.gridlabd.us/active.html
+++ b/cloud/websites/status.gridlabd.us/active.html
@@ -96,7 +96,7 @@
 
             start = new Date(prompt("Enter report start date (yyyy-mm-dd): ",stop.getFullYear() + "-" + (stop.getMonth()+1) + "-01"));
 
-            r = run_query("/repos/slacgismo/gridlabd/issues?state=open&per_page=100&sort=updated&direction=asc&since="+start+"T00:00:00Z");
+            r = run_query("/repos/hipas/gridlabd/issues?state=open&per_page=100&sort=updated&direction=asc&since="+start+"T00:00:00Z");
             item_number = 1;
             if ( r.status == 200 )
             {
@@ -154,7 +154,7 @@
                             if ( start <= closed_dt && closed_dt <= stop )
                             {
                                 // console.info("*** output ***");
-                                report += "\n" + item_number + ". " + title + " ([" + number + "](https://github.com/slacgismo/gridlabd/issues/" + number + ") updated " + updated_at.substring(0,updated_at.indexOf("T")) + ")\n";
+                                report += "\n" + item_number + ". " + title + " ([" + number + "](https://source.gridlabd.us/issues/" + number + ") updated " + updated_at.substring(0,updated_at.indexOf("T")) + ")\n";
                                 // report += "Opened " + created_at.substring(0,created_at.indexOf("T")) + "\n";
                                 //report += "\n" + body + "\n\n";
                                 count += 1;

--- a/cloud/websites/status.gridlabd.us/issues-open.html
+++ b/cloud/websites/status.gridlabd.us/issues-open.html
@@ -94,7 +94,7 @@
                 set_default("token",token);
             }
 
-            r = run_query("/repos/slacgismo/gridlabd/issues?state=open&per_page=100&sort=updated&direction=desc");
+            r = run_query("/repos/hipas/gridlabd/issues?state=open&per_page=100&sort=updated&direction=desc");
             if ( r.status == 200 )
             {
                 report = "GridLAB-D Open Issues as of " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";

--- a/cloud/websites/status.gridlabd.us/pulls-closed.html
+++ b/cloud/websites/status.gridlabd.us/pulls-closed.html
@@ -95,7 +95,7 @@
 
             start = new Date(prompt("Enter report start date (yyyy-mm-dd): ",stop.getFullYear() + "-" + (stop.getMonth()+1) + "-01"));
 
-            r = run_query("/repos/slacgismo/gridlabd/pulls?state=closed&per_page=100&sort=updated&direction=desc");
+            r = run_query("/repos/hipas/gridlabd/pulls?state=closed&per_page=100&sort=updated&direction=desc");
             if ( r.status == 200 )
             {
                 report = "GridLAB-D Pull Requests Completed for period " + start.getFullYear() + "-" + (start.getMonth()+1) + "-" + start.getDate() + " - " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";

--- a/cloud/websites/status.gridlabd.us/pulls-open.html
+++ b/cloud/websites/status.gridlabd.us/pulls-open.html
@@ -94,7 +94,7 @@
                 set_default("token",token);
             }
 
-            r = run_query("/repos/slacgismo/gridlabd/pulls?state=open&per_page=100&sort=updated&direction=desc");
+            r = run_query("/repos/hipas/gridlabd/pulls?state=open&per_page=100&sort=updated&direction=desc");
             if ( r.status == 200 )
             {
                 report = "GridLAB-D Open Pull Requests as of " + stop.getFullYear() + "-" + (stop.getMonth()+1) + "-" + stop.getDate() + "\n";

--- a/converters/json2html.py
+++ b/converters/json2html.py
@@ -277,7 +277,7 @@ def get_popup(name,tag):
         label = item.title().replace("_","&nbsp;")
         try:
             module = data['classes'][value]['module']
-            value = f'<A TARGET="_blank" HREF="https://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=master&folder=/Module/Powerflow&doc=/Module/{module.title()}/{value.title()}.md">{value}</A>'
+            value = f'<A TARGET="_blank" HREF="https://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&branch=master&folder=/Module/Powerflow&doc=/Module/{module.title()}/{value.title()}.md">{value}</A>'
         except:
             pass
         popup += f'<TR><TH>{label}</TH><TD>&nbsp;</TD><TD>{value}</TD></TR>\n'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM slacgismo/gridlabd_dockerhub_base:220322
+FROM hipas/gridlabd_base:220322
 
 
 ENV container docker
-ENV REPO=https://github.com/slacgismo/gridlabd
+ENV REPO=https://source.gridlabd.us/
 ARG BRANCH
 RUN echo "Building $BRANCH"
 ENV ENABLE=gismo

--- a/docker/gridlabd.sh
+++ b/docker/gridlabd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REPO=${REPO:-https://github.com/slacgismo/gridlabd}
+REPO=${REPO:-https://source.gridlabd.us/}
 BRANCH=${BRANCH:-master}
 echo "
 #####################################

--- a/docs/Cloud/AWS.md
+++ b/docs/Cloud/AWS.md
@@ -104,7 +104,7 @@ The following command connects to an EC2 instance and installs GridLAB-D:
 ~~~
 user@localhost$ ssh -i my-key.pem ec2-user@my-instance-ip
 ec2-user@my-instance-ip$ sudo yum install git -y
-ec2-user@my-instance-ip$ git clone https://github.com/slacgismo/gridlabd gridlabd
+ec2-user@my-instance-ip$ git clone https://source.gridlabd.us/ gridlabd
 ec2-user@my-instance-ip$ gridlabd/install.sh
 ~~~
 

--- a/docs/Command/Cite.md
+++ b/docs/Command/Cite.md
@@ -14,11 +14,11 @@ Supported formats are `json` and `bibtex`.
 
 # Example
 
-The following example prints the citation text for the GitHub user `slacgismo`'s MacOS `master` version of GridLAB-D 4.2 built on October 9, 2019.
+The following example prints the citation text for the version of GridLAB-D 4.2 built on October 9, 2019.
 
 ~~~
 bash$ gridlabd --cite
-Chassin, D.P., et al., "GridLAB-D 4.2.0-191009 (master) Darwin" (2019) [online]. Available at https://github.com/slacgismo/gridlabd. Accessed Oct. 9, 2019
+Chassin, D.P., et al., "GridLAB-D 4.2.0-191009 (master) Darwin" (2019) [online]. Available at https://source.gridlabd.us/. Accessed Oct. 9, 2019
 ~~~
 
 # See also

--- a/docs/Command/Origin.md
+++ b/docs/Command/Origin.md
@@ -20,13 +20,13 @@ The following is the output for a clean build of a branch
 
 ~~~
 bash$ gridlabd --origin
-# https://github.com/slacgismo/gridlabd/commits/d2fca77b4985e28452e72e259ce6bf77d2d454b1
+# https://source.gridlabd.us/commits/d2fca77b4985e28452e72e259ce6bf77d2d454b1
 ~~~
 
 The following example includes diff output resulting from local changes to the code
 
 ~~~
-# https://github.com/slacgismo/gridlabd/commits/ff655ab92b650b2373d02b44bf884334d40faf06
+# https://source.gridlabd.us/commits/ff655ab92b650b2373d02b44bf884334d40faf06
 #  M source/Makefile.mk
 #  M utilities/build_number
 # ?? utilities/update_origin.sh

--- a/docs/Developer/Install.md
+++ b/docs/Developer/Install.md
@@ -47,7 +47,7 @@ bash$ curl -L http://code.gridlabd.us/<branch>/install.sh | bash
 Manual installation is discouraged because the process is complex, highly error-prone, and varies widely from one platform to another.  However, it is necessary on platforms that are not supported by the automated installation script.  The general approach is roughly as follows, keeping in mind that the specific will vary from one system to another, and you may need to install certain tools and libraries to be successful.
 
 ~~~
-bash$ git clone https://github.com/slacgismo/gridlabd gridlabd
+bash$ git clone https://source.gridlabd.us/ gridlabd
 bash$ cd gridlabd
 bash$ autoreconf -isf
 bash$ ./configure

--- a/docs/Developers.md
+++ b/docs/Developers.md
@@ -1,14 +1,13 @@
-Software developers and engineers are welcome to contribute to HiPAS GridLAB-D. The source code to HiPAS is available to the public through the [GitHub SLAC Gismo GridLAB-D project](https://github.com/slacgismo/gridlabd). 
+Software developers and engineers are welcome to contribute to HiPAS GridLAB-D. The source code to HiPAS is available to the public through the [GitHub SLAC Gismo GridLAB-D project](https://source.gridlabd.us/). 
 
 ## Developer Resources
 
-  - [Source code](https://github.com/slacgismo/gridlabd)
-  - [Issues](https://github.com/slacgismo/gridlabd/issues)
-  - [Pull requests](https://github.com/slacgismo/gridlabd/pulls)
-  - [Projects](https://github.com/slacgismo/gridlabd/projects)
-  - [Wiki](https://github.com/slacgismo/gridlabd)
-  - [Team Discussions](https://github.com/slacgismo/teams/gridlab-d/discussions)
-  - [HiPAS GridLAB-D URLs](https://s3.us-west-1.amazonaws.com/gridlabd.us/websites.txt)
+  - [Source code](https://source.gridlabd.us/)
+  - [Issues](https://source.gridlabd.us/issues)
+  - [Pull requests](https://source.gridlabd.us/pulls)
+  - [Projects](https://source.gridlabd.us/projects)
+  - [Wiki](https://source.gridlabd.us/wiki)
+  - [Discussions](https://source.gridlabd.us/discussions)
 
 Developers should consult the [[/Developer/README]] for information about modifying and contributing to HiPAS GridLAB-D.
 
@@ -17,7 +16,7 @@ Developers should consult the [[/Developer/README]] for information about modify
 You can set up your system to host development and build GridLAB-D from source code using the installation script. 
 
 ~~~
-bash$ git clone https://github.com/slacgismo/gridlabd
+bash$ git clone https://source.gridlabd.us/ gridlabd
 bash$ cd gridlabd
 bash$ ./install.sh
 ~~~

--- a/docs/GLM/Directive/Clock.md
+++ b/docs/GLM/Directive/Clock.md
@@ -65,5 +65,5 @@ Introducing more than one clock directive in a model is allowed. However, all el
 
 # See also
 
-* [share/tzinfo.txt](https://github.com/slacgismo/gridlabd/blob/master/runtime/tzinfo.txt)
+* [share/tzinfo.txt](https://source.gridlabd.us/blob/master/runtime/tzinfo.txt)
 * [[/Subcommand/Timezone]]

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -1,7 +1,7 @@
 The preferred method for running GridLAB-D is using [Docker](www.docker.org).  Once you have installed Docker, you can run GridLAB-D as follows.
 
 ~~~
-bash% docker run -it slacgismo/gridlabd:latest gridlabd <filename>
+bash% docker run -it hipas/gridlabd:latest gridlabd <filename>
 ~~~
 
 where `<filename` is the name of the model file in the container that you wish to run.
@@ -9,7 +9,7 @@ where `<filename` is the name of the model file in the container that you wish t
 If you wish to access the files in the current folder while running GridLAB-D in a container, then use the command
 
 ~~~
-bash% docker run -vit $PWD:$PWD slacgismo/gridlabd:latest gridlabd -W $PWD <filename>
+bash% docker run -vit $PWD:$PWD hipas/gridlabd:latest gridlabd -W $PWD <filename>
 ~~~
 
 More information on using GridLAB-D docker containers can be found at [[/Install/Docker]].

--- a/docs/Global/Kmlhost.md
+++ b/docs/Global/Kmlhost.md
@@ -5,14 +5,14 @@
 GLM:
 
 ~~~
-#set kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/runtime
+#set kmlhost=https://code.gridlabd.us/master/runtime
 ~~~
 
 Shell:
 
 ~~~
-bash$ gridlabd -D kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/source/rt
-bash$ gridlabd --define kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/source/rt
+bash$ gridlabd -D kmlhost=https://code.gridlabd.us/master/source/rt
+bash$ gridlabd --define kmlhost=https://code.gridlabd.us/master/source/rt
 ~~~
 
 # Description
@@ -22,5 +22,5 @@ KML server URL
 # Example
 
 ~~~
-#set kmlhost=https://raw.githubusercontent.com/slacgismo/gridlabd/master/runtime
+#set kmlhost=https://code.gridlabd.us/master/runtime
 ~~~

--- a/docs/Global/Tmp.md
+++ b/docs/Global/Tmp.md
@@ -5,14 +5,14 @@
 GLM:
 
 ~~~
-#set tmp=/Users/slacgismo/.gridlabd/tmp
+#set tmp=${HOME}/.gridlabd/tmp
 ~~~
 
 Shell:
 
 ~~~
-bash$ gridlabd -D tmp=/Users/slacgismo/.gridlabd/tmp
-bash$ gridlabd --define tmp=/Users/slacgismo/.gridlabd/tmp
+bash$ gridlabd -D tmp=$HOME/.gridlabd/tmp
+bash$ gridlabd --define tmp=$HOME/.gridlabd/tmp
 ~~~
 
 # Description
@@ -22,5 +22,5 @@ Temporary folder name
 # Example
 
 ~~~
-#set tmp=/Users/slacgismo/.gridlabd/tmp
+#set tmp=${HOME}/.gridlabd/tmp
 ~~~

--- a/docs/Module/Powerflow/Pole.md
+++ b/docs/Module/Powerflow/Pole.md
@@ -246,12 +246,12 @@ Guy wire attachment height.
 
 # Model
 
-The pole failure model is described in [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/master/module/powerflow/docs/pole_loading.pdf).
+The pole failure model is described in [Pole Loading Model](https://source.gridlabd.us/raw/master/module/powerflow/docs/pole_loading.pdf).
 
 The pole reaches end of life status based on a degradation rate that is defined by minimum shell thickness of 2". See [Pole Degradation Model](https://www.sciencedirect.com/science/article/pii/S0167473005000457) details.
 
 # See also
 
 * [[/Module/Powerflow/Pole_configuration]]
-* [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/master/module/powerflow/docs/pole_loading.pdf)
+* [Pole Loading Model](https://source.gridlabd.us/raw/master/module/powerflow/docs/pole_loading.pdf)
 * [Pole Degradation Model](https://www.sciencedirect.com/science/article/pii/S0167473005000457)

--- a/docs/Module/Powerflow/Pole_configuration.md
+++ b/docs/Module/Powerflow/Pole_configuration.md
@@ -29,7 +29,7 @@ GLM:
 
 # Description
 
-The `pole_configuration` object contains information about pole designs, and is referred to by `pole` objects.  See [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/grip/powerflow/docs/pole_loading.pdf) for details on values for the pole library.
+The `pole_configuration` object contains information about pole designs, and is referred to by `pole` objects.  See [Pole Loading Model](https://source.gridlabd.us/raw/master/module/powerflow/docs/pole_loading.pdf) for details on values for the pole library.
 
 ## Properties
 
@@ -196,5 +196,5 @@ The pole treatment method.
 # See also
 
 * [[/Module/Powerflow/Pole]]
-* [Pole Loading Model](https://github.com/slacgismo/gridlabd/raw/grip/powerflow/docs/pole_loading.pdf)
+* [Pole Loading Model](https://source.gridlabd.us/raw/master/module/powerflow/docs/pole_loading.pdf)
 * [UEP Bulletin 1728F-804](https://www.rd.usda.gov/files/UEP_Bulletin_1728F-804.pdf)

--- a/docs/News.md
+++ b/docs/News.md
@@ -4,4 +4,4 @@ The HiPAS GridLAB-D Technical Advisory Committee Meetings and User Workshops are
 
 # Recent Updates
 
-A list of recent updates to the master release of HiPAS GridLAB-D may be found at the [GitHub repository](https://github.com/slacgismo/gridlabd/commits/master).
+A list of recent releases of HiPAS GridLAB-D may be found at the [GitHub repository](https://source.gridlabd.us/discussions).

--- a/docs/Resources.md
+++ b/docs/Resources.md
@@ -1,25 +1,25 @@
 The following resources are available to GridLAB-D users.
 
-## [Models](https://github.com/slacgismo/gridlabd-models)
+## [Models](https://github.com/hipas/gridlabd-models)
 
 This GitHub project contains numerous models used in the development, testing, and teaching of GridLAB-D. These models can also serve as examples of how to do some more exotic things using GridLAB-D.
 
-## [Templates](https://github.com/slacgismo/gridlabd-templates)
+## [Templates](https://github.com/hipas/gridlabd-templates)
 
 This GitHub project contains GLM templates that can be configured using CSV inputs to perform specific analyses on models. See [[/Subcommand/Template]] for details.
 
-## [Converters](https://github.com/slacgismo/gridlabd-converters)
+## [Converters](https://github.com/hipas/gridlabd-converters)
 
 This GitHub project contains converters that GridLAB-D uses to accept inputs or generate outputs of various formats. See [[/Converters/README]] for details.
 
-## [Weather](https://github.com/slacgismo/gridlabd-weather)
+## [Weather](https://github.com/hipas/gridlabd-weather)
 
 This GitHub project contains weather data that can be accessed using the `weather` subcommand. See [[/Subcommand/Weather]] for details.
 
-## [Library](https://github.com/slacgismo/gridlabd-library)
+## [Library](https://github.com/hipas/gridlabd-library)
 
 This GitHub project contains libraries of GLM object that can be used in GridLAB-D models. See [[/Subcommand/Library]] for details.
 
-## [Examples](https://github.com/slacgismo/gridlabd-examples)
+## [Examples](https://github.com/hipas/gridlabd-examples)
 
 This GitHub project contains example GLM files that illustrate various ways of using GridLAB-D.

--- a/docs/Server/REST API.md
+++ b/docs/Server/REST API.md
@@ -168,7 +168,7 @@ In the event of an error, the JSON response is of the form
 
 ## Real-time models
 
-Server mode is essential to the realtime mode. Together this allows a web-based application to access the global variable and properties of named objects of a real-time simulation to emulate a control room.  See the [IEEE-123 Model](https://github.com/slacgismo/gridlabd/models/ieee123) for an example.
+Server mode is essential to the realtime mode. Together this allows a web-based application to access the global variable and properties of named objects of a real-time simulation to emulate a control room.  See the [IEEE-123 Model](https://github.com/hipas/gridlabd-models/tree/master/ieee123) for an example.
 
 # See also
 

--- a/docs/Sponsors.md
+++ b/docs/Sponsors.md
@@ -3,7 +3,7 @@ HiPAS GridLAB-D was developed with funding from the following organizations:
 # California Energy Commission EPIC Program
 [image:cec-logo.png]
 
-The current California version of GridLAB-D is called [HiPAS GridLAB-D 4.2](https://github.com/slacgismo/gridlabd) and is managed by [Stanford University](https://www.stanford.edu/) at [SLAC National Accelerator Laboratory](https://slac.stanford.edu.) under funding from the [California Energy Commission](https://energy.ca.gov/) under the [Electric Program Investment Charge (EPIC) program](https://www.energy.ca.gov/programs-and-topics/programs/electric-program-investment-charge-epic-program).
+The current California version of GridLAB-D is called [HiPAS GridLAB-D](https://source.gridlabd.us/) and is managed by [Stanford University](https://www.stanford.edu/) at [SLAC National Accelerator Laboratory](https://slac.stanford.edu.) under funding from the [California Energy Commission](https://energy.ca.gov/) under the [Electric Program Investment Charge (EPIC) program](https://www.energy.ca.gov/programs-and-topics/programs/electric-program-investment-charge-epic-program).
 
 # US Department of Energy Office of Electricity
 [image:doe-logo.png]

--- a/docs/Subcommand/Weather.md
+++ b/docs/Subcommand/Weather.md
@@ -250,7 +250,7 @@ bash$ gridlabd weather config show
   GITHUB="https://github.com"
   GITHUBUSERCONTENT="https://raw.githubusercontent.com"
   COUNTRY="US"
-  GITUSER="slacgismo"
+  GITUSER="hipas"
 
   GITREPO="gridlabd-weather"
   GITBRANCH="master"

--- a/docs/_footer.md
+++ b/docs/_footer.md
@@ -1,4 +1,4 @@
-This documentation is distributed under the terms of the [GridLAB-D license](https://github.com/slacgismo/gridlabd/blob/master/LICENSE). The terms of the license cover all updates and modifications by all contributors to the code and documentation since the original date of the license.
+This documentation is distributed under the terms of the [GridLAB-D license](https://source.gridlabd.us/blob/master/LICENSE). The terms of the license cover all updates and modifications by all contributors to the code and documentation since the original date of the license.
 
 This version of GridLAB-D and the documentation provided with it were created with funding from the US Department of Energy's Office of Electricity, Building Technology Office, Solar Energy Technology Office, ARPA-E, and the California Energy Commission under multiple grants and programs, including EPC-17-043, EPC-17-046, and EPC-17-047.
 

--- a/gridlabd.spec.in
+++ b/gridlabd.spec.in
@@ -6,7 +6,7 @@ License: Unknown
 Group: Simulators
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Packager: GridLAB-D GISMo SLAC Team <gridlabd@gmail.com>
-URL: https://github.com/slacgismo/gridlabd
+URL: https://source.gridlabd.us/
 Source0: %{name}_%{version}.tar.gz
 
 %description

--- a/python_extras/doc/network_tree.ipynb
+++ b/python_extras/doc/network_tree.ipynb
@@ -22,7 +22,7 @@
     "1. Series simplification of components <br>\n",
     "2. Enumeration of nodes based on their level on the network tree\n",
     "\n",
-    "The instructions for extracting a json file from a gridlab-d model see link __https://github.com/slacgismo/gridlabd/wiki/json__"
+    "The instructions for extracting a json file from a gridlab-d model see link __https://source.gridlabd.us/wiki/json__"
    ]
   },
   {

--- a/source/globals.h
+++ b/source/globals.h
@@ -12,6 +12,8 @@
 #error "this header may only be included from gldcore.h or gridlabd.h"
 #endif
 
+#define GITHUB_ORG "hipas"
+
 #include "version.h"
 #include "build.h"
 #include "validate.h"
@@ -283,7 +285,7 @@ GLOBAL unsigned char global_no_balance INIT(FALSE);
 GLOBAL char global_kmlfile[1024] INIT(""); /**< Specifies KML file to dump */
 
 /* Variable: global_kmlhost */
-GLOBAL char global_kmlhost[1024] INIT("https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/rt"); /**< Specifies the KML image library server */
+GLOBAL char global_kmlhost[1024] INIT("https://code.gridlabd.us/" BRANCH "/runtime"); /**< Specifies the KML image library server */
 
 /* Variable: global_modelname */
 GLOBAL char global_modelname[1024] INIT(""); /**< Name of the current model */
@@ -506,7 +508,7 @@ GLOBAL int global_mainloopstate INIT(MLS_INIT); /**< main loop processing state 
 GLOBAL TIMESTAMP global_mainlooppauseat INIT(TS_NEVER); /**< time at which to pause main loop */
 
 /* Variable: global_infourl */
-GLOBAL char global_infourl[1024] INIT("http://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&search="); /**< URL for info calls */
+GLOBAL char global_infourl[1024] INIT("http://docs.gridlabd.us/index.html?owner=" GITHUB_ORG "&project=gridlabd&search="); /**< URL for info calls */
 
 /* Variable: global_hostname */
 GLOBAL char global_hostname[1024] INIT("localhost"); /**< machine hostname */

--- a/source/legal.cpp
+++ b/source/legal.cpp
@@ -145,7 +145,7 @@ static pthread_t check_version_thread_id;
 void *check_version_proc(void *ptr)
 {
 	int patch, build;
-	const char *url = "https://raw.githubusercontent.com/slacgismo/gridlabd/master/gldcore/versions.txt";
+	const char *url = "https://code.gridlabd.us/master/source/versions.txt";
 	HTTPRESULT *result = http_read(url,0x1000);
 	char target[32];
 	char *pv = NULL, *nv = NULL;

--- a/subcommands/gridlabd-contributors
+++ b/subcommands/gridlabd-contributors
@@ -92,7 +92,7 @@ if not token:
 try:
 	git = github.Github(token)
 
-	repo = git.get_repo("slacgismo/gridlabd")
+	repo = git.get_repo("hipas/gridlabd")
 	for user in repo.get_contributors():
 		if login:
 			output(user.login)

--- a/subcommands/gridlabd-library
+++ b/subcommands/gridlabd-library
@@ -12,7 +12,7 @@ fi
 # configurable parameters
 GITHUB="https://github.com"
 ORGANIZATION="US/CA/SLAC"
-GITUSER=slacgismo
+GITUSER=hipas
 GITREPO="gridlabd-library"
 GITBRANCH="master"
 DATADIR="$GLD_ETC/library/$ORGANIZATION"

--- a/subcommands/gridlabd-template
+++ b/subcommands/gridlabd-template
@@ -14,7 +14,7 @@ GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 if [ "${ORGANIZATION}" == "" ]; then
     export ORGANIZATION="US/CA/SLAC"
 fi
-GITUSER=slacgismo
+GITUSER=hipas
 GITREPO="gridlabd-template"
 GITBRANCH="master"
 DATADIR="$GLD_ETC/template/$ORGANIZATION"

--- a/subcommands/gridlabd-version
+++ b/subcommands/gridlabd-version
@@ -52,7 +52,7 @@ function version-check()
 {
 	version=$(${BIN} --version)
 	branch=$(${BIN} --version=git-branch)
-	remote=$( (curl -sL "https://raw.githubusercontent.com/slacgismo/gridlabd/$branch/source/version.h" | grep '#define REV_' | cut -f3 -d' ' | tr '\n' . | cut -f-3 -d.) || echo "none" )
+	remote=$( (curl -sL "https://raw.githubusercontent.com/hipas/gridlabd/$branch/source/version.h" | grep '#define REV_' | cut -f3 -d' ' | tr '\n' . | cut -f-3 -d.) || echo "none" )
 	if [ "$remote" == "none" -o -z "$remote" ]; then
 		[ "$1" != "-q" -a "$1" != "-w" ] && error 2 "$version ($branch) branch not found on github"
 		[ "$1" != "-q" ] && warning "$version ($branch) branch not found on github"

--- a/subcommands/gridlabd-weather
+++ b/subcommands/gridlabd-weather
@@ -13,7 +13,7 @@ fi
 GITHUB="https://github.com"
 GITHUBUSERCONTENT="https://raw.githubusercontent.com"
 COUNTRY="US"
-GITUSER=slacgismo
+GITUSER=hipas
 GITREPO="gridlabd-weather"
 GITBRANCH="master"
 DATADIR="$GLD_ETC/weather/$COUNTRY"

--- a/utilities/report.py
+++ b/utilities/report.py
@@ -7,7 +7,7 @@ start = datetime.datetime(now.year,now.month-1,1,0,0,0);
 stop = datetime.datetime(now.year,now.month,1,0,0,0);
 
 # get pulls closed last month
-os.system('curl -s https://api.github.com/repos/slacgismo/gridlabd/pulls\\?state=closed\\&per_page=100\\&sort=updated\\&direction=desc > pulls.json');
+os.system('curl -s https://api.github.com/repos/hipas/gridlabd/pulls\\?state=closed\\&per_page=100\\&sort=updated\\&direction=desc > pulls.json');
 with open("pulls.json","r") as fh:
     pulls = json.load(fh);
     fh.close()
@@ -31,7 +31,7 @@ if os.system('pandoc --listings -o pulls.pdf pulls.md') == 0 :
     os.system('open pulls.pdf');
 
 # get all issues
-os.system('curl -s https://api.github.com/repos/slacgismo/gridlabd/issues\\?state=open\\&per_page=1000\\&sort=created\\&direction=desc > issues.json');
+os.system('curl -s https://api.github.com/repos/hipas/gridlabd/issues\\?state=open\\&per_page=1000\\&sort=created\\&direction=desc > issues.json');
 with open("issues.json","r") as fh:
     issues = json.load(fh);
     fh.close()

--- a/utilities/troubleshooting.awk
+++ b/utilities/troubleshooting.awk
@@ -82,7 +82,7 @@ BEGIN { # this is executed before any files are processed
 			}
 			while ( index($0,"*/") == 0 )
 			
-			info = explanation "<cite>See <a href=\"http://github.com/slacgismo/gridlabd/blob/master/" module "/" filename "#L" tag "\">" id "</a>.</cite>"
+			info = explanation "<cite>See <a href=\"http://source.gridlabd.us/blob/master/" module "/" filename "#L" tag "\">" id "</a>.</cite>"
 			
 			# add message and TROUBLESHOOT text to appropriate array
 			if ( group == "Warnings" ) {


### PR DESCRIPTION
This PR fixes #1150.  

**IMPORTANT CAVEAT**: The source code now uses `hipas/gridlabd*` instead of `slacgismo/gridlabd*` for resources. This means that the `hipas` organization needs to pull changes from `slacgismo` organization until the relationship between the two is reversed.