### PR TITLE
Fix voltage violation detection implementation errors

### DIFF
--- a/docs/Use cases/Hosting capacity.md
+++ b/docs/Use cases/Hosting capacity.md
@@ -1,0 +1,25 @@
+[[/Use cases/Hosting capacity analysis]] - Hosting capacity analysis support
+
+The `powerflow` module implements support for hosting capacity analysis in all objects derives from `link` and `node` classes.  
+
+# Limit violations
+
+When limit violations are detected, they are flagged by setting the `violation_active` property of the object whose limits are violated. The `violation_count` variable is also incremented.
+
+# Violation recording
+
+When limit violations are enables they are recorded in the filename specified by the `powerflow` module global `violation_record`.  If this file is not specified, violations are not recorded when they are detected.
+
+# Current violations
+
+Current limit violations are detected on all links when the `violation_rating[A]` is exceeded by the `current_in_[ABC]` on the link.  Current limits are only detected when the `violation_rating[A]` is positive. If the `violation_rating[A]` property of an object is zero, then the value of the module global `default_violation_rating[A]` is used. By default, this value is zero, which disables current violation detection.
+
+# Voltage violations
+
+Voltage limit violations are detected on all nodes when the `voltage_violation_threshold[pu]` is exceeded by the node voltages on any phases relative to the nominal voltage.  If the `voltage_violation_threshold[pu]` property is zero, then the value of the module global `default_voltage_violation_threshold[pu]` is used.  By default, this value is `0.05`, which enables voltage violation detection for all objects. Setting the global value to zero disables voltage violation checks.
+
+If either the `undervoltage_violation_threshold[pu]` or `overvoltage_violation_threshold[pu]` are set and `undervoltage_violation_threshold[pu]` < `overvoltage_violation_threshold[pu]`, then these values are used instead.  Similarly, the corresponding global values are used if these values are zero. The default `undervoltage_violation_threshold[pu]` and `overvoltage_violation_threshold[pu]` values are zero, which disables them.
+
+# Voltage fluctuations
+
+Voltage fluctuations are detected on all nodes when both `voltage_fluctuation_threshold[pu]` and `DER_value[W]` are non-zero.  The solver compares the voltage of each phase of each object in the network with the DER on and off. If the difference in voltage exceeds `voltage_fluctuation_threshold[pu]`, then the violation is detected.  The default value of `voltage_fluctuation_threshold[pu]` is given by `default_voltage_fluctuation_threshold[pu]`, which is zero by default.

--- a/docs/Use cases/Hosting capacity.md
+++ b/docs/Use cases/Hosting capacity.md
@@ -6,20 +6,24 @@ The `powerflow` module implements support for hosting capacity analysis in all o
 
 When limit violations are detected, they are flagged by setting the `violation_active` property of the object whose limits are violated. The `violation_count` variable is also incremented.
 
-# Violation recording
-
-When limit violations are enables they are recorded in the filename specified by the `powerflow` module global `violation_record`.  If this file is not specified, violations are not recorded when they are detected.
-
-# Current violations
+## Current violations
 
 Current limit violations are detected on all links when the `violation_rating[A]` is exceeded by the `current_in_[ABC]` on the link.  Current limits are only detected when the `violation_rating[A]` is positive. If the `violation_rating[A]` property of an object is zero, then the value of the module global `default_violation_rating[A]` is used. By default, this value is zero, which disables current violation detection.
 
-# Voltage violations
+## Voltage violations
 
 Voltage limit violations are detected on all nodes when the `voltage_violation_threshold[pu]` is exceeded by the node voltages on any phases relative to the nominal voltage.  If the `voltage_violation_threshold[pu]` property is zero, then the value of the module global `default_voltage_violation_threshold[pu]` is used.  By default, this value is `0.05`, which enables voltage violation detection for all objects. Setting the global value to zero disables voltage violation checks.
 
 If either the `undervoltage_violation_threshold[pu]` or `overvoltage_violation_threshold[pu]` are set and `undervoltage_violation_threshold[pu]` < `overvoltage_violation_threshold[pu]`, then these values are used instead.  Similarly, the corresponding global values are used if these values are zero. The default `undervoltage_violation_threshold[pu]` and `overvoltage_violation_threshold[pu]` values are zero, which disables them.
 
-# Voltage fluctuations
+## Voltage fluctuations
 
 Voltage fluctuations are detected on all nodes when both `voltage_fluctuation_threshold[pu]` and `DER_value[W]` are non-zero.  The solver compares the voltage of each phase of each object in the network with the DER on and off. If the difference in voltage exceeds `voltage_fluctuation_threshold[pu]`, then the violation is detected.  The default value of `voltage_fluctuation_threshold[pu]` is given by `default_voltage_fluctuation_threshold[pu]`, which is zero by default.
+
+# Violation recording
+
+When limit violations are enables they are recorded in the filename specified by the `powerflow` module global `violation_record`.  If this file is not specified, violations are not recorded when they are detected.
+
+# Exhaustive violation checks
+
+Normally, the voltage fluctuation tests stop checking if any violation is found, and no further tests are conducted.  If the module global `DER_violation_tests` is set to `ALL`, then all violations will be reported.

--- a/module/powerflow/autotest/test_node_voltage_fluctuation.csv
+++ b/module/powerflow/autotest/test_node_voltage_fluctuation.csv
@@ -1,7 +1,4 @@
 timestamp,object,type,description
-2000-01-01 00:00:00,load_1,VOLTAGE,"load_1 phase A voltage magnitude 2252.6 V outside 3.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
-2000-01-01 00:00:00,load_1,VOLTAGE,"load_1 phase B voltage magnitude 2252.6 V outside 3.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
-2000-01-01 00:00:00,load_1,VOLTAGE,"load_1 phase C voltage magnitude 2252.6 V outside 3.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
-2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase A voltage magnitude 2184.0 V outside 3.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
-2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase B voltage magnitude 2184.0 V outside 3.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
-2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase C voltage magnitude 2184.0 V outside 3.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
+2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase A voltage magnitude 2184.0 V outside 4.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
+2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase B voltage magnitude 2184.0 V outside 4.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
+2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase C voltage magnitude 2184.0 V outside 4.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"

--- a/module/powerflow/autotest/test_node_voltage_fluctuation.csv
+++ b/module/powerflow/autotest/test_node_voltage_fluctuation.csv
@@ -1,4 +1,7 @@
 timestamp,object,type,description
-2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase A voltage magnitude 2184.0 V outside 4.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
-2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase B voltage magnitude 2184.0 V outside 4.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
-2000-01-01 00:00:00,load_2,VOLTAGE,"load_2 phase C voltage magnitude 2184.0 V outside 4.0% violation threshold for load_2 DER_value 100000.0+0.0j kVA"
+2000-01-01 00:00:00,node_2,VOLTAGE,"node_2 phase A voltage magnitude 2184.0 V outside 4.0% violation threshold for node_2 DER_value 100000.0+0.0j kVA"
+2000-01-01 00:00:00,node_2,VOLTAGE,"node_2 phase B voltage magnitude 2184.0 V outside 4.0% violation threshold for node_2 DER_value 100000.0+0.0j kVA"
+2000-01-01 00:00:00,node_2,VOLTAGE,"node_2 phase C voltage magnitude 2184.0 V outside 4.0% violation threshold for node_2 DER_value 100000.0+0.0j kVA"
+2000-01-01 00:00:00,node_2,VOLTAGE,"node phase A voltage 2257.7 V is outside 5.0% violation threshold"
+2000-01-01 00:00:00,node_2,VOLTAGE,"node phase B voltage 2258.8 V is outside 5.0% violation threshold"
+2000-01-01 00:00:00,node_2,VOLTAGE,"node phase C voltage 2259.5 V is outside 5.0% violation threshold"

--- a/module/powerflow/autotest/test_node_voltage_fluctuation.glm
+++ b/module/powerflow/autotest/test_node_voltage_fluctuation.glm
@@ -10,6 +10,7 @@ module powerflow
 	solver_method NR;
 	violation_record "test_node_voltage_fluctuation.csv";
 	voltage_fluctuation_threshold 0.04;
+	DER_violation_test ALL;
 }
 
 object node {

--- a/module/powerflow/autotest/test_node_voltage_fluctuation.glm
+++ b/module/powerflow/autotest/test_node_voltage_fluctuation.glm
@@ -79,13 +79,21 @@ object overhead_line
 {
 	phases ABCN;
 	from "load_1";
-	to "load_2";
+	to "node_2";
 	length 1 mile;
 	configuration "lc";
 }
 
+object node
+{
+	name "node_2";
+	phases ABCN;
+	nominal_voltage 2400 V;
+}
+
 object load
 {
+	parent "node_2";
 	phases ABCN;
 	nominal_voltage 2400 V;
 	name "load_2";
@@ -99,3 +107,4 @@ object load
 #on_exit 0 diff ../test_node_voltage_fluctuation.csv test_node_voltage_fluctuation.csv >gridlabd.diff
 #endif
 
+#set savefile=test_node_voltage_fluctuation.json

--- a/module/powerflow/autotest/test_node_voltage_fluctuation.glm
+++ b/module/powerflow/autotest/test_node_voltage_fluctuation.glm
@@ -9,6 +9,7 @@ module powerflow
 {
 	solver_method NR;
 	violation_record "test_node_voltage_fluctuation.csv";
+	voltage_fluctuation_threshold 0.04;
 }
 
 object node {

--- a/module/powerflow/link.cpp
+++ b/module/powerflow/link.cpp
@@ -10,6 +10,7 @@ CLASS* link_object::pclass = NULL;
 
 double link_object::default_continuous_rating = 1000;
 double link_object::default_emergency_rating = 2000;
+double link_object::default_violation_rating = 0.0;
 
 EXPORT_COMMIT_C(link,link_object)
 
@@ -157,6 +158,7 @@ link_object::link_object(MODULE *mod) : powerflow_object(mod)
 
 			gl_global_create("powerflow::default_continuous_rating[A]",PT_double,&default_continuous_rating,NULL);
 			gl_global_create("powerflow::default_emergency_rating[A]",PT_double,&default_emergency_rating,NULL);
+			gl_global_create("powerflow::default_violation_rating[A]",PT_double,&default_violation_rating,NULL);
 
 			//Publish deltamode functions
 			if (gl_publish_function(oclass,	"interupdate_pwr_object", (FUNCTIONADDR)interupdate_link)==NULL)
@@ -878,6 +880,10 @@ int link_object::init(OBJECT *parent)
 	{
 		error("negative violation_rating is not valid");
 		return 0;
+	}
+	else if ( violation_rating == 0 )
+	{
+		violation_rating = default_violation_rating;
 	}
 
 	return 1;

--- a/module/powerflow/link.h
+++ b/module/powerflow/link.h
@@ -97,6 +97,7 @@ public:
 	int protect_locations[3];	///< Links to protection object for different phase faults - part of reliability
 	FUNCTIONADDR link_recalc_fxn;	///< Function address for link recalculation function - frequency dependence
 	double violation_rating; ///< maximum line flow before a violation occurs
+	static double default_violation_rating; /// default maximum line flow before a violation occurs
 
 	int create(void);
 	int init(OBJECT *parent);

--- a/module/powerflow/node.cpp
+++ b/module/powerflow/node.cpp
@@ -90,6 +90,7 @@ double node::default_undervoltage_violation_threshold = 0.00;
 double node::default_voltage_fluctuation_threshold = 0.03;
 OBJECT* *node::DER_objectlist = NULL;
 unsigned int node::DER_nodecount = 0;
+enumeration node::DER_violation_test = DVT_ANY;
 
 node::node(MODULE *mod) : powerflow_object(mod)
 {
@@ -376,6 +377,7 @@ node::node(MODULE *mod) : powerflow_object(mod)
 		gl_global_create("powerflow::undervoltage_violation_threshold[pu]",PT_double,&default_undervoltage_violation_threshold,NULL);
 		gl_global_create("powerflow::overvoltage_violation_threshold[pu]",PT_double,&default_overvoltage_violation_threshold,NULL);
 		gl_global_create("powerflow::voltage_fluctuation_threshold[pu]",PT_double,&default_voltage_fluctuation_threshold,NULL);
+		gl_global_create("powerflow::DER_violation_test",PT_enumeration,&DER_violation_test,PT_KEYWORD,"ANY",DVT_ANY,PT_KEYWORD,"ALL",DVT_ALL,NULL);
 
 		if (gl_publish_function(oclass,	"delta_linkage_node", (FUNCTIONADDR)delta_linkage)==NULL)
 			GL_THROW("Unable to publish node delta_linkage function");
@@ -2914,19 +2916,30 @@ TIMESTAMP node::sync(TIMESTAMP t0)
 										debug("phase A voltage fluctuation violation detected on '%s' due to '%s' DER_value %.1f%+.1fj",check_name, der_name, der_data->DER_value.r, der_data->DER_value.i);
 										check_data->add_violation(VF_VOLTAGE,"%s phase A voltage magnitude %.1f V outside %.1f%% violation threshold for %s DER_value %.1f%+.1fj kVA", 
 											check_name, check_data->voltage[0].Mag(), voltage_fluctuation_threshold*100, der_name, der_data->DER_value.r, der_data->DER_value.i);
+										if ( DER_violation_test == DVT_ANY )
+										{
+											break;
+										}
 									}
 									if ( has_phase(PHASE_B) && fabs((Vb[check_bus][1]-check_data->voltage[1]).Mag()) / Vb[check_bus][1].Mag() > voltage_fluctuation_threshold )
 									{
 										debug("phase B voltage fluctuation violation detected on '%s' due to '%s' DER_value %.1f%+.1fj",check_name, der_name, der_data->DER_value.r, der_data->DER_value.i);
 										check_data->add_violation(VF_VOLTAGE,"%s phase B voltage magnitude %.1f V outside %.1f%% violation threshold for %s DER_value %.1f%+.1fj kVA", 
 											check_name, check_data->voltage[0].Mag(), voltage_fluctuation_threshold*100, der_name, der_data->DER_value.r, der_data->DER_value.i);
-
+										if ( DER_violation_test == DVT_ANY )
+										{
+											break;
+										}
 									}
 									if ( has_phase(PHASE_C) && fabs((Vb[check_bus][2]-check_data->voltage[2]).Mag()) / Vb[check_bus][2].Mag() > voltage_fluctuation_threshold )
 									{
 										debug("phase C voltage fluctuation violation detected on '%s' due to '%s' DER_value %.1f%+.1fj",check_name, der_name, der_data->DER_value.r, der_data->DER_value.i);
 										check_data->add_violation(VF_VOLTAGE,"%s phase C voltage magnitude %.1f V outside %.1f%% violation threshold for %s DER_value %.1f%+.1fj kVA", 
 											check_name, check_data->voltage[0].Mag(), voltage_fluctuation_threshold*100, der_name, der_data->DER_value.r, der_data->DER_value.i);
+										if ( DER_violation_test == DVT_ANY )
+										{
+											break;
+										}
 									}
 								}
 							}

--- a/module/powerflow/node.cpp
+++ b/module/powerflow/node.cpp
@@ -361,6 +361,7 @@ node::node(MODULE *mod) : powerflow_object(mod)
 			NULL) < 1) GL_THROW("unable to publish properties in %s",__FILE__);
 
 		gl_global_create("powerflow::voltage_violation_threshold[pu]",PT_double,&default_voltage_violation_threshold,NULL);
+		gl_global_create("powerflow::voltage_fluctuation_threshold[pu]",PT_double,&voltage_fluctuation_threshold,NULL);
 
 		if (gl_publish_function(oclass,	"delta_linkage_node", (FUNCTIONADDR)delta_linkage)==NULL)
 			GL_THROW("Unable to publish node delta_linkage function");

--- a/module/powerflow/node.cpp
+++ b/module/powerflow/node.cpp
@@ -2881,6 +2881,8 @@ TIMESTAMP node::sync(TIMESTAMP t0)
 					{
 						BUSDATA *der_bus = NR_busdata + der;
 						node *der_data = OBJECTDATA(der_bus->obj,node);
+						if ( der_bus->obj->parent != NULL && gl_object_isa(der_bus->obj->parent,"node") )
+							continue; // ignore child nodes because they're already included in parent node DER_value
 						der_data->clear_violation();
 
 						// DER is present on this bus

--- a/module/powerflow/node.h
+++ b/module/powerflow/node.h
@@ -100,6 +100,8 @@ typedef struct {
 	double cosangmeas[3];	 //cos of bus voltage angle
 } FREQM_STATES;
 
+#define DVT_ANY ((enumeration)0x00)
+#define DVT_ALL ((enumeration)0x01)
 
 class node : public powerflow_object
 {
@@ -190,6 +192,7 @@ public:
 
 	// DER functionality
 	complex DER_value; // DER fluctuation power value (0 for none)
+	static enumeration DER_violation_test; // flag indicates whether to test for any DER test or all DER violations
 
 	//GFA functionality
 	bool GFA_enable;

--- a/module/powerflow/node.h
+++ b/module/powerflow/node.h
@@ -136,7 +136,6 @@ private:
 	OBJECT *VFD_object;						///< Object pointer for the VFD - for later function calls
 
 	// DER globals
-	static double voltage_fluctuation_threshold; ///< maximum voltage fluctuation permitted
 	static unsigned int DER_nodecount;		///< count of DER nodes
 	static OBJECT **DER_objectlist;			///< list of DER objects to examine for voltage fluctuations violations
 
@@ -242,8 +241,15 @@ public:
 	int *NR_subnode_reference;	/// Pointer to parent node's reference in NR_busdata - just in case things get inited out of synch
 	unsigned char prev_phases;	/// Phase tracking variable for use in reliability calls
 
-	static double default_voltage_violation_threshold; 	// voltage deviation limit (pu)
-	double voltage_violation_threshold; 	// voltage deviation limit (pu)
+	static double default_voltage_violation_threshold; 	// global voltage deviation limit (pu)
+	static double default_overvoltage_violation_threshold; 	// global voltage deviation limit (pu)
+	static double default_undervoltage_violation_threshold; 	// global voltage deviation limit (pu)
+	static double default_voltage_fluctuation_threshold; // global voltage fluctuation limit (pu)
+
+	double voltage_violation_threshold; // object voltage deviation limit (pu)
+	double undervoltage_violation_threshold;  // object voltage deviation limit (pu)
+	double overvoltage_violation_threshold;  // object voltage deviation limit (pu)
+	double voltage_fluctuation_threshold; // object voltage fluctuation limit (pu)
 
 	inline bool is_split() {return (phases&PHASE_S)!=0;};
 public:

--- a/module/powerflow/powerflow_object.cpp
+++ b/module/powerflow/powerflow_object.cpp
@@ -299,15 +299,12 @@ void powerflow_object::clear_violation(void)
 
 void powerflow_object::add_violation(int vf_type, const char *format, ...)
 {
-	if ( violation_watch )
-	{
-		char message[1024];
-		va_list ptr;
-		va_start(ptr,format);
-		vsnprintf(message,sizeof(message)-1,format,ptr);
-		va_end(ptr);
-		add_violation(gl_globalclock,THISOBJECTHDR,vf_type,message);
-	}
+	char message[1024];
+	va_list ptr;
+	va_start(ptr,format);
+	vsnprintf(message,sizeof(message)-1,format,ptr);
+	va_end(ptr);
+	add_violation(gl_globalclock,THISOBJECTHDR,vf_type,message);
 }
 void powerflow_object::add_violation(TIMESTAMP t, OBJECT *obj, int vf_type, const char *message)
 {

--- a/subcommands/gridlabd-version
+++ b/subcommands/gridlabd-version
@@ -52,7 +52,10 @@ function version-check()
 {
 	version=$(${BIN} --version)
 	branch=$(${BIN} --version=git-branch)
-	origin=$(git remote get-url $(git remote) | cut -f4- -d/ | cut -f1 -d. )
+	if [ $(git remote | wc -l) -gt 1 ]; then
+		warning "more than 1 git remote found, using '$(git remote | head -n 1)' for version check"
+	fi
+	origin=$(git remote get-url $(git remote | head -n 1) | cut -f4- -d/ | cut -f1 -d. )
 	remote=$( (curl -sL "https://raw.githubusercontent.com/$origin/$branch/source/version.h" | grep '#define REV_' | cut -f3 -d' ' | tr '\n' . | cut -f-3 -d.) || echo "none" )
 	if [ "$remote" == "none" -o -z "$remote" ]; then
 		[ "$1" != "-q" -a "$1" != "-w" ] && error 2 "$version ($branch) branch not found on github"


### PR DESCRIPTION
- [x] Add missing module global variable `voltage_fluctuation_threshold` in `module/powerflow/node.cpp`.
- [x] Add separate under and over-voltage deviation thresholds in `module/powerflow/node.cpp`.
- [x] Fix voltage deviation default logic in `module/powerflow/node.cpp`
- [x] Separate `violation_rating` parameter from continuous/emergency rating logic on links.
- [x] Fix child node roll up of `DER_value` in node
- [x] Add documentation for [/Use cases/Hosting capacity](https://docs.gridlabd.us/index.html?owner=slacgismo&project=gridlabd&branch=develop-fix-voltage-violation-detection&folder=/Use%20cases&doc=/Use%20cases/Hosting%20capacity.md)