### PR TITLE
Fix json error in version output

### DIFF
--- a/source/cmdarg.cpp
+++ b/source/cmdarg.cpp
@@ -707,10 +707,10 @@ int GldCmdarg::version(int argc, const char *argv[])
 		global_suppress_repeat_messages = false;
 		output_message("{");
 #define OUTPUT(TAG,FORMAT,VALUE) output_message("\t\"%s\" : \"" FORMAT "\",",TAG,VALUE)
-#define OUTPUT_LAST(TAG,FORMAT,VALUE) output_message("\t\"%s\" : \"" FORMAT "\"\n}",TAG,VALUE)
+#define OUTPUT_LAST(TAG,FORMAT,VALUE) output_message("\t\"%s\" : \"%s\"\n}",TAG,escape(VALUE))
 #define OUTPUT_LIST_START(TAG) output_message("\t\"%s\" : [",TAG)
-#define OUTPUT_LIST_ITEM(VALUE) output_message("\t\t\"%s\",",VALUE)
-#define OUTPUT_LIST_END(VALUE) output_message("\t\t\"%s\"],",VALUE)
+#define OUTPUT_LIST_ITEM(VALUE) output_message("\t\t\"%s\",",escape(VALUE))
+#define OUTPUT_LIST_END(VALUE) output_message("\t\t\"%s\"],",escape(VALUE))
 #define OUTPUT_MULTILINE(TAG,VALUE) {\
 		const char *value = VALUE;\
 		char *token=NULL, *last=NULL;\

--- a/source/json.cpp
+++ b/source/json.cpp
@@ -35,7 +35,7 @@ GldJsonWriter::~GldJsonWriter(void)
 	free((void*)filename);
 }
 
-const char * escape(const char *buffer, size_t len = 1024)
+const char * escape(const char *buffer, size_t len)
 {
 	static char *result = NULL;
 	static size_t result_len = 0;

--- a/source/json.h
+++ b/source/json.h
@@ -18,6 +18,7 @@
 DEPRECATED CDECL int json_dump(const char *filename);
 DEPRECATED CDECL int json_output(FILE *fp);
 DEPRECATED CDECL int json_to_glm(const char *jsonfile, char *glmfile);
+DEPRECATED CDECL const char * escape(const char *buffer, size_t len = 1024);
 
 class GldJsonWriter
 {


### PR DESCRIPTION
This fixes a problem with GridLAB-D version data containing unescaped quotes and causing an error when displaying the license data in the TK dialog. Running `gridlabd` alone without a `gridlabd.glm` present should display the version info in a dialog. 