### PR TITLE
Add support for module template folder

### DIFF
--- a/runtime/gridlabd.h
+++ b/runtime/gridlabd.h
@@ -653,6 +653,7 @@ struct s_module_list {
 	bool (*on_commit)(TIMESTAMP t);
 	void (*on_term)(void);
 	bool templates_loaded;
+	bool no_templates;
 	MODULE *next;
 };
 

--- a/runtime/gridlabd.h
+++ b/runtime/gridlabd.h
@@ -652,6 +652,7 @@ struct s_module_list {
 	TIMESTAMP (*on_postsync)(TIMESTAMP t);
 	bool (*on_commit)(TIMESTAMP t);
 	void (*on_term)(void);
+	bool templates_loaded;
 	MODULE *next;
 };
 

--- a/source/load.cpp
+++ b/source/load.cpp
@@ -2766,6 +2766,11 @@ int GldLoader::module_properties(PARSER, MODULE *mod)
 			REJECT;
 		}
 	}
+	OR if ( LITERAL("no_templates") && (WHITE,LITERAL(";")) )
+	{
+		mod->no_templates = true;
+		ACCEPT;
+	}
 	OR if (TERM(name(HERE,propname,sizeof(propname))) && (WHITE))
 	{
 		current_object = NULL; /* object context */

--- a/source/module.cpp
+++ b/source/module.cpp
@@ -527,6 +527,7 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 	mod->on_term = NULL;
 	strcpy(mod->name,file);
 	mod->templates_loaded = false;
+	mod->no_templates = false;
 	mod->next = NULL;
 
 	/* check the module version before trying to initialize */
@@ -2940,7 +2941,7 @@ void module_help_md(MODULE *mod, CLASS *oclass)
 
 void module_load_templates(MODULE *mod)
 {
-	if ( mod->templates_loaded )
+	if ( mod->templates_loaded || mod->no_templates )
 	{
 		return;
 	}

--- a/source/module.cpp
+++ b/source/module.cpp
@@ -526,6 +526,7 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 	mod->on_commit = NULL;
 	mod->on_term = NULL;
 	strcpy(mod->name,file);
+	mod->templates_loaded = false;
 	mod->next = NULL;
 
 	/* check the module version before trying to initialize */
@@ -589,7 +590,9 @@ MODULE *module_load(const char *file, /**< module filename, searches \p PATH */
 			}
 		}
 	}
-	return module_add(mod);
+	module_add(mod);
+	module_load_templates(mod);
+	return last_module;
 }
 
 MODULE *module_add(MODULE *mod)
@@ -2933,6 +2936,52 @@ void module_help_md(MODULE *mod, CLASS *oclass)
 		}
 	}
 	output_raw("\n");
+}
+
+void module_load_templates(MODULE *mod)
+{
+	if ( mod->templates_loaded )
+	{
+		return;
+	}
+	char loadpath[1024];
+	sprintf(loadpath,"%s/module.d/%s",getenv("GLD_ETC"),mod->name);
+	DIR *dp;
+	struct dirent *entry;
+	struct stat statbuf;
+	if ( (dp=opendir(loadpath)) != NULL )
+	{
+		output_debug("module_load_templates(MODULE *mod=<%s>): reading shared module templates folder '%s'",mod->name,loadpath);
+		while ( (entry=readdir(dp)) )
+		{
+			char file[1024];
+			sprintf(file,"%s/%s",loadpath,entry->d_name);
+			output_debug("module_load_templates(MODULE *mod=<%s>): loading '%s'",mod->name,file);
+			if ( lstat(file,&statbuf) != 0 )
+			{
+				output_warning("module_load_templates(MODULE *mod=<%s>): unable to get status of '%s'",mod->name,file);
+			}
+			else if ( S_ISDIR(statbuf.st_mode) )
+			{
+				output_debug("module_load_templates(MODULE *mod=<%s>): '%s' is a directory -- ignoring",mod->name,file);
+			}
+			else
+			{
+				output_debug("module_load_templates(MODULE *mod=<%s>): loading '%s'",mod->name,file);
+				if ( my_instance->get_loader()->loadall_glm(file) != SUCCESS )
+				{
+					output_error("module template '%s' load failed",file);
+				}
+			}
+		}
+		closedir(dp);
+		mod->templates_loaded = true;
+	}
+	else
+	{
+		output_debug("module_load_templates(MODULE *mod=<%s>): shared module templates folder '%s' not found",mod->name,loadpath);
+	}
+	return;
 }
 
 /**@}*/

--- a/source/module.h
+++ b/source/module.h
@@ -54,6 +54,7 @@ struct s_module_list {
 	TIMESTAMP (*on_postsync)(TIMESTAMP t);
 	bool (*on_commit)(TIMESTAMP t);
 	void (*on_term)(void);
+	bool templates_loaded;
 	struct s_module_list *next;
 }; /* MODULE */
 
@@ -136,6 +137,8 @@ extern "C" {
 	int sched_getnproc(void);
 
 	void module_help_md(MODULE *mod, CLASS *oclass=NULL);
+
+	void module_load_templates(MODULE *mod);
 
 #ifdef __cplusplus
 }

--- a/source/module.h
+++ b/source/module.h
@@ -55,6 +55,7 @@ struct s_module_list {
 	bool (*on_commit)(TIMESTAMP t);
 	void (*on_term)(void);
 	bool templates_loaded;
+	bool no_templates;
 	struct s_module_list *next;
 }; /* MODULE */
 

--- a/subcommands/gridlabd-template
+++ b/subcommands/gridlabd-template
@@ -291,6 +291,12 @@ function get()
         fi
         FOUND=$((${FOUND}+1))
     done
+    for FILE in $(cd $DSTDIR; ls -1 module_*.glm 2>/dev/null); do
+        GLMNAME=${FILE/module_/}
+        MODNAME=${GLMNAME/.glm/}
+        mkdir -p $GLD_ETC/module.d/$MODNAME
+        ln -sf $DSTDIR/$FILE $GLD_ETC/module.d/$MODNAME/$TEMPLATE.glm
+    done
     if [ ${FOUND} -eq 0 ]; then
         error 1 "no template(s) not found"
     fi


### PR DESCRIPTION
This PR implements a solution to issue #1158.

# Issues

None

# Code changes

- [x] Add support for loading GLM files in `${GLD_ETC}/module.d/<MODULE>`.
- [x] Add support for linking `module_NAME.glm` files from `template` into module template folder.

