### PR TITLE
Add create_meters tool

### DIFF
--- a/source/load.cpp
+++ b/source/load.cpp
@@ -8238,11 +8238,11 @@ int GldLoader::process_macro(char *line, int size, char *_filename, int linenum)
 	}
 	else if ( strncmp(line, "#for",4) == 0 )
 	{
-		char var[64], range[1024];
+		char var[64], range[1024] = "";
 		if ( line[0] == '"' ) line++;
 		char *end = line + strlen(line);
 		if ( end[-1] == '"') end[-1] = '\0';
-		if ( sscanf(line+4,"%s in%*[ \t\"]%[^\n\"]",var,range) == 2 )
+		if ( sscanf(line+4,"%s in%*[ \t\"]%[^\n\"]",var,range) >= 1 )
 		{
 			strcpy(line,"\n");
 			return for_open(var,range) ? TRUE : FALSE;

--- a/tools/Makefile.mk
+++ b/tools/Makefile.mk
@@ -1,5 +1,6 @@
 dist_pkgdata_DATA += tools/create_filter.py
 dist_pkgdata_DATA += tools/create_player.py
+dist_pkgdata_DATA += tools/create_meters.py
 dist_pkgdata_DATA += tools/create_poles.py
 dist_pkgdata_DATA += tools/eia_recs.py
 dist_pkgdata_DATA += tools/find_location.py

--- a/tools/autotest/ieee13-meters.glm
+++ b/tools/autotest/ieee13-meters.glm
@@ -1,0 +1,3983 @@
+// JSON to GLM Converter Output
+// InputFile '../ieee13-meters.json'
+// CreateDate '2022-11-23 13:23:54 '
+
+
+// CLOCK
+clock {
+	timezone PST8PDT;
+	starttime "1999-12-31 16:00:00 PST";
+	stoptime "NEVER";
+}
+
+// MODULES
+module powerflow
+{
+	show_matrix_values FALSE;
+	primary_voltage_ratio +60 pu;
+	nominal_frequency +60 Hz;
+	require_voltage_control FALSE;
+	geographic_degree +3.21944;
+	fault_impedance +1e-06+0j Ohm;
+	ground_impedance +1e-06+0j Ohm;
+	warning_underfrequency +55 Hz;
+	warning_overfrequency +65 Hz;
+	warning_undervoltage +0.8 V;
+	warning_overvoltage +1.2 V;
+	warning_voltageangle +2;
+	maximum_voltage_error +1e-06 V;
+	solver_method NR;
+	NR_matrix_output_interval NEVER;
+	NR_matrix_output_references FALSE;
+	NR_matrix_output_rhs FALSE;
+	NR_island_failure_handled FALSE;
+	line_capacitance FALSE;
+	line_limits TRUE;
+	NR_iteration_limit 500;
+	NR_deltamode_iteration_limit 10;
+	NR_superLU_procs 1;
+	default_maximum_voltage_error +1e-06 pu;
+	default_maximum_power_error +0.0001 pu;
+	NR_admit_change FALSE;
+	enable_subsecond_models FALSE;
+	all_powerflow_delta FALSE;
+	deltamode_timestep +1e+07 ns;
+	current_frequency +60 Hz;
+	master_frequency_update FALSE;
+	enable_frequency_dependence FALSE;
+	default_resistance +0.0001 Ohm;
+	enable_inrush FALSE;
+	low_voltage_impedance_level +0.7 pu;
+	enable_mesh_fault_current FALSE;
+	convergence_error_handling FATAL;
+	solver_profile_enable FALSE;
+	solver_profile_filename solver_nr_profile.txt;
+	solver_profile_headers_included TRUE;
+	solver_headers timestamp,duration[microsec],iteration,bus_count,branch_count,error;
+	solver_profile_csv FALSE;
+	solver_py_config /usr/local/var/gridlabd/solver_py.conf;
+	solver_dump_enable FALSE;
+	violation_count 4;
+	violation_active 4;
+	violation_watchset ALL;
+	voltage_violation_threshold +0.05 pu;
+	undervoltage_violation_threshold +0 pu;
+	overvoltage_violation_threshold +0 pu;
+	voltage_fluctuation_threshold +0.03 pu;
+	DER_violation_test ANY;
+	default_continuous_rating +1000 A;
+	default_emergency_rating +2000 A;
+	default_violation_rating +0 A;
+	market_price_name current_market.clearing_price;
+	repair_time +24 h;
+	wind_speed_name wind_speed;
+	wind_dir_name wind_dir;
+	wind_gust_name wind_gust;
+	stop_on_pole_failure FALSE;
+	climate_impact_zone NONE;
+}
+
+// GLOBALS
+// version.major is set to 4
+// version.minor is set to 3
+// version.patch is set to 1
+// version.build is set to 221114
+// version.branch is set to develop
+// version is set to 4.3.1-221114-develop
+// command_line is set to /usr/local/opt/gridlabd/4.3.1-221114-develop/bin/gridlabd.bin -I ./ieee13.glm -o ./ieee13.json
+#ifndef environment
+#define environment=batch
+#else
+#set environment=batch
+#endif //environment
+#ifndef quiet
+global bool quiet FALSE;
+#else
+#set quiet=FALSE
+#endif //quiet
+#ifndef warn
+global bool warn TRUE;
+#else
+#set warn=TRUE
+#endif //warn
+#ifndef debugger
+global bool debugger FALSE;
+#else
+#set debugger=FALSE
+#endif //debugger
+#ifndef gdb
+global bool gdb FALSE;
+#else
+#set gdb=FALSE
+#endif //gdb
+#ifndef debug
+global bool debug FALSE;
+#else
+#set debug=FALSE
+#endif //debug
+#ifndef test
+global bool test FALSE;
+#else
+#set test=FALSE
+#endif //test
+#ifndef verbose
+global bool verbose FALSE;
+#else
+#set verbose=FALSE
+#endif //verbose
+#ifndef iteration_limit
+global int32 iteration_limit 100;
+#else
+#set iteration_limit=100
+#endif //iteration_limit
+// workdir is set to /Users/david/Documents/GitHub/slacgismo/gridlabd/tools/autotest
+#ifndef dumpfile
+#define dumpfile=gridlabd.json
+#else
+#set dumpfile=gridlabd.json
+#endif //dumpfile
+#ifndef savefile
+#define savefile=./ieee13.json
+#else
+#set savefile=./ieee13.json
+#endif //savefile
+#ifndef dumpall
+global bool dumpall FALSE;
+#else
+#set dumpall=FALSE
+#endif //dumpall
+#ifndef runchecks
+global bool runchecks FALSE;
+#else
+#set runchecks=FALSE
+#endif //runchecks
+#ifndef threadcount
+global int32 threadcount 1;
+#else
+#set threadcount=1
+#endif //threadcount
+#ifndef profiler
+global bool profiler FALSE;
+#else
+#set profiler=FALSE
+#endif //profiler
+#ifndef pauseatexit
+global bool pauseatexit FALSE;
+#else
+#set pauseatexit=FALSE
+#endif //pauseatexit
+#ifndef testoutputfile
+#define testoutputfile=test.txt
+#else
+#set testoutputfile=test.txt
+#endif //testoutputfile
+#ifndef xml_encoding
+global int32 xml_encoding 8;
+#else
+#set xml_encoding=8
+#endif //xml_encoding
+#ifndef clock
+global timestamp clock "1999-12-31 16:00:00 PST";
+#else
+#set clock=1999-12-31 16:00:00 PST
+#endif //clock
+#ifndef starttime
+global timestamp starttime "1999-12-31 16:00:00 PST";
+#else
+#set starttime=1999-12-31 16:00:00 PST
+#endif //starttime
+#ifndef stoptime
+global timestamp stoptime "NEVER";
+#else
+#set stoptime=NEVER
+#endif //stoptime
+#ifndef double_format
+global char32 double_format "%+lg";
+#else
+#set double_format=%+lg
+#endif //double_format
+#ifndef complex_format
+global char256 complex_format "%+lg%+lg%c";
+#else
+#set complex_format=%+lg%+lg%c
+#endif //complex_format
+#ifndef complex_output_format
+global enumeration complex_output_format DEFAULT;
+#else
+#set complex_output_format=DEFAULT
+#endif //complex_output_format
+#ifndef object_format
+global char32 object_format "%s:%d";
+#else
+#set object_format=%s:%d
+#endif //object_format
+#ifndef object_scan
+global char32 object_scan "%[^:]:%d";
+#else
+#set object_scan=%[^:]:%d
+#endif //object_scan
+#ifndef object_tree_balance
+global bool object_tree_balance FALSE;
+#else
+#set object_tree_balance=FALSE
+#endif //object_tree_balance
+// kmlfile is set to 
+#ifndef kmlhost
+#define kmlhost=https://code.gridlabd.us/develop/runtime
+#else
+#set kmlhost=https://code.gridlabd.us/develop/runtime
+#endif //kmlhost
+// modelname is set to ./ieee13.glm
+// execdir is set to /usr/local/opt/gridlabd/4.3.1-221114-develop/bin
+#ifndef strictnames
+global bool strictnames TRUE;
+#else
+#set strictnames=TRUE
+#endif //strictnames
+#ifndef website
+#define website=http://www.gridlabd.org/
+#else
+#set website=http://www.gridlabd.org/
+#endif //website
+#ifndef urlbase
+#define urlbase=http://www.gridlabd.org/
+#else
+#set urlbase=http://www.gridlabd.org/
+#endif //urlbase
+#ifndef randomstate
+global int32 randomstate 1006654997;
+#else
+#set randomstate=1006654997
+#endif //randomstate
+#ifndef randomseed
+global int32 randomseed 1006654997;
+#else
+#set randomseed=1006654997
+#endif //randomseed
+// include is set to 
+// trace is set to 
+#ifndef gdb_window
+global bool gdb_window FALSE;
+#else
+#set gdb_window=FALSE
+#endif //gdb_window
+#ifndef tmp
+#define tmp=/Users/david/.gridlabd/tmp
+#else
+#set tmp=/Users/david/.gridlabd/tmp
+#endif //tmp
+#ifndef force_compile
+global int32 force_compile 0;
+#else
+#set force_compile=0
+#endif //force_compile
+#ifndef nolocks
+global bool nolocks FALSE;
+#else
+#set nolocks=FALSE
+#endif //nolocks
+#ifndef skipsafe
+global bool skipsafe FALSE;
+#else
+#set skipsafe=FALSE
+#endif //skipsafe
+#ifndef dateformat
+global enumeration dateformat ISO;
+#else
+#set dateformat=ISO
+#endif //dateformat
+#ifndef init_sequence
+global enumeration init_sequence DEFERRED;
+#else
+#set init_sequence=DEFERRED
+#endif //init_sequence
+#ifndef minimum_timestep
+global int32 minimum_timestep 1;
+#else
+#set minimum_timestep=1
+#endif //minimum_timestep
+// platform is set to MACOSX
+#ifndef suppress_repeat_messages
+global bool suppress_repeat_messages TRUE;
+#else
+#set suppress_repeat_messages=TRUE
+#endif //suppress_repeat_messages
+#ifndef maximum_synctime
+global int32 maximum_synctime 60;
+#else
+#set maximum_synctime=60
+#endif //maximum_synctime
+#ifndef run_realtime
+global bool run_realtime FALSE;
+#else
+#set run_realtime=FALSE
+#endif //run_realtime
+#ifndef enter_realtime
+global timestamp enter_realtime "NEVER";
+#else
+#set enter_realtime=NEVER
+#endif //enter_realtime
+// realtime_metric is set to +0
+#ifndef no_deprecate
+global bool no_deprecate FALSE;
+#else
+#set no_deprecate=FALSE
+#endif //no_deprecate
+// streaming_io is set to FALSE
+// compileonly is set to FALSE
+#ifndef relax_naming_rules
+global bool relax_naming_rules FALSE;
+#else
+#set relax_naming_rules=FALSE
+#endif //relax_naming_rules
+#ifndef browser
+#define browser=safari
+#else
+#set browser=safari
+#endif //browser
+#ifndef server_portnum
+global int32 server_portnum 0;
+#else
+#set server_portnum=0
+#endif //server_portnum
+#ifndef server_quit_on_close
+global bool server_quit_on_close FALSE;
+#else
+#set server_quit_on_close=FALSE
+#endif //server_quit_on_close
+// client_allowed is set to 
+#ifndef autoclean
+global bool autoclean TRUE;
+#else
+#set autoclean=TRUE
+#endif //autoclean
+#ifndef technology_readiness_level
+global enumeration technology_readiness_level UNKNOWN;
+#else
+#set technology_readiness_level=UNKNOWN
+#endif //technology_readiness_level
+#ifndef show_progress
+global bool show_progress TRUE;
+#else
+#set show_progress=TRUE
+#endif //show_progress
+#ifndef checkpoint_type
+global enumeration checkpoint_type NONE;
+#else
+#set checkpoint_type=NONE
+#endif //checkpoint_type
+// checkpoint_file is set to 
+#ifndef checkpoint_seqnum
+global int32 checkpoint_seqnum 0;
+#else
+#set checkpoint_seqnum=0
+#endif //checkpoint_seqnum
+#ifndef checkpoint_interval
+global int32 checkpoint_interval 0;
+#else
+#set checkpoint_interval=0
+#endif //checkpoint_interval
+#ifndef checkpoint_keepall
+global bool checkpoint_keepall FALSE;
+#else
+#set checkpoint_keepall=FALSE
+#endif //checkpoint_keepall
+#ifndef check_version
+global bool check_version FALSE;
+#else
+#set check_version=FALSE
+#endif //check_version
+#ifndef random_number_generator
+global enumeration random_number_generator RNG3;
+#else
+#set random_number_generator=RNG3
+#endif //random_number_generator
+#ifndef mainloop_state
+global enumeration mainloop_state DONE;
+#else
+#set mainloop_state=DONE
+#endif //mainloop_state
+#ifndef pauseat
+global timestamp pauseat "NEVER";
+#else
+#set pauseat=NEVER
+#endif //pauseat
+// infourl is set to http://docs.gridlabd.us/index.html?owner=hipas&project=gridlabd&search=
+#ifndef hostname
+#define hostname=localhost
+#else
+#set hostname=localhost
+#endif //hostname
+#ifndef hostaddr
+global char32 hostaddr "127.0.0.1";
+#else
+#set hostaddr=127.0.0.1
+#endif //hostaddr
+#ifndef autostart_gui
+global bool autostart_gui TRUE;
+#else
+#set autostart_gui=TRUE
+#endif //autostart_gui
+// master is set to 
+#ifndef master_port
+global int64 master_port 0;
+#else
+#set master_port=0
+#endif //master_port
+#ifndef multirun_mode
+global enumeration multirun_mode STANDALONE;
+#else
+#set multirun_mode=STANDALONE
+#endif //multirun_mode
+#ifndef multirun_conn
+global enumeration multirun_conn NONE;
+#else
+#set multirun_conn=NONE
+#endif //multirun_conn
+#ifndef signal_timeout
+global int32 signal_timeout 5000;
+#else
+#set signal_timeout=5000
+#endif //signal_timeout
+#ifndef slave_port
+global int16 slave_port 6267;
+#else
+#set slave_port=6267
+#endif //slave_port
+#ifndef slave_id
+global int64 slave_id 0;
+#else
+#set slave_id=0
+#endif //slave_id
+// return_code is set to 0
+// exit_code is set to 0
+#ifndef module_compiler_flags
+global set module_compiler_flags NONE;
+#else
+#set module_compiler_flags=NONE
+#endif //module_compiler_flags
+// init_max_defer is set to 64
+#ifndef mt_analysis
+global bool mt_analysis FALSE;
+#else
+#set mt_analysis=FALSE
+#endif //mt_analysis
+#ifndef inline_block_size
+global int32 inline_block_size 1048576;
+#else
+#set inline_block_size=1048576
+#endif //inline_block_size
+#ifndef validate
+global set validate TSTD|RALL;
+#else
+#set validate=TSTD|RALL
+#endif //validate
+#ifndef sanitize
+global set sanitize NAMES|POSITIONS;
+#else
+#set sanitize=NAMES|POSITIONS
+#endif //sanitize
+#ifndef sanitize_prefix
+global char8 sanitize_prefix "GLD_";
+#else
+#set sanitize_prefix=GLD_
+#endif //sanitize_prefix
+#ifndef sanitize_index
+#define sanitize_index=.txt
+#else
+#set sanitize_index=.txt
+#endif //sanitize_index
+// sanitize_offset is set to 
+#ifndef simulation_mode
+global enumeration simulation_mode EVENT;
+#else
+#set simulation_mode=EVENT
+#endif //simulation_mode
+#ifndef deltamode_allowed
+global bool deltamode_allowed FALSE;
+#else
+#set deltamode_allowed=FALSE
+#endif //deltamode_allowed
+#ifndef deltamode_timestep
+global int32 deltamode_timestep 10000000;
+#else
+#set deltamode_timestep=10000000
+#endif //deltamode_timestep
+#ifndef deltamode_maximumtime
+global int64 deltamode_maximumtime 3600000000000;
+#else
+#set deltamode_maximumtime=3600000000000
+#endif //deltamode_maximumtime
+#ifndef deltaclock
+global int64 deltaclock 0;
+#else
+#set deltaclock=0
+#endif //deltaclock
+#ifndef delta_current_clock
+global double delta_current_clock +0;
+#else
+#set delta_current_clock=+0
+#endif //delta_current_clock
+// deltamode_updateorder is set to powerflow
+#ifndef deltamode_iteration_limit
+global int32 deltamode_iteration_limit 10;
+#else
+#set deltamode_iteration_limit=10
+#endif //deltamode_iteration_limit
+#ifndef deltamode_forced_extra_timesteps
+global int32 deltamode_forced_extra_timesteps 0;
+#else
+#set deltamode_forced_extra_timesteps=0
+#endif //deltamode_forced_extra_timesteps
+#ifndef deltamode_forced_always
+global bool deltamode_forced_always FALSE;
+#else
+#set deltamode_forced_always=FALSE
+#endif //deltamode_forced_always
+#ifndef run_powerworld
+global bool run_powerworld FALSE;
+#else
+#set run_powerworld=FALSE
+#endif //run_powerworld
+#ifndef bigranks
+global bool bigranks TRUE;
+#else
+#set bigranks=TRUE
+#endif //bigranks
+// exename is set to /usr/local/opt/gridlabd/4.3.1-221114-develop/bin/gridlabd.bin
+#ifndef wget_options
+#define wget_options=maxsize:100MB;update:newer
+#else
+#set wget_options=maxsize:100MB;update:newer
+#endif //wget_options
+#ifndef curl_options
+#define curl_options=maxsize:100MB;update:newer
+#else
+#set curl_options=maxsize:100MB;update:newer
+#endif //curl_options
+#ifndef svnroot
+#define svnroot=http://gridlab-d.svn.sourceforge.net/svnroot/gridlab-d
+#else
+#set svnroot=http://gridlab-d.svn.sourceforge.net/svnroot/gridlab-d
+#endif //svnroot
+#ifndef github
+#define github=https://github.com/gridlab-d
+#else
+#set github=https://github.com/gridlab-d
+#endif //github
+#ifndef gitraw
+#define gitraw=https://raw.githubusercontent.com/gridlab-d
+#else
+#set gitraw=https://raw.githubusercontent.com/gridlab-d
+#endif //gitraw
+#ifndef allow_reinclude
+global bool allow_reinclude FALSE;
+#else
+#set allow_reinclude=FALSE
+#endif //allow_reinclude
+#ifndef output_message_context
+global set output_message_context ALL;
+#else
+#set output_message_context=ALL
+#endif //output_message_context
+#ifndef permissive_access
+global int32 permissive_access 0;
+#else
+#set permissive_access=0
+#endif //permissive_access
+#ifndef relax_undefined_if
+global bool relax_undefined_if FALSE;
+#else
+#set relax_undefined_if=FALSE
+#endif //relax_undefined_if
+#ifndef literal_if
+global bool literal_if TRUE;
+#else
+#set literal_if=TRUE
+#endif //literal_if
+#ifndef validto_context
+global enumeration validto_context 1414746112;
+#else
+#set validto_context=1414746112
+#endif //validto_context
+#ifndef daemon_configfile
+#define daemon_configfile=gridlabd.cnf
+#else
+#set daemon_configfile=gridlabd.cnf
+#endif //daemon_configfile
+// timezone_locale is set to PST8PDT
+#ifndef glm_save_options
+global set glm_save_options MINIMAL;
+#else
+#set glm_save_options=MINIMAL
+#endif //glm_save_options
+#ifndef filesave_options
+global set filesave_options ALL;
+#else
+#set filesave_options=ALL
+#endif //filesave_options
+#ifndef ignore_errors
+global bool ignore_errors FALSE;
+#else
+#set ignore_errors=FALSE
+#endif //ignore_errors
+#ifndef keep_progress
+global bool keep_progress FALSE;
+#else
+#set keep_progress=FALSE
+#endif //keep_progress
+#ifndef allow_variant_aggregates
+global bool allow_variant_aggregates FALSE;
+#else
+#set allow_variant_aggregates=FALSE
+#endif //allow_variant_aggregates
+// progress is set to +0
+#ifndef server_keepalive
+global bool server_keepalive FALSE;
+#else
+#set server_keepalive=FALSE
+#endif //server_keepalive
+#ifndef pythonpath
+#define pythonpath=.
+#else
+#set pythonpath=.
+#endif //pythonpath
+// pythonexec is set to /usr/local/Cellar/python@3.10/3.10.8/Frameworks/Python.framework/Versions/3.10/bin/python3.10
+#ifndef datadir
+#define datadir=/usr/local/opt/gridlabd/4.3.1-221114-develop/share/gridlabd
+#else
+#set datadir=/usr/local/opt/gridlabd/4.3.1-221114-develop/share/gridlabd
+#endif //datadir
+#ifndef json_complex_format
+global set json_complex_format STRING;
+#else
+#set json_complex_format=STRING
+#endif //json_complex_format
+#ifndef rusage_file
+#define rusage_file=gridlabd-rusage.csv
+#else
+#set rusage_file=gridlabd-rusage.csv
+#endif //rusage_file
+#ifndef rusage_rate
+global int64 rusage_rate 0;
+#else
+#set rusage_rate=0
+#endif //rusage_rate
+#ifndef rusage
+#define rusage={"utime" : 0.429164, "stime" : 0.084959, "maxrss" : 26968064, "ixrss" : 0, "idrss" : 0, "isrss" : 0, "minflt" : 7464, "majflt" : 0, "nswap" : 0, "inblock" : 0, "oublock" : 0, "msgsnd" : 0, "msgrcv" : 0, "nsignals" : 0, "nvcsw" : 0, "nivcsw" : 1726}
+#else
+#set rusage={"utime" : 0.429164, "stime" : 0.084959, "maxrss" : 26968064, "ixrss" : 0, "idrss" : 0, "isrss" : 0, "minflt" : 7464, "majflt" : 0, "nswap" : 0, "inblock" : 0, "oublock" : 0, "msgsnd" : 0, "msgrcv" : 0, "nsignals" : 0, "nvcsw" : 0, "nivcsw" : 1726}
+#endif //rusage
+#ifndef echo
+global bool echo FALSE;
+#else
+#set echo=FALSE
+#endif //echo
+// filename is set to 
+#ifndef country
+global char8 country "US";
+#else
+#set country=US
+#endif //country
+#ifndef region
+global char32 region "CA";
+#else
+#set region=CA
+#endif //region
+#ifndef organization
+global char32 organization "SLAC";
+#else
+#set organization=SLAC
+#endif //organization
+// profile_output_format is set to 
+#ifndef maximum_runtime
+global int64 maximum_runtime 0;
+#else
+#set maximum_runtime=0
+#endif //maximum_runtime
+// powerflow::message_flags is set to 
+// powerflow::show_matrix_values is set to FALSE
+// powerflow::primary_voltage_ratio is set to +60 pu
+// powerflow::nominal_frequency is set to +60 Hz
+// powerflow::require_voltage_control is set to FALSE
+// powerflow::geographic_degree is set to +3.21944
+// powerflow::fault_impedance is set to +1e-06+0j Ohm
+// powerflow::ground_impedance is set to +1e-06+0j Ohm
+// powerflow::warning_underfrequency is set to +55 Hz
+// powerflow::warning_overfrequency is set to +65 Hz
+// powerflow::warning_undervoltage is set to +0.8 V
+// powerflow::warning_overvoltage is set to +1.2 V
+// powerflow::warning_voltageangle is set to +2
+// powerflow::maximum_voltage_error is set to +1e-06 V
+// powerflow::solver_method is set to NR
+// powerflow::NR_matrix_file is set to 
+// powerflow::NR_matrix_output_interval is set to NEVER
+// powerflow::NR_matrix_output_references is set to FALSE
+// powerflow::NR_matrix_output_rhs is set to FALSE
+// powerflow::NR_island_failure_handled is set to FALSE
+// powerflow::line_capacitance is set to FALSE
+// powerflow::line_limits is set to TRUE
+// powerflow::lu_solver is set to 
+// powerflow::NR_iteration_limit is set to 500
+// powerflow::NR_deltamode_iteration_limit is set to 10
+// powerflow::NR_superLU_procs is set to 1
+// powerflow::default_maximum_voltage_error is set to +1e-06 pu
+// powerflow::default_maximum_power_error is set to +0.0001 pu
+// powerflow::NR_admit_change is set to FALSE
+// powerflow::enable_subsecond_models is set to FALSE
+// powerflow::all_powerflow_delta is set to FALSE
+// powerflow::deltamode_timestep is set to +1e+07 ns
+// powerflow::current_frequency is set to +60 Hz
+// powerflow::master_frequency_update is set to FALSE
+// powerflow::enable_frequency_dependence is set to FALSE
+// powerflow::default_resistance is set to +0.0001 Ohm
+// powerflow::enable_inrush is set to FALSE
+// powerflow::low_voltage_impedance_level is set to +0.7 pu
+// powerflow::enable_mesh_fault_current is set to FALSE
+// powerflow::convergence_error_handling is set to FATAL
+// powerflow::solver_profile_enable is set to FALSE
+// powerflow::solver_profile_filename is set to solver_nr_profile.txt
+// powerflow::solver_profile_headers_included is set to TRUE
+// powerflow::solver_headers is set to timestamp,duration[microsec],iteration,bus_count,branch_count,error
+// powerflow::solver_profile_csv is set to FALSE
+// powerflow::solver_py_config is set to /usr/local/var/gridlabd/solver_py.conf
+// powerflow::solver_dump_enable is set to FALSE
+// powerflow::violation_record is set to 
+// powerflow::violation_count is set to 4
+// powerflow::violation_active is set to 4
+// powerflow::violation_watchset is set to ALL
+// powerflow::voltage_violation_threshold is set to +0.05 pu
+// powerflow::undervoltage_violation_threshold is set to +0 pu
+// powerflow::overvoltage_violation_threshold is set to +0 pu
+// powerflow::voltage_fluctuation_threshold is set to +0.03 pu
+// powerflow::DER_violation_test is set to ANY
+// powerflow::default_continuous_rating is set to +1000 A
+// powerflow::default_emergency_rating is set to +2000 A
+// powerflow::default_violation_rating is set to +0 A
+// powerflow::market_price_name is set to current_market.clearing_price
+// powerflow::repair_time is set to +24 h
+// powerflow::wind_speed_name is set to wind_speed
+// powerflow::wind_dir_name is set to wind_dir
+// powerflow::wind_gust_name is set to wind_gust
+// powerflow::stop_on_pole_failure is set to FALSE
+// powerflow::climate_impact_zone is set to NONE
+
+// CLASSES// SCHEDULES
+
+
+
+// OBJECTS
+object overhead_line_conductor
+{
+	name "conductor1";
+	rng_state "16807";
+	guid "762C2B2AF26D6AC87A3BC37B61CCF7EA";
+	geometric_mean_radius "0.0313 ft";
+	resistance "0.1859 Ohm/mile";
+	diameter "0 in";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+	weight "0 lb/ft";
+	strength "0 lb";
+}
+object overhead_line_conductor
+{
+	name "conductor2";
+	rng_state "282475249";
+	guid "6DB1A47F56D8FE3D483A77F52770A74C";
+	geometric_mean_radius "0.00814 ft";
+	resistance "0.592 Ohm/mile";
+	diameter "0 in";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+	weight "0 lb/ft";
+	strength "0 lb";
+}
+object overhead_line_conductor
+{
+	name "conductor3";
+	rng_state "1622650073";
+	guid "273F5FD7535348522F72A946E249A432";
+	geometric_mean_radius "0.00446 ft";
+	resistance "1.12 Ohm/mile";
+	diameter "0 in";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+	weight "0 lb/ft";
+	strength "0 lb";
+}
+object underground_line_conductor
+{
+	name "conductor4";
+	rng_state "984943658";
+	guid "4962AF764100E0C29F4ED17FE2920A";
+	outer_diameter "1.29 in";
+	conductor_gmr "0.0171 ft";
+	conductor_diameter "0.567 in";
+	conductor_resistance "0.41 Ohm/mile";
+	neutral_gmr "0.00208 ft";
+	neutral_diameter "0.0640837 in";
+	neutral_resistance "14.872 Ohm/mile";
+	neutral_strands "13";
+	shield_thickness "0 in";
+	shield_diameter "0 in";
+	insulation_relative_permitivitty "1 unit";
+	shield_gmr "0 ft";
+	shield_resistance "0 Ohm/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object underground_line_conductor
+{
+	name "conductor5";
+	rng_state "1144108930";
+	guid "2DD4481C1B1107A83C135EBAE7E0AEB2";
+	outer_diameter "1.06 in";
+	conductor_gmr "0.0111 ft";
+	conductor_diameter "0.368 in";
+	conductor_resistance "0.97 Ohm/mile";
+	neutral_gmr "0.0111 ft";
+	neutral_diameter "0.0640837 in";
+	neutral_resistance "0.97 Ohm/mile";
+	neutral_strands "6";
+	shield_thickness "0 in";
+	shield_diameter "0 in";
+	insulation_relative_permitivitty "1 unit";
+	shield_gmr "0 ft";
+	shield_resistance "0 Ohm/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object line_spacing
+{
+	name "line_spacing1";
+	rng_state "470211272";
+	guid "5C8E6AA9B2F69CC14D638A91F7B557BA";
+	distance_AB "2.5 ft";
+	distance_BC "7 ft";
+	distance_AC "4.5 ft";
+	distance_AN "4.272 ft";
+	distance_BN "5.65685 ft";
+	distance_CN "5 ft";
+	distance_AE "0 ft";
+	distance_BE "0 ft";
+	distance_CE "0 ft";
+	distance_NE "0 ft";
+}
+object line_spacing
+{
+	name "line_spacing2";
+	rng_state "101027544";
+	guid "6EB3E09C384CD06110F0C9FAF8F3B9A4";
+	distance_AB "4.5 ft";
+	distance_BC "7 ft";
+	distance_AC "2.5 ft";
+	distance_AN "4.272 ft";
+	distance_BN "5 ft";
+	distance_CN "5.65685 ft";
+	distance_AE "0 ft";
+	distance_BE "0 ft";
+	distance_CE "0 ft";
+	distance_NE "0 ft";
+}
+object line_spacing
+{
+	name "line_spacing3";
+	rng_state "1457850878";
+	guid "69F6A86853D37FB87121410CE94D69F9";
+	distance_AB "0 ft";
+	distance_BC "7 ft";
+	distance_AC "0 ft";
+	distance_AN "0 ft";
+	distance_BN "5 ft";
+	distance_CN "5.65685 ft";
+	distance_AE "0 ft";
+	distance_BE "0 ft";
+	distance_CE "0 ft";
+	distance_NE "0 ft";
+}
+object line_spacing
+{
+	name "line_spacing4";
+	rng_state "1458777923";
+	guid "3A83468B08E03F304302F38C533B64C6";
+	distance_AB "0 ft";
+	distance_BC "0 ft";
+	distance_AC "7 ft";
+	distance_AN "5.65685 ft";
+	distance_BN "0 ft";
+	distance_CN "5 ft";
+	distance_AE "0 ft";
+	distance_BE "0 ft";
+	distance_CE "0 ft";
+	distance_NE "0 ft";
+}
+object line_spacing
+{
+	name "line_spacing5";
+	rng_state "2007237709";
+	guid "49BA227BC2FCE8602C0CFAE49E2D9D3C";
+	distance_AB "0 ft";
+	distance_BC "0 ft";
+	distance_AC "0 ft";
+	distance_AN "0 ft";
+	distance_BN "0 ft";
+	distance_CN "5 ft";
+	distance_AE "0 ft";
+	distance_BE "0 ft";
+	distance_CE "0 ft";
+	distance_NE "0 ft";
+}
+object line_spacing
+{
+	name "line_spacing6";
+	rng_state "823564440";
+	guid "BAE066DD581BC1034D19818A5646C59";
+	distance_AB "0.5 ft";
+	distance_BC "0.5 ft";
+	distance_AC "1 ft";
+	distance_AN "0 ft";
+	distance_BN "0 ft";
+	distance_CN "0 ft";
+	distance_AE "0 ft";
+	distance_BE "0 ft";
+	distance_CE "0 ft";
+	distance_NE "0 ft";
+}
+object line_spacing
+{
+	name "line_spacing_7";
+	rng_state "1115438165";
+	guid "54381159185F4FCA64547F410C8230E4";
+	distance_AB "0 ft";
+	distance_BC "0 ft";
+	distance_AC "0 ft";
+	distance_AN "0.083333 ft";
+	distance_BN "0 ft";
+	distance_CN "0 ft";
+	distance_AE "0 ft";
+	distance_BE "0 ft";
+	distance_CE "0 ft";
+	distance_NE "0 ft";
+}
+object line_configuration
+{
+	name "line_configuration1";
+	rng_state "1784484492";
+	guid "2640FEDC951AD99069CA1E2C3081C784";
+	conductor_A "conductor1";
+	conductor_B "conductor1";
+	conductor_C "conductor1";
+	conductor_N "conductor2";
+	spacing "line_spacing1";
+	z11 "0+0j Ohm/mile";
+	z12 "0+0j Ohm/mile";
+	z13 "0+0j Ohm/mile";
+	z21 "0+0j Ohm/mile";
+	z22 "0+0j Ohm/mile";
+	z23 "0+0j Ohm/mile";
+	z31 "0+0j Ohm/mile";
+	z32 "0+0j Ohm/mile";
+	z33 "0+0j Ohm/mile";
+	c11 "0 nF/mile";
+	c12 "0 nF/mile";
+	c13 "0 nF/mile";
+	c21 "0 nF/mile";
+	c22 "0 nF/mile";
+	c23 "0 nF/mile";
+	c31 "0 nF/mile";
+	c32 "0 nF/mile";
+	c33 "0 nF/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object line_configuration
+{
+	name "line_configuration2";
+	rng_state "74243042";
+	guid "42211C6C3ED018EA74806382BCA13A6C";
+	conductor_A "conductor2";
+	conductor_B "conductor2";
+	conductor_C "conductor2";
+	conductor_N "conductor2";
+	spacing "line_spacing2";
+	z11 "0+0j Ohm/mile";
+	z12 "0+0j Ohm/mile";
+	z13 "0+0j Ohm/mile";
+	z21 "0+0j Ohm/mile";
+	z22 "0+0j Ohm/mile";
+	z23 "0+0j Ohm/mile";
+	z31 "0+0j Ohm/mile";
+	z32 "0+0j Ohm/mile";
+	z33 "0+0j Ohm/mile";
+	c11 "0 nF/mile";
+	c12 "0 nF/mile";
+	c13 "0 nF/mile";
+	c21 "0 nF/mile";
+	c22 "0 nF/mile";
+	c23 "0 nF/mile";
+	c31 "0 nF/mile";
+	c32 "0 nF/mile";
+	c33 "0 nF/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object line_configuration
+{
+	name "line_configuration3";
+	rng_state "114807987";
+	guid "79C7974B786813CF63A8AFFAD18D55D4";
+	conductor_B "conductor3";
+	conductor_C "conductor3";
+	conductor_N "conductor3";
+	spacing "line_spacing3";
+	z11 "0+0j Ohm/mile";
+	z12 "0+0j Ohm/mile";
+	z13 "0+0j Ohm/mile";
+	z21 "0+0j Ohm/mile";
+	z22 "0+0j Ohm/mile";
+	z23 "0+0j Ohm/mile";
+	z31 "0+0j Ohm/mile";
+	z32 "0+0j Ohm/mile";
+	z33 "0+0j Ohm/mile";
+	c11 "0 nF/mile";
+	c12 "0 nF/mile";
+	c13 "0 nF/mile";
+	c21 "0 nF/mile";
+	c22 "0 nF/mile";
+	c23 "0 nF/mile";
+	c31 "0 nF/mile";
+	c32 "0 nF/mile";
+	c33 "0 nF/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object line_configuration
+{
+	name "line_configuration4";
+	rng_state "1137522503";
+	guid "435A02D9B3CC207B71D31F1A568B0C87";
+	conductor_A "conductor3";
+	conductor_C "conductor3";
+	conductor_N "conductor3";
+	spacing "line_spacing4";
+	z11 "0+0j Ohm/mile";
+	z12 "0+0j Ohm/mile";
+	z13 "0+0j Ohm/mile";
+	z21 "0+0j Ohm/mile";
+	z22 "0+0j Ohm/mile";
+	z23 "0+0j Ohm/mile";
+	z31 "0+0j Ohm/mile";
+	z32 "0+0j Ohm/mile";
+	z33 "0+0j Ohm/mile";
+	c11 "0 nF/mile";
+	c12 "0 nF/mile";
+	c13 "0 nF/mile";
+	c21 "0 nF/mile";
+	c22 "0 nF/mile";
+	c23 "0 nF/mile";
+	c31 "0 nF/mile";
+	c32 "0 nF/mile";
+	c33 "0 nF/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object line_configuration
+{
+	name "line_configuration5";
+	rng_state "1441282327";
+	guid "25320AB8BD70603E69CE391972E958B5";
+	conductor_C "conductor3";
+	conductor_N "conductor3";
+	spacing "line_spacing5";
+	z11 "0+0j Ohm/mile";
+	z12 "0+0j Ohm/mile";
+	z13 "0+0j Ohm/mile";
+	z21 "0+0j Ohm/mile";
+	z22 "0+0j Ohm/mile";
+	z23 "0+0j Ohm/mile";
+	z31 "0+0j Ohm/mile";
+	z32 "0+0j Ohm/mile";
+	z33 "0+0j Ohm/mile";
+	c11 "0 nF/mile";
+	c12 "0 nF/mile";
+	c13 "0 nF/mile";
+	c21 "0 nF/mile";
+	c22 "0 nF/mile";
+	c23 "0 nF/mile";
+	c31 "0 nF/mile";
+	c32 "0 nF/mile";
+	c33 "0 nF/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object line_configuration
+{
+	name "line_configuration6";
+	rng_state "16531729";
+	guid "67D538334EC9A4344CAA6336575C60BD";
+	conductor_A "conductor4";
+	conductor_B "conductor4";
+	conductor_C "conductor4";
+	spacing "line_spacing6";
+	z11 "0+0j Ohm/mile";
+	z12 "0+0j Ohm/mile";
+	z13 "0+0j Ohm/mile";
+	z21 "0+0j Ohm/mile";
+	z22 "0+0j Ohm/mile";
+	z23 "0+0j Ohm/mile";
+	z31 "0+0j Ohm/mile";
+	z32 "0+0j Ohm/mile";
+	z33 "0+0j Ohm/mile";
+	c11 "0 nF/mile";
+	c12 "0 nF/mile";
+	c13 "0 nF/mile";
+	c21 "0 nF/mile";
+	c22 "0 nF/mile";
+	c23 "0 nF/mile";
+	c31 "0 nF/mile";
+	c32 "0 nF/mile";
+	c33 "0 nF/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object line_configuration
+{
+	name "line_configuration7";
+	rng_state "823378840";
+	guid "7CB4867C4B02A8331AA9084165DACB98";
+	conductor_A "conductor5";
+	conductor_N "conductor5";
+	spacing "line_spacing6";
+	z11 "0+0j Ohm/mile";
+	z12 "0+0j Ohm/mile";
+	z13 "0+0j Ohm/mile";
+	z21 "0+0j Ohm/mile";
+	z22 "0+0j Ohm/mile";
+	z23 "0+0j Ohm/mile";
+	z31 "0+0j Ohm/mile";
+	z32 "0+0j Ohm/mile";
+	z33 "0+0j Ohm/mile";
+	c11 "0 nF/mile";
+	c12 "0 nF/mile";
+	c13 "0 nF/mile";
+	c21 "0 nF/mile";
+	c22 "0 nF/mile";
+	c23 "0 nF/mile";
+	c31 "0 nF/mile";
+	c32 "0 nF/mile";
+	c33 "0 nF/mile";
+	rating.summer.continuous "1000 A";
+	rating.summer.emergency "2000 A";
+	rating.winter.continuous "1000 A";
+	rating.winter.emergency "2000 A";
+}
+object transformer_configuration
+{
+	name "transformer_configuration1";
+	rng_state "143542612";
+	guid "3A7B354390C50A982ADA768A6EF3492E";
+	connect_type "WYE_WYE";
+	install_type "PADMOUNT";
+	coolant_type "UNKNOWN";
+	cooling_type "UNKNOWN";
+	primary_voltage "4160 V";
+	secondary_voltage "480 V";
+	power_rating "500 kVA";
+	powerA_rating "166.667 kVA";
+	powerB_rating "166.667 kVA";
+	powerC_rating "166.667 kVA";
+	powerN_rating "0 kVA";
+	resistance "0.011 pu*Ohm";
+	reactance "0.02 pu*Ohm";
+	impedance "0.011+0.02j pu*Ohm";
+	resistance1 "0 pu*Ohm";
+	reactance1 "0 pu*Ohm";
+	impedance1 "0+0j pu*Ohm";
+	resistance2 "0 pu*Ohm";
+	reactance2 "0 pu*Ohm";
+	impedance2 "0+0j pu*Ohm";
+	shunt_resistance "1e+09 pu*Ohm";
+	shunt_reactance "1e+09 pu*Ohm";
+	shunt_impedance "1e+09+1e+09j pu*Ohm";
+	core_coil_weight "0 lb";
+	tank_fittings_weight "0 lb";
+	oil_volume "0 gal";
+	rated_winding_time_constant "0 h";
+	rated_winding_hot_spot_rise "0 degC";
+	rated_top_oil_rise "0 degC";
+	no_load_loss "0 pu";
+	full_load_loss "0 pu";
+	reactance_resistance_ratio "4.5";
+	installed_insulation_life "0 h";
+	magnetization_location "NONE";
+	inrush_saturation_enabled "FALSE";
+	L_A "0.2 pu";
+	phi_K "1.17 pu";
+	phi_M "1 pu";
+	I_M "0.01 pu";
+	T_D "0.5";
+}
+object regulator_configuration
+{
+	name "regulator_configuration1";
+	rng_state "896544303";
+	guid "71A0DD02942E56722711D50F24151165";
+	connect_type "WYE_WYE";
+	band_center "2300 V";
+	band_width "20 V";
+	time_delay "30 s";
+	dwell_time "0 s";
+	raise_taps "16";
+	lower_taps "16";
+	current_transducer_ratio "0 pu";
+	power_transducer_ratio "0 pu";
+	compensator_r_setting_A "0 V";
+	compensator_r_setting_B "0 V";
+	compensator_r_setting_C "0 V";
+	compensator_x_setting_A "0 V";
+	compensator_x_setting_B "0 V";
+	compensator_x_setting_C "0 V";
+	CT_phase "CBA";
+	PT_phase "CBA";
+	regulation "0.1 %";
+	control_level "INDIVIDUAL";
+	Control "MANUAL";
+	reverse_flow_control "LOCK_NONE";
+	Type "B";
+	tap_pos_A "10";
+	tap_pos_B "8";
+	tap_pos_C "11";
+}
+object overhead_line
+{
+	name "overhead_line1";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1474833169";
+	guid "6E043CC4FBC532685C15550E0536CF23";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration3";
+	length "500 ft";
+	status "CLOSED";
+	from "Node632";
+	to "Load645";
+	power_in "415846+267024j VA";
+	power_out "413077+264627j VA";
+	power_out_real "413077 W";
+	power_losses "2769.49+2397.52j VA";
+	power_in_A "0-0j VA";
+	power_in_B "335347+127801j VA";
+	power_in_C "80499.4+139224j VA";
+	power_out_A "0+0j VA";
+	power_out_B "332801+125636j VA";
+	power_out_C "80276.1+138991j VA";
+	power_losses_A "0-0j VA";
+	power_losses_B "2546.21+2164.31j VA";
+	power_losses_C "223.279+233.209j VA";
+	current_out_A "0+0j A";
+	current_out_B "-113.592-86.92j A";
+	current_out_C "34.8038+55.4415j A";
+	current_in_A "0+0j A";
+	current_in_B "-113.592-86.92j A";
+	current_in_C "34.8038+55.4415j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BF|AN";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "BCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line2";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1264817709";
+	guid "3C4D8C8A43C8322C17A7E9C9F932D348";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration3";
+	length "300 ft";
+	status "CLOSED";
+	from "Load645";
+	to "Load646";
+	power_in "243077+139627j VA";
+	power_out "242531+139192j VA";
+	power_out_real "242531 W";
+	power_losses "545.388+434.765j VA";
+	power_in_A "0+0j VA";
+	power_in_B "162801+636.317j VA";
+	power_in_C "80276.1+138991j VA";
+	power_out_A "0+0j VA";
+	power_out_B "162527+420.132j VA";
+	power_out_C "80004.1+138772j VA";
+	power_losses_A "0+0j VA";
+	power_losses_B "273.378+216.185j VA";
+	power_losses_C "272.01+218.58j VA";
+	current_out_A "0+0j A";
+	current_out_B "-34.8038-55.4415j A";
+	current_out_C "34.8038+55.4415j A";
+	current_in_A "0+0j A";
+	current_in_B "-34.8038-55.4415j A";
+	current_in_C "34.8038+55.4415j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BF|AN";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "BCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line3";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1998097157";
+	guid "7BDA5428F25D2801484353BF67C7276A";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration1";
+	length "2000 ft";
+	status "CLOSED";
+	from "Node630";
+	to "Node632";
+	power_in "3.58139e+06+1.7191e+06j VA";
+	power_out "3.52212e+06+1.52772e+06j VA";
+	power_out_real "3.52212e+06 W";
+	power_losses "65704.4+191376j VA";
+	power_in_A "1.25277e+06+680249j VA";
+	power_in_B "977813+371577j VA";
+	power_in_C "1.35081e+06+667271j VA";
+	power_out_A "1.23132e+06+601391j VA";
+	power_out_B "981028+339552j VA";
+	power_out_C "1.30977e+06+586779j VA";
+	power_losses_A "21452+78858.2j VA";
+	power_losses_B "3214.83+32025j VA";
+	power_losses_C "41037.5+80492.6j VA";
+	current_out_A "489.014-265.526j A";
+	current_out_B "-320.669-261.467j A";
+	current_out_C "-37.8226+582.958j A";
+	current_in_A "489.014-265.526j A";
+	current_in_B "-320.669-261.467j A";
+	current_in_C "-37.8226+582.958j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BF|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line4";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1817129560";
+	guid "27F2D9E23001D7737C37310E14301ADF";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration1";
+	length "500 ft";
+	status "CLOSED";
+	from "Node632";
+	to "Load6321";
+	power_in "2.70008e+06+959867j VA";
+	power_out "2.6906e+06+929565j VA";
+	power_out_real "2.6906e+06 W";
+	power_losses "12392.8+30301.4j VA";
+	power_in_A "1.06847e+06+486333j VA";
+	power_in_B "524119+118915j VA";
+	power_in_C "1.10749e+06+354619j VA";
+	power_out_A "1.0661e+06+470085j VA";
+	power_out_B "525574+117730j VA";
+	power_out_C "1.09892e+06+341751j VA";
+	power_losses_A "2367.52+16248.4j VA";
+	power_losses_B "1455.5+1184.65j VA";
+	power_losses_C "8569.8+12868.4j VA";
+	current_out_A "424.961-215.998j A";
+	current_out_B "-150.131-152.784j A";
+	current_out_C "-82.922+466.017j A";
+	current_in_A "424.961-215.998j A";
+	current_in_B "-150.131-152.784j A";
+	current_in_C "-82.922+466.017j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BR|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line5";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1131570933";
+	guid "14FC30579F2212C237EB08591F6FB7A8";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration1";
+	length "1500 ft";
+	status "CLOSED";
+	from "Load6321";
+	to "Load671";
+	power_in "2.55727e+06+852232j VA";
+	power_out "2.53121e+06+769172j VA";
+	power_out_real "2.53121e+06 W";
+	power_losses "35499.6+83059.5j VA";
+	power_in_A "1.05477e+06+463418j VA";
+	power_in_B "481574+92396.6j VA";
+	power_in_C "1.02092e+06+296417j VA";
+	power_out_A "1.04665e+06+414663j VA";
+	power_out_B "486299+89237.4j VA";
+	power_out_C "998269+265272j VA";
+	power_losses_A "8124.48+48754.7j VA";
+	power_losses_B "4724.64+3159.18j VA";
+	power_losses_C "22650.5+31145.6j VA";
+	current_out_A "420.481-213.02j A";
+	current_out_B "-132.335-143.243j A";
+	current_out_C "-84.7349+428.955j A";
+	current_in_A "420.481-213.02j A";
+	current_in_B "-132.335-143.243j A";
+	current_in_C "-84.7349+428.955j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BR|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line6";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "197493099";
+	guid "6088BF3715BA8F3A6515E7AE81035798";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration1";
+	length "1000 ft";
+	status "CLOSED";
+	from "Load671";
+	to "Node680";
+	power_in "0+0j VA";
+	power_out "0+0j VA";
+	power_out_real "0 W";
+	power_losses "0+0j VA";
+	power_in_A "0-0j VA";
+	power_in_B "-0+0j VA";
+	power_in_C "0+0j VA";
+	power_out_A "0-0j VA";
+	power_out_B "-0+0j VA";
+	power_out_C "0+0j VA";
+	power_losses_A "0+0j VA";
+	power_losses_B "0+0j VA";
+	power_losses_C "0+0j VA";
+	current_out_A "0+0j A";
+	current_out_B "0+0j A";
+	current_out_C "0+0j A";
+	current_in_A "0+0j A";
+	current_in_B "0+0j A";
+	current_in_C "0+0j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CN|BN|AN";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line7";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1404280278";
+	guid "44D7D662643090AC568A3522ED94B1FF";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration4";
+	length "300 ft";
+	status "CLOSED";
+	from "Load671";
+	to "Node684";
+	power_in "293216+67380.6j VA";
+	power_out "292631+66905.1j VA";
+	power_out_real "292631 W";
+	power_losses "585.336+475.505j VA";
+	power_in_A "125934+84324.8j VA";
+	power_in_B "-0+0j VA";
+	power_in_C "167282-16944.2j VA";
+	power_out_A "125720+84108.3j VA";
+	power_out_B "0+0j VA";
+	power_out_C "166911-17203.2j VA";
+	power_losses_A "214.227+216.458j VA";
+	power_losses_B "-0+0j VA";
+	power_losses_C "371.11+259.047j VA";
+	current_out_A "49.2727-39.9866j A";
+	current_out_B "0+0j A";
+	current_out_C "-37.5475+60.465j A";
+	current_in_A "49.2727-39.9866j A";
+	current_in_B "0+0j A";
+	current_in_C "-37.5475+60.465j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BN|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ACN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line8";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "893351816";
+	guid "22AD6EBE9C2C0917681B25489F0E92D";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration5";
+	length "300 ft";
+	status "CLOSED";
+	from "Node684";
+	to "Load611";
+	power_in "166911-17203.2j VA";
+	power_out "166528-17590.9j VA";
+	power_out_real "166528 W";
+	power_losses "382.647+387.732j VA";
+	power_in_A "0-0j VA";
+	power_in_B "0+0j VA";
+	power_in_C "166911-17203.2j VA";
+	power_out_A "0+0j VA";
+	power_out_B "0+0j VA";
+	power_out_C "166528-17590.9j VA";
+	power_losses_A "0-0j VA";
+	power_losses_B "0+0j VA";
+	power_losses_C "382.647+387.732j VA";
+	current_out_A "0+0j A";
+	current_out_B "0+0j A";
+	current_out_C "-37.5475+60.465j A";
+	current_in_A "0+0j A";
+	current_in_B "0+0j A";
+	current_in_C "-37.5475+60.465j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BN|AN";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "CN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object underground_line
+{
+	name "overhead_line9";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1505795335";
+	guid "262DB05E52B7812B4EF978A3F1D7ACA8";
+	configuration "line_configuration7";
+	length "800 ft";
+	status "CLOSED";
+	from "Node684";
+	to "Load652";
+	power_in "125720+84108.3j VA";
+	power_out "125030+84004.8j VA";
+	power_out_real "125030 W";
+	power_losses "689.606+103.49j VA";
+	power_in_A "125720+84108.3j VA";
+	power_in_B "0+0j VA";
+	power_in_C "0+0j VA";
+	power_out_A "125030+84004.8j VA";
+	power_out_B "0+0j VA";
+	power_out_C "0+0j VA";
+	power_losses_A "689.606+103.49j VA";
+	power_losses_B "0+0j VA";
+	power_losses_C "0+0j VA";
+	current_out_A "49.2727-39.9866j A";
+	current_out_B "0+0j A";
+	current_out_C "0+0j A";
+	current_in_A "49.2727-39.9866j A";
+	current_in_B "0+0j A";
+	current_in_C "0+0j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CN|BN|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "AN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object underground_line
+{
+	name "overhead_line10";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1954899097";
+	guid "2D7D298B20530B3A6605D754013A6791";
+	configuration "line_configuration6";
+	length "500 ft";
+	status "CLOSED";
+	from "Load692";
+	to "Load675";
+	power_in "847095-147181j VA";
+	power_out "843000-149811j VA";
+	power_out_real "843000 W";
+	power_losses "4095.27+2630.36j VA";
+	power_in_A "488188-3129.57j VA";
+	power_in_B "68346.9-163279j VA";
+	power_in_C "290560+19227.5j VA";
+	power_out_A "485000-5213.07j VA";
+	power_out_B "68000-163856j VA";
+	power_out_C "290000+19257.9j VA";
+	power_losses_A "3188.44+2083.5j VA";
+	power_losses_B "346.873+577.176j VA";
+	power_losses_C "559.954-30.3179j VA";
+	current_out_A "203.663-17.4124j A";
+	current_out_B "39.997-57.2254j A";
+	current_out_C "-46.715+114.072j A";
+	current_in_A "203.663-17.4124j A";
+	current_in_B "39.997-57.2254j A";
+	current_in_C "-46.715+114.072j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BR|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABC";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object overhead_line
+{
+	name "overhead_line11";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1636807826";
+	guid "9F0D6062A589FAA61C98167776B1158";
+	ice_thickness "0 in";
+	is_covered "FALSE";
+	configuration "line_configuration2";
+	length "500 ft";
+	status "CLOSED";
+	from "Node632";
+	to "Node633";
+	power_in "406192+300830j VA";
+	power_out "405391+299802j VA";
+	power_out_real "405391 W";
+	power_losses "800.74+1027.87j VA";
+	power_in_A "162847+115058j VA";
+	power_in_B "121562+92836.5j VA";
+	power_in_C "121783+92935.9j VA";
+	power_out_A "162496+114538j VA";
+	power_out_B "121415+92572.6j VA";
+	power_out_C "121480+92691.5j VA";
+	power_losses_A "351.252+519.595j VA";
+	power_losses_B "147.055+263.879j VA";
+	power_losses_C "302.432+244.391j VA";
+	current_out_A "64.0526-49.5276j A";
+	current_out_B "-56.9453-21.7635j A";
+	current_out_C "10.2956+61.4997j A";
+	current_in_A "64.0526-49.5276j A";
+	current_in_B "-56.9453-21.7635j A";
+	current_in_C "10.2956+61.4997j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BF|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object node
+{
+	name "Node633";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "563613512";
+	guid "56792A3BC868747D71D45C61F27FC44B";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2452.99-108.542j V";
+	voltage_B "-1318.29-2129.47j V";
+	voltage_C "-1144.43+2166.89j V";
+	voltage_AB "3771.27+2020.92j V";
+	voltage_BC "-173.857-4296.35j V";
+	voltage_CA "-3597.42+2275.43j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object node
+{
+	name "Node630";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "101929267";
+	guid "7026499560DDC2C955A885BBEAB7FC65";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2561.85+0.0265526j V";
+	voltage_B "-1264.06-2189.45j V";
+	voltage_C "-1289.54+2233.5j V";
+	voltage_AB "3825.91+2189.47j V";
+	voltage_BC "25.4798-4422.95j V";
+	voltage_CA "-3851.39+2233.47j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "VOLTAGE";
+}
+object node
+{
+	name "Node632";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1580723810";
+	guid "1F6263C85F84C77D622BC8553C428940";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2460.34-106.119j V";
+	voltage_B "-1319-2134.37j V";
+	voltage_C "-1147.5+2172.32j V";
+	voltage_AB "3779.34+2028.25j V";
+	voltage_BC "-171.5-4306.69j V";
+	voltage_CA "-3607.84+2278.44j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object node
+{
+	name "Node650";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "704877633";
+	guid "32C5E86DB17AD45821BCBF7776C9AF8F";
+	bustype "SWING";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2401.78+0j V";
+	voltage_B "-1200.89-2080j V";
+	voltage_C "-1200.89+2080j V";
+	voltage_AB "3602.67+2080j V";
+	voltage_BC "0-4160j V";
+	voltage_CA "-3602.67+2080j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object node
+{
+	name "Node680";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1358580979";
+	guid "2E1DD43E78F8223D44B248EC917E17BB";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2378.35-218.733j V";
+	voltage_B "-1356.04-2142.14j V";
+	voltage_C "-1037.64+2122.24j V";
+	voltage_AB "3734.39+1923.41j V";
+	voltage_BC "-318.404-4264.38j V";
+	voltage_CA "-3415.99+2340.97j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "VOLTAGE";
+}
+object node
+{
+	name "Node684";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1624379149";
+	guid "4295CFECB478994B3205ABAFCADD2182";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2373.58-219.254j V";
+	voltage_B "0+0j V";
+	voltage_C "-1031.79+2119.73j V";
+	voltage_AB "2373.58-219.254j V";
+	voltage_BC "1031.79-2119.73j V";
+	voltage_CA "-3405.38+2338.99j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ACN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load634";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "2128236579";
+	guid "68F2B7B5BDA97E811DAFC8F6309F147";
+	load_class "U";
+	constant_power_A "160000+110000j VA";
+	constant_power_B "120000+90000j VA";
+	constant_power_C "120000+90000j VA";
+	constant_power_A_real "160000 W";
+	constant_power_B_real "120000 W";
+	constant_power_C_real "120000 W";
+	constant_power_A_reac "110000 VAr";
+	constant_power_B_reac "90000 VAr";
+	constant_power_C_reac "90000 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "276.267-15.4643j V";
+	measured_voltage_B "-151.347-240.203j V";
+	measured_voltage_C "-127.59+246.502j V";
+	measured_voltage_AB "427.614+224.739j V";
+	measured_voltage_BC "-23.7569-486.705j V";
+	measured_voltage_CA "-403.857+261.966j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00048 V";
+	voltage_A "276.267-15.4643j V";
+	voltage_B "-151.347-240.203j V";
+	voltage_C "-127.59+246.502j V";
+	voltage_AB "427.614+224.739j V";
+	voltage_BC "-23.7569-486.705j V";
+	voltage_CA "-403.857+261.966j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCN";
+	nominal_voltage "480 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load645";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "784558821";
+	guid "5613F624FEAB10A625BDCE8087C9AE89";
+	load_class "U";
+	constant_power_A "0+0j VA";
+	constant_power_B "170000+125000j VA";
+	constant_power_C "0+0j VA";
+	constant_power_A_real "0 W";
+	constant_power_B_real "170000 W";
+	constant_power_C_real "0 W";
+	constant_power_A_reac "0 VAr";
+	constant_power_B_reac "125000 VAr";
+	constant_power_C_reac "0 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "0+0j V";
+	measured_voltage_B "-1314.05-2111.54j V";
+	measured_voltage_C "-1146.29+2167.54j V";
+	measured_voltage_AB "1314.05+2111.54j V";
+	measured_voltage_BC "-167.762-4279.07j V";
+	measured_voltage_CA "-1146.29+2167.54j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "0+0j V";
+	voltage_B "-1314.05-2111.54j V";
+	voltage_C "-1146.29+2167.54j V";
+	voltage_AB "1314.05+2111.54j V";
+	voltage_BC "-167.762-4279.07j V";
+	voltage_CA "-1146.29+2167.54j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "BCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load646";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "530511967";
+	guid "668185F0369379AE2C3E1FFB3126EAC1";
+	load_class "U";
+	constant_power_A "0+0j VA";
+	constant_power_B "0+0j VA";
+	constant_power_C "0+0j VA";
+	constant_power_A_real "0 W";
+	constant_power_B_real "0 W";
+	constant_power_C_real "0 W";
+	constant_power_A_reac "0 VAr";
+	constant_power_B_reac "0 VAr";
+	constant_power_C_reac "0 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "56.5993+32.4831j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "56.5993 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "32.4831 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "0+0j V";
+	measured_voltage_B "-1314.63-2106.24j V";
+	measured_voltage_C "-1145.67+2162.24j V";
+	measured_voltage_AB "1314.63+2106.24j V";
+	measured_voltage_BC "-168.957-4268.48j V";
+	measured_voltage_CA "-1145.67+2162.24j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "0+0j V";
+	voltage_B "-1314.63-2106.24j V";
+	voltage_C "-1145.67+2162.24j V";
+	voltage_AB "1314.63+2106.24j V";
+	voltage_BC "-168.957-4268.48j V";
+	voltage_CA "-1145.67+2162.24j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "BCD";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load652";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "2110010672";
+	guid "6A4BB69C48E57D8967B9BACDD59948DB";
+	load_class "U";
+	constant_power_A "0+0j VA";
+	constant_power_B "0+0j VA";
+	constant_power_C "0+0j VA";
+	constant_power_A_real "0 W";
+	constant_power_B_real "0 W";
+	constant_power_C_real "0 W";
+	constant_power_A_reac "0 VAr";
+	constant_power_B_reac "0 VAr";
+	constant_power_C_reac "0 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "31.0501+20.8618j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "31.0501 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "20.8618 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "2364.12-213.673j V";
+	measured_voltage_B "0+0j V";
+	measured_voltage_C "0+0j V";
+	measured_voltage_AB "2364.12-213.673j V";
+	measured_voltage_BC "0+0j V";
+	measured_voltage_CA "-2364.12+213.673j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2364.12-213.673j V";
+	voltage_B "0+0j V";
+	voltage_C "0+0j V";
+	voltage_AB "2364.12-213.673j V";
+	voltage_BC "0+0j V";
+	voltage_CA "-2364.12+213.673j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "AN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load671";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1551901393";
+	guid "237BFB641A4AACFB2A04E01EC4FAEF39";
+	load_class "U";
+	constant_power_A "385000+220000j VA";
+	constant_power_B "385000+220000j VA";
+	constant_power_C "385000+220000j VA";
+	constant_power_A_real "385000 W";
+	constant_power_B_real "385000 W";
+	constant_power_C_real "385000 W";
+	constant_power_A_reac "220000 VAr";
+	constant_power_B_reac "220000 VAr";
+	constant_power_C_reac "220000 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "2378.35-218.733j V";
+	measured_voltage_B "-1356.04-2142.14j V";
+	measured_voltage_C "-1037.64+2122.24j V";
+	measured_voltage_AB "3734.39+1923.41j V";
+	measured_voltage_BC "-318.404-4264.38j V";
+	measured_voltage_CA "-3415.99+2340.97j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2378.35-218.733j V";
+	voltage_B "-1356.04-2142.14j V";
+	voltage_C "-1037.64+2122.24j V";
+	voltage_AB "3734.39+1923.41j V";
+	voltage_BC "-318.404-4264.38j V";
+	voltage_CA "-3415.99+2340.97j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCD";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load675";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1617819336";
+	guid "75BB130A1F85961BC71DF6A0F03550";
+	load_class "U";
+	constant_power_A "485000+190000j VA";
+	constant_power_B "68000+60000j VA";
+	constant_power_C "290000+212000j VA";
+	constant_power_A_real "485000 W";
+	constant_power_B_real "68000 W";
+	constant_power_C_real "290000 W";
+	constant_power_A_reac "190000 VAr";
+	constant_power_B_reac "60000 VAr";
+	constant_power_C_reac "212000 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "0-28.8427j Ohm";
+	constant_impedance_B "0-28.8427j Ohm";
+	constant_impedance_C "0-28.8427j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "-28.8427 Ohm";
+	constant_impedance_B_reac "-28.8427 Ohm";
+	constant_impedance_C_reac "-28.8427 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "2361.93-227.531j V";
+	measured_voltage_B "-1365.66-2142.8j V";
+	measured_voltage_C "-1036.15+2117.92j V";
+	measured_voltage_AB "3727.59+1915.27j V";
+	measured_voltage_BC "-329.508-4260.72j V";
+	measured_voltage_CA "-3398.08+2345.45j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2361.93-227.531j V";
+	voltage_B "-1365.66-2142.8j V";
+	voltage_C "-1036.15+2117.92j V";
+	voltage_AB "3727.59+1915.27j V";
+	voltage_BC "-329.508-4260.72j V";
+	voltage_CA "-3398.08+2345.45j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABC";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load692";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1399125485";
+	guid "6AAAC1B53E723176483B8FC6D2196C58";
+	load_class "U";
+	constant_power_A "0+0j VA";
+	constant_power_B "0+0j VA";
+	constant_power_C "0+0j VA";
+	constant_power_A_real "0 W";
+	constant_power_B_real "0 W";
+	constant_power_C_real "0 W";
+	constant_power_A_reac "0 VAr";
+	constant_power_B_reac "0 VAr";
+	constant_power_C_reac "0 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "-17.2414+51.8677j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "-17.2414 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "51.8677 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "2378.34-218.704j V";
+	measured_voltage_B "-1356.04-2142.13j V";
+	measured_voltage_C "-1037.65+2122.22j V";
+	measured_voltage_AB "3734.38+1923.43j V";
+	measured_voltage_BC "-318.392-4264.35j V";
+	measured_voltage_CA "-3415.99+2340.92j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2378.34-218.704j V";
+	voltage_B "-1356.04-2142.13j V";
+	voltage_C "-1037.65+2122.22j V";
+	voltage_AB "3734.38+1923.43j V";
+	voltage_BC "-318.392-4264.35j V";
+	voltage_CA "-3415.99+2340.92j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCD";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load611";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "156091745";
+	guid "2D35681C99FBB9B94108FA200B23B52";
+	load_class "U";
+	constant_power_A "0+0j VA";
+	constant_power_B "0+0j VA";
+	constant_power_C "0+0j VA";
+	constant_power_A_real "0 W";
+	constant_power_B_real "0 W";
+	constant_power_C_real "0 W";
+	constant_power_A_reac "0 VAr";
+	constant_power_B_reac "0 VAr";
+	constant_power_C_reac "0 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "-6.5443+77.9524j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "-6.5443 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "77.9524 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0-57.6854j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "-57.6854 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "0+0j V";
+	measured_voltage_B "0+0j V";
+	measured_voltage_C "-1024.33+2118.04j V";
+	measured_voltage_AB "0+0j V";
+	measured_voltage_BC "1024.33-2118.04j V";
+	measured_voltage_CA "-1024.33+2118.04j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "0+0j V";
+	voltage_B "0+0j V";
+	voltage_C "-1024.33+2118.04j V";
+	voltage_AB "0+0j V";
+	voltage_BC "1024.33-2118.04j V";
+	voltage_CA "-1024.33+2118.04j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "CN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load6711";
+	parent "Load671";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1356425228";
+	guid "42BCA38F0C499256683D01678001AC92";
+	load_class "U";
+	constant_power_A "5666.67+3333.33j VA";
+	constant_power_B "22000+12666.7j VA";
+	constant_power_C "39000+22666.7j VA";
+	constant_power_A_real "5666.67 W";
+	constant_power_B_real "22000 W";
+	constant_power_C_real "39000 W";
+	constant_power_A_reac "3333.33 VAr";
+	constant_power_B_reac "12666.7 VAr";
+	constant_power_C_reac "22666.7 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "2378.35-218.733j V";
+	measured_voltage_B "-1356.04-2142.14j V";
+	measured_voltage_C "-1037.64+2122.24j V";
+	measured_voltage_AB "3734.39+1923.41j V";
+	measured_voltage_BC "-318.404-4264.38j V";
+	measured_voltage_CA "-3415.99+2340.97j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2378.35-218.733j V";
+	voltage_B "-1356.04-2142.14j V";
+	voltage_C "-1037.64+2122.24j V";
+	voltage_AB "3734.39+1923.41j V";
+	voltage_BC "-318.404-4264.38j V";
+	voltage_CA "-3415.99+2340.97j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	topological_parent "Load671";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABC";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object load
+{
+	name "Load6321";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1899894091";
+	guid "3ABB56329A2860FE7576E5814353FBFE";
+	load_class "U";
+	constant_power_A "11333.3+6666.67j VA";
+	constant_power_B "44000+25333.3j VA";
+	constant_power_C "78000+45333.3j VA";
+	constant_power_A_real "11333.3 W";
+	constant_power_B_real "44000 W";
+	constant_power_C_real "78000 W";
+	constant_power_A_reac "6666.67 VAr";
+	constant_power_B_reac "25333.3 VAr";
+	constant_power_C_reac "45333.3 VAr";
+	constant_current_A "0+0j A";
+	constant_current_B "0+0j A";
+	constant_current_C "0+0j A";
+	constant_current_A_real "0 A";
+	constant_current_B_real "0 A";
+	constant_current_C_real "0 A";
+	constant_current_A_reac "0 A";
+	constant_current_B_reac "0 A";
+	constant_current_C_reac "0 A";
+	constant_impedance_A "0+0j Ohm";
+	constant_impedance_B "0+0j Ohm";
+	constant_impedance_C "0+0j Ohm";
+	constant_impedance_A_real "0 Ohm";
+	constant_impedance_B_real "0 Ohm";
+	constant_impedance_C_real "0 Ohm";
+	constant_impedance_A_reac "0 Ohm";
+	constant_impedance_B_reac "0 Ohm";
+	constant_impedance_C_reac "0 Ohm";
+	constant_power_AN "0+0j VA";
+	constant_power_BN "0+0j VA";
+	constant_power_CN "0+0j VA";
+	constant_power_AN_real "0 W";
+	constant_power_BN_real "0 W";
+	constant_power_CN_real "0 W";
+	constant_power_AN_reac "0 VAr";
+	constant_power_BN_reac "0 VAr";
+	constant_power_CN_reac "0 VAr";
+	constant_current_AN "0+0j A";
+	constant_current_BN "0+0j A";
+	constant_current_CN "0+0j A";
+	constant_current_AN_real "0 A";
+	constant_current_BN_real "0 A";
+	constant_current_CN_real "0 A";
+	constant_current_AN_reac "0 A";
+	constant_current_BN_reac "0 A";
+	constant_current_CN_reac "0 A";
+	constant_impedance_AN "0+0j Ohm";
+	constant_impedance_BN "0+0j Ohm";
+	constant_impedance_CN "0+0j Ohm";
+	constant_impedance_AN_real "0 Ohm";
+	constant_impedance_BN_real "0 Ohm";
+	constant_impedance_CN_real "0 Ohm";
+	constant_impedance_AN_reac "0 Ohm";
+	constant_impedance_BN_reac "0 Ohm";
+	constant_impedance_CN_reac "0 Ohm";
+	constant_power_AB "0+0j VA";
+	constant_power_BC "0+0j VA";
+	constant_power_CA "0+0j VA";
+	constant_power_AB_real "0 W";
+	constant_power_BC_real "0 W";
+	constant_power_CA_real "0 W";
+	constant_power_AB_reac "0 VAr";
+	constant_power_BC_reac "0 VAr";
+	constant_power_CA_reac "0 VAr";
+	constant_current_AB "0+0j A";
+	constant_current_BC "0+0j A";
+	constant_current_CA "0+0j A";
+	constant_current_AB_real "0 A";
+	constant_current_BC_real "0 A";
+	constant_current_CA_real "0 A";
+	constant_current_AB_reac "0 A";
+	constant_current_BC_reac "0 A";
+	constant_current_CA_reac "0 A";
+	constant_impedance_AB "0+0j Ohm";
+	constant_impedance_BC "0+0j Ohm";
+	constant_impedance_CA "0+0j Ohm";
+	constant_impedance_AB_real "0 Ohm";
+	constant_impedance_BC_real "0 Ohm";
+	constant_impedance_CA_real "0 Ohm";
+	constant_impedance_AB_reac "0 Ohm";
+	constant_impedance_BC_reac "0 Ohm";
+	constant_impedance_CA_reac "0 Ohm";
+	measured_voltage_A "2440.47-134.254j V";
+	measured_voltage_B "-1327.7-2135.34j V";
+	measured_voltage_C "-1117.56+2159.26j V";
+	measured_voltage_AB "3768.18+2001.09j V";
+	measured_voltage_BC "-210.145-4294.6j V";
+	measured_voltage_CA "-3558.03+2293.51j V";
+	phase_loss_protection "FALSE";
+	base_power_A "0 VA";
+	base_power_B "0 VA";
+	base_power_C "0 VA";
+	power_pf_A "1 pu";
+	current_pf_A "1 pu";
+	impedance_pf_A "1 pu";
+	power_pf_B "1 pu";
+	current_pf_B "1 pu";
+	impedance_pf_B "1 pu";
+	power_pf_C "1 pu";
+	current_pf_C "1 pu";
+	impedance_pf_C "1 pu";
+	power_fraction_A "0 pu";
+	current_fraction_A "0 pu";
+	impedance_fraction_A "0 pu";
+	power_fraction_B "0 pu";
+	current_fraction_B "0 pu";
+	impedance_fraction_B "0 pu";
+	power_fraction_C "0 pu";
+	current_fraction_C "0 pu";
+	impedance_fraction_C "0 pu";
+	bustype "PQ";
+	busflags "HASSOURCE";
+	maximum_voltage_error "0.00240178 V";
+	voltage_A "2440.47-134.254j V";
+	voltage_B "-1327.7-2135.34j V";
+	voltage_C "-1117.56+2159.26j V";
+	voltage_AB "3768.18+2001.09j V";
+	voltage_BC "-210.145-4294.6j V";
+	voltage_CA "-3558.03+2293.51j V";
+	mean_repair_time "0 s";
+	frequency_measure_type "NONE";
+	sfm_Tf "0.01 s";
+	pll_Kp "10 pu";
+	pll_Ki "100 pu";
+	measured_angle_A "0 rad";
+	measured_frequency_A "60 Hz";
+	measured_angle_B "0 rad";
+	measured_frequency_B "60 Hz";
+	measured_angle_C "0 rad";
+	measured_frequency_C "60 Hz";
+	measured_frequency "60 Hz";
+	service_status "IN_SERVICE";
+	service_status_double "-1";
+	previous_uptime "-1 min";
+	current_uptime "0 min";
+	Norton_dynamic "FALSE";
+	generator_dynamic "FALSE";
+	reset_disabled_island_state "FALSE";
+	GFA_enable "FALSE";
+	GFA_freq_low_trip "59.5 Hz";
+	GFA_freq_high_trip "60.5 Hz";
+	GFA_volt_low_trip "0.8 pu";
+	GFA_volt_high_trip "1.2 pu";
+	GFA_reconnect_time "300 s";
+	GFA_freq_disconnect_time "0.2 s";
+	GFA_volt_disconnect_time "0.2 s";
+	GFA_status "TRUE";
+	GFA_trip_method "NONE";
+	voltage_violation_threshold "0.05 pu";
+	undervoltage_violation_threshold "0 pu";
+	overvoltage_violation_threshold "0 pu";
+	voltage_fluctuation_threshold "0.03 pu";
+	DER_value "0+0j VA";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object switch
+{
+	name "switch1";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "585640194";
+	guid "2FC08B3272559B4D770CC4D05B8F8543";
+	phase_A_state "CLOSED";
+	phase_B_state "CLOSED";
+	phase_C_state "CLOSED";
+	operating_mode "BANKED";
+	switch_impedance "0.0001-0.0001j Ohm";
+	switch_resistance "0.0001 Ohm";
+	switch_reactance "-0.0001 Ohm";
+	status "CLOSED";
+	from "Load671";
+	to "Load692";
+	power_in "1.01633e+06+3124.84j VA";
+	power_out "1.01632e+06+3133.67j VA";
+	power_out_real "1.01632e+06 W";
+	power_losses "8.83802-8.83802j VA";
+	power_in_A "531166+120134j VA";
+	power_in_B "68347.4-163279j VA";
+	power_in_C "416819+46270.4j VA";
+	power_out_A "531161+120139j VA";
+	power_out_B "68346.9-163279j VA";
+	power_out_C "416815+46273.5j VA";
+	power_losses_A "5.19896-5.19896j VA";
+	power_losses_B "0.487451-0.487451j VA";
+	power_losses_C "3.15161-3.15161j VA";
+	current_out_A "216.854-70.4551j A";
+	current_out_B "39.997-57.2254j A";
+	current_out_C "-59.9057+167.115j A";
+	current_in_A "216.854-70.4551j A";
+	current_in_B "39.997-57.2254j A";
+	current_in_C "-59.9057+167.115j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BF|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object transformer
+{
+	name "XFMR1";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "937186357";
+	guid "46639E211413EF3A9F5CAFE2475295B";
+	configuration "transformer_configuration1";
+	ambient_temperature "0 degC";
+	top_oil_hot_spot_temperature "0 degC";
+	winding_hot_spot_temperature "0 degC";
+	percent_loss_of_life "0";
+	aging_constant "0";
+	use_thermal_model "FALSE";
+	transformer_replacement_count "0";
+	aging_granularity "0 s";
+	phase_A_primary_flux_value "0 Wb";
+	phase_B_primary_flux_value "0 Wb";
+	phase_C_primary_flux_value "0 Wb";
+	phase_A_secondary_flux_value "0 Wb";
+	phase_B_secondary_flux_value "0 Wb";
+	phase_C_secondary_flux_value "0 Wb";
+	degradation_factor "0 pu";
+	status "CLOSED";
+	from "Node633";
+	to "Load634";
+	power_in "405391+299802j VA";
+	power_out "400000+290000j VA";
+	power_out_real "400000 W";
+	power_losses "5391.17+9802.13j VA";
+	power_in_A "162496+114538j VA";
+	power_in_B "121415+92572.6j VA";
+	power_in_C "121480+92691.5j VA";
+	power_out_A "160000+110000j VA";
+	power_out_B "120000+90000j VA";
+	power_out_C "120000+90000j VA";
+	power_losses_A "2495.91+4538.02j VA";
+	power_losses_B "1414.93+2572.6j VA";
+	power_losses_C "1480.33+2691.51j VA";
+	current_out_A "555.122-429.239j A";
+	current_out_B "-493.526-188.617j A";
+	current_out_C "89.2285+532.997j A";
+	current_in_A "64.0526-49.5276j A";
+	current_in_B "-56.9453-21.7635j A";
+	current_in_C "10.2956+61.4997j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BF|AF";
+	mean_repair_time "0 s";
+	continuous_rating "500 A";
+	emergency_rating "500 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABCN";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}
+object regulator
+{
+	name "Reg1";
+	latitude "0.000000";
+	longitude "0.000000";
+	rng_state "1646035001";
+	guid "5909E13BFFDC96271EB70900308BDBAB";
+	configuration "regulator_configuration1";
+	tap_A "10";
+	tap_B "8";
+	tap_C "11";
+	tap_A_change_count "0";
+	tap_B_change_count "0";
+	tap_C_change_count "0";
+	sense_node "Load671";
+	regulator_resistance "0.0001 Ohm";
+	status "CLOSED";
+	from "Node650";
+	to "Node630";
+	power_in "3.58148e+06+1.7191e+06j VA";
+	power_out "3.58139e+06+1.7191e+06j VA";
+	power_out_real "3.58139e+06 W";
+	power_losses "82.2102-1.16415e-10j VA";
+	power_in_A "1.2528e+06+680249j VA";
+	power_in_B "977830+371577j VA";
+	power_in_C "1.35084e+06+667271j VA";
+	power_out_A "1.25277e+06+680249j VA";
+	power_out_B "977813+371577j VA";
+	power_out_C "1.35081e+06+667271j VA";
+	power_losses_A "30.9638+0j VA";
+	power_losses_B "17.1193-2.32831e-10j VA";
+	power_losses_C "34.127+1.16415e-10j VA";
+	current_out_A "489.014-265.526j A";
+	current_out_B "-320.669-261.467j A";
+	current_out_C "-37.8226+582.958j A";
+	current_in_A "521.615-283.227j A";
+	current_in_B "-337.546-275.228j A";
+	current_in_C "-40.6149+625.995j A";
+	fault_current_in_A "0+0j A";
+	fault_current_in_B "0+0j A";
+	fault_current_in_C "0+0j A";
+	fault_current_out_A "0+0j A";
+	fault_current_out_B "0+0j A";
+	fault_current_out_C "0+0j A";
+	fault_voltage_A "0+0j A";
+	fault_voltage_B "0+0j A";
+	fault_voltage_C "0+0j A";
+	flow_direction "CF|BF|AF";
+	mean_repair_time "0 s";
+	continuous_rating "1000 A";
+	emergency_rating "2000 A";
+	inrush_convergence_value "0.0001 V";
+	violation_rating "0 A";
+	phases "ABC";
+	nominal_voltage "2401.78 V";
+	violation_detected "NONE";
+}

--- a/tools/autotest/ieee13.glm
+++ b/tools/autotest/ieee13.glm
@@ -1,4 +1,7 @@
-module powerflow;
+module powerflow
+{
+     solver_method NR;
+}
 
 object overhead_line_conductor 
 {

--- a/tools/autotest/test_create_meters.glm
+++ b/tools/autotest/test_create_meters.glm
@@ -1,0 +1,11 @@
+#ifexist ../ieee13.glm
+#define DIR=..
+#endif
+
+#gridlabd -C ${DIR:-.}/ieee13.glm -o ${DIR:-.}/ieee13.json
+#python -m create_meters ${DIR:-.}/ieee13.json ieee13-meters.json
+#input "ieee13-meters.json"
+
+//#ifexist ../ieee13-meters.json
+//#on_exit 0 diff ../ieee13-meters.json ieee13-meters.json
+//#endif

--- a/tools/create_meters.py
+++ b/tools/create_meters.py
@@ -1,0 +1,203 @@
+"""Add meters to a MODEL
+
+SYNOPSIS
+
+    gridlabd create_meters [--with-ami] INPUTFILE [OUTPUTFILE]
+
+DESCRIPTION
+
+    The `create_meters` tool adds meters and optionally recorders
+    to the input JSON file.  If the output JSON file is not specified
+    the output is written to the input JSON file.
+"""
+
+import os, sys
+import json
+
+BASENAME = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+
+if len(sys.argv) == 1:
+    print(f"Syntax: gridlabd {BASENAME} [OPTIONS ...] INPUT [OUTPUT]",file=sys.stderr)
+    exit(1)
+
+INPUTFILE = None
+OUTPUTFILE = None
+WITHAMI = False
+
+for arg in sys.argv[1:]:
+    if arg.startswith('-'):
+        if arg == '--with-ami':
+            WITHAMI = True
+        else:
+            raise Exception(f"argument {arg} is invalid")
+    elif not INPUTFILE:
+        INPUTFILE = arg
+    elif not OUTPUTFILE:
+        OUTPUTFILE = arg
+    else:
+        raise Exception(f"argument {arg} not expected")
+
+with open(INPUTFILE,"rt") as fh:
+    MODEL = json.load(fh)
+    OBJECTS = MODEL['objects']
+
+if WITHAMI and 'recorder' not in MODEL['modules']:
+    VERSION = MODEL['version'].split('.')
+    MODEL['modules']['tape'] = {
+        "major": VERSION[0],
+        "minor": VERSION[1]
+    }
+    MODEL['classes']['recorder'] = {
+            "file" : {
+                "type" : "char1024",
+                "access" : "PUBLIC",
+                "flags" : "REQUIRED",
+                "description" : "file in which to record data"
+            },
+            "interval" : {
+                "type" : "double",
+                "access" : "PUBLIC",
+                "unit" : "s",
+                "default" : "-1 s",
+                "description" : "sampling interval"
+            },
+            "property" : {
+                "type" : "method",
+                "access" : "PUBLIC",
+                "flags" : "REQUIRED",
+                "description" : "list of properties to sample"
+            },
+        }
+
+LINKLIST = {}
+LINKOBJS = {}
+def get_links(name):
+    global LINKLIST
+    if not LINKLIST:
+        for tag, obj in OBJECTS.items():
+            try:
+                add_links(obj['to'],obj['from'],tag)
+            except KeyError:
+                pass
+    try:
+        return LINKLIST[name]
+    except KeyError:
+        return None
+
+def add_links(a,b,name):
+    global LINKLIST
+    if a not in LINKLIST:
+        LINKLIST[a] = [b]
+        add_links(b,a,name)
+    elif b not in LINKLIST[a]:
+        LINKLIST[a].append(b)
+        add_links(b,a,name)
+
+    global LINKOBS
+    if a not in LINKOBJS:
+        LINKOBJS[a] = [name]
+    elif name not in LINKOBJS[a]:
+        LINKOBJS[a].append(name)
+
+def set_link(old,new):
+    # print(old,'-->',new,':',LINKOBJS[old])
+    for link in LINKOBJS[old]:
+        for d in ['to','from']:
+            if get_data(link,d) == old:
+                set_data(link,d,new)
+                # print(link,d,old,'-->',OBJECTS[link][d])
+
+def get_data(name,tag=None):
+    try:
+        return OBJECTS[name][tag] if tag else OBJECTS[name]
+    except KeyError:
+        return None
+
+def set_data(name,tag,value=None):
+    if value:
+        OBJECTS[name][tag] = value
+    else:
+        del OBJECTS[name][tag]
+
+def add_object(name,data):
+    global MODEL
+    if name in OBJECTS:
+        raise ValueError(f"object '{name}' exists")
+    OBJECTS[name] = data
+    OBJECTS[name]['id'] = len(OBJECTS.keys())
+    if 'meter' in data['class'] and WITHAMI:
+        add_object(name+'_ami',{
+            'class' : 'recorder',
+            'file' : name+'.csv',
+            'interval' : '3600',
+            'parent' : name,
+            'property' : 'measured_real_energy_delta,measured_demand'
+            })
+
+def get_parent(name):
+    try:
+        return OBJECTS[name]['parent']
+    except KeyError:
+        return None
+
+def fix_parent(parent,name,oclass):
+    pclass = get_data(parent,'class')
+
+    # change parent nodes to meters
+    if pclass and pclass == oclass.replace('load','node'):
+
+        # change node to meter
+        nclass = pclass.replace('load','meter')
+        set_data(parent,'class',nclass)
+
+    else:
+
+        # change parent
+        parent = get_parent(parent)
+        if parent:
+            fix_parent(parent,name,oclass)
+            set_data(name,'parent',parent)
+
+def warning(msg):
+    print(f"WARNING [{BASENAME}]: {msg}",file=sys.stderr)
+
+def error(msg):
+    print(f"ERROR [{BASENAME}]: {msg}",file=sys.stderr)
+
+for name in list(OBJECTS):
+    obj = OBJECTS[name]
+    oclass = obj['class']
+    parent = get_parent(name)
+    if oclass in ['load','triplex_load']:
+        links = get_links(name)
+        if parent:
+
+            fix_parent(parent,name,oclass)
+
+        elif links == None:
+
+            warning(f"{oclass} {name} is isolated")
+
+        else:
+
+            meter_name = name+"_meter"
+            meter = add_object(meter_name,{
+                'class' : oclass.replace('load','meter'),
+                'phases' : obj['phases'],
+                'nominal_voltage' : obj['nominal_voltage'],
+                'measured_energy_delta_timestep' : '3600',
+                })
+            set_link(name,meter_name)
+            set_data(name,'parent',meter_name)
+
+    elif oclass == 'triplex_load':
+        link = get_links(name)
+        if parent and parent['class'] == 'node':
+            obj['class'] == 'triplex_meter'
+        else:
+            pass
+    else:
+        pass
+
+with open(OUTPUTFILE,"wt") as fh:
+    json.dump(MODEL,fh,indent=4)

--- a/tools/create_meters.py
+++ b/tools/create_meters.py
@@ -2,7 +2,7 @@
 
 SYNOPSIS
 
-    gridlabd create_meters [--with-ami] INPUTFILE [OUTPUTFILE]
+    bash$ gridlabd create_meters [--with-ami] INPUTFILE [OUTPUTFILE]
 
 DESCRIPTION
 

--- a/tools/create_meters.py
+++ b/tools/create_meters.py
@@ -9,6 +9,17 @@ DESCRIPTION
     The `create_meters` tool adds meters and optionally recorders
     to the input JSON file.  If the output JSON file is not specified
     the output is written to the input JSON file.
+
+    Meters are added to all load and triplex_load objects that do not
+    already have meters. If the load is connected using a link, the
+    meter is assigned as the load's parent and link is reconnected to
+    the meter.  If the load is connected using a parent object, then
+    the parent object is converted to a meter if it is a node, otherwise
+    the object is assigned a new meter parent and the meter is linked
+    to the model.
+
+    If the `--with-ami` is included, each new meter will be assigned
+    a recorder with a sampling interval of 1 hour.
 """
 
 import os, sys


### PR DESCRIPTION
This PR allows meters to be added to network model.  

SYNOPSIS

    gridlabd create_meters [--with-ami] INPUTFILE [OUTPUTFILE]

DESCRIPTION

The `create_meters` tool adds meters and optionally recorders
to the input JSON file.  If the output JSON file is not specified
the output is written to the input JSON file.

Meters are added to all load and triplex_load objects that do not
already have meters. If the load is connected using a link, the
meter is assigned as the load's parent and link is reconnected to
the meter.  If the load is connected using a parent object, then
the parent object is converted to a meter if it is a node, otherwise
the object is assigned a new meter parent and the meter is linked
to the model.

If the `--with-ami` is included, each new meter will be assigned
a recorder with a sampling interval of 1 hour.