### PR TITLE
Fix node undervoltage violation limit

### DIFF
--- a/docs/Module/Powerflow/Node.md
+++ b/docs/Module/Powerflow/Node.md
@@ -79,6 +79,8 @@ GLM:
     nominal_voltage "<decimal> V";
     voltage_violation_threshold "<decimal> pu";
     voltage_fluctuation_threshold "<decimal> pu";
+    undervoltage_violation_threshold "<decimal> pu";
+    overvoltage_violation_threshold "<decimal> pu";
     DER_value "<decimal> kVA";
   }
 ~~~
@@ -660,6 +662,8 @@ TODO
 TODO
 
 ### `voltage_violation_threshold`
+### `undervoltage_violation_threshold`
+### `overvoltage_violation_threshold`
 
 ~~~
   double voltage_violation_threshold[pu];

--- a/module/powerflow/node.cpp
+++ b/module/powerflow/node.cpp
@@ -511,7 +511,7 @@ int node::create(void)
 	//Multi-island tracking
 	reset_island_state = false;	//Reset is disabled, by default
 
-	undervoltage_violation_threshold = -default_undervoltage_violation_threshold;
+	undervoltage_violation_threshold = default_undervoltage_violation_threshold;
 	overvoltage_violation_threshold = default_overvoltage_violation_threshold;
 
 	return result;

--- a/module/powerflow/node.cpp
+++ b/module/powerflow/node.cpp
@@ -511,6 +511,9 @@ int node::create(void)
 	//Multi-island tracking
 	reset_island_state = false;	//Reset is disabled, by default
 
+	undervoltage_violation_threshold = -default_undervoltage_violation_threshold;
+	overvoltage_violation_threshold = default_overvoltage_violation_threshold;
+
 	return result;
 }
 
@@ -1439,21 +1442,9 @@ int node::init(OBJECT *parent)
 	{
 		voltage_violation_threshold = 0.0;
 	}
-	if ( undervoltage_violation_threshold == 0.0 ) // 0.0 --> use global default threshold
+	if ( undervoltage_violation_threshold > overvoltage_violation_threshold ) // this is not good
 	{
-		undervoltage_violation_threshold = default_undervoltage_violation_threshold;
-	}
-	else if ( undervoltage_violation_threshold < 0.0 ) // <0.0 --> disable threshold
-	{
-		undervoltage_violation_threshold = 0.0;
-	}
-	if ( overvoltage_violation_threshold == 0.0 ) // 0.0 --> use global default threshold
-	{
-		overvoltage_violation_threshold = default_overvoltage_violation_threshold;
-	}
-	else if ( overvoltage_violation_threshold < 0.0 ) // <0.0 --> disable threshold
-	{
-		overvoltage_violation_threshold = 0.0;
+		warning("undervoltage_violation_threshold is greater than overvoltage_violation_threshold");
 	}
 	if ( voltage_fluctuation_threshold == 0.0 ) // 0.0 --> use global default threshold
 	{

--- a/source/autotest/test_class_event_handler.py
+++ b/source/autotest/test_class_event_handler.py
@@ -1,7 +1,7 @@
 import sys, gridlabd
 
 def on_init(t):
-    print(gridlabd.version(),file=sys.stderr)
+    # print(gridlabd.version(),file=sys.stderr)
     return True
 
 def test_init(obj,t):


### PR DESCRIPTION
This PR fixes issue #1197.

Note the change in how the under/over voltage violation limit defaults are handled.  

1. When `undervoltage_violation_threshold` is not set, it is set to `default_undervoltage_violation_threshold`.
2. When `overvoltage_violation_threshold` is not set, it is set to `default_overvoltage_violation_threshold`.
3. When `undervoltage_violation_threshold > overvoltage_violation_threshold` a warning is reported.