### PR TITLE
Add missing powerflow switch autotests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,8 @@ python/dist/*.tar.gz
 python/gridlabd.egg-info/
 gridlabd.egg-*
 module/resilience/docs/output.csv
+module/powerflow/autotest/controller_1.csv
+module/powerflow/autotest/switch_1.csv
+module/powerflow/autotest/switch_2.csv
+module/powerflow/autotest/switch_3.csv
+module/powerflow/autotest/switch_4.csv

--- a/module/powerflow/autotest/test_switch.glm
+++ b/module/powerflow/autotest/test_switch.glm
@@ -1,0 +1,41 @@
+// test_switch.glm
+//
+// Verify that banked switch works correctly when opened
+//
+module powerflow;
+module assert;
+
+object meter 
+{
+    name "test";
+    phases ABC;
+    nominal_voltage 2400;
+    bustype SWING;
+    object assert
+    {
+        target measured_real_power;
+        value 2000;
+        within 1;
+    };
+}
+#for PHASE in A B C
+object load
+{
+    name "load_${PHASE}";
+    phases ${PHASE};
+    nominal_voltage 2400;
+    bustype SWING_PQ;
+    constant_power_${PHASE} 1000;
+}
+object switch
+{
+    phases ${PHASE};
+    name "switch_${PHASE}";
+    from "test";
+    to "load_${PHASE}";
+    operating_mode INDIVIDUAL;
+    phase_${PHASE}_state CLOSED;
+}
+#done
+
+modify switch_C.phase_C_state OPEN;

--- a/module/powerflow/autotest/test_switch_banked.glm
+++ b/module/powerflow/autotest/test_switch_banked.glm
@@ -1,0 +1,42 @@
+// test_switch.glm
+//
+// Verify that banked switch works correctly when opened
+//
+module powerflow;
+module assert;
+
+object meter 
+{
+    name "test";
+    phases ABC;
+    nominal_voltage 2400;
+    bustype SWING;
+    object assert
+    {
+        target measured_real_power;
+        value 2000;
+        within 1;
+    };
+}
+#for PHASE in A B C
+object load
+{
+    name "load_${PHASE}";
+    phases ${PHASE};
+    nominal_voltage 2400;
+    bustype SWING_PQ;
+    constant_power_${PHASE} 1000;
+}
+object switch
+{
+    phases ${PHASE};
+    name "switch_${PHASE}";
+    from "test";
+    to "load_${PHASE}";
+    operating_mode BANKED;
+    phase_${PHASE}_state CLOSED;
+}
+#done
+
+modify switch_C.phase_C_state OPEN;
+modify switch_C.phase_A_state CLOSED;

--- a/module/powerflow/autotest/test_switch_coordinator.csv
+++ b/module/powerflow/autotest/test_switch_coordinator.csv
@@ -1,0 +1,6 @@
+timestamp,status,armed
+2011-01-01 00:00:00 UTC,ARMED,NONE
+2011-01-01 00:00:02 UTC,ARMED,switch_1
+2011-01-01 00:00:03 UTC,ARMED,switch_1|switch_2
+2011-01-01 00:00:05 UTC,ARMED,switch_1|switch_2|switch_3
+2011-01-01 00:00:08 UTC,ARMED,switch_1|switch_2|switch_3|switch_4

--- a/module/powerflow/autotest/test_switch_coordinator.glm
+++ b/module/powerflow/autotest/test_switch_coordinator.glm
@@ -6,6 +6,10 @@
 //#set verbose=TRUE
 //#set debug=TRUE
 
+#ifexist ../controller_1_armed.player
+#define DIR=..
+#endif
+
 clock
 {
 	timezone UTC0;						//Local timezone for the simulation
@@ -17,7 +21,10 @@ module powerflow {
 	solver_method NR;
 	convergence_error_handling IGNORE;
 }
-module tape;
+module tape
+{
+	csv_header_type NAME;
+}
 
 // nodes
 object meter {
@@ -59,16 +66,19 @@ object switch_coordinator {
 	connect switch_4;
 	object player {
 		property armed;
-		file "../controller_1_armed.player";
+		file "${DIR:-.}/controller_1_armed.player";
 	};
 	object player {
 		property status;
-		file "../controller_1_status.player";
+		file "${DIR:-.}/controller_1_status.player";
 	};
 	object recorder {
 		property status,armed;
-		file controller_1.csv;
+		file "test_switch_coordinator.csv";
 		interval -1;
 	};
 }
 
+#ifexist ../test_switch_coordinate.csv
+#on_exit 0 diff -q ../test_switch_coordinate.csv test_switch_coordinate.csv
+#endif


### PR DESCRIPTION
This PR fixes #318.

- [x] Add tests for `powerflow switch` objects
- [x] Update test for `powerflow switch_coordinator` objects.

All the other items listed in #318 are already being tested.
