### PR TITLE
Add gridlabd-model subcommand

### DIFF
--- a/subcommands/Makefile.mk
+++ b/subcommands/Makefile.mk
@@ -13,6 +13,7 @@ bin_SCRIPTS += subcommands/gridlabd-library
 bin_SCRIPTS += subcommands/gridlabd-lock
 bin_SCRIPTS += subcommands/gridlabd-manual
 bin_SCRIPTS += subcommands/gridlabd-matrix
+bin_SCRIPTS += subcommands/gridlabd-model
 bin_SCRIPTS += subcommands/gridlabd-openfido
 bin_SCRIPTS += subcommands/gridlabd-pandas
 bin_SCRIPTS += subcommands/gridlabd-plot

--- a/subcommands/autotest/13.glm
+++ b/subcommands/autotest/13.glm
@@ -1,0 +1,591 @@
+// IEEE 13 bus network
+
+#set relax_naming_rules=TRUE
+
+module powerflow 
+{
+    solver_method NR;
+}
+
+// Phase Conductor 556,500 26/7 ACSR
+object overhead_line_conductor 
+{
+    name conductor1; 
+    geometric_mean_radius 0.031300;
+    resistance 0.185900;
+}
+
+// Phase Conductor 4/0 6/1 ACSR
+object overhead_line_conductor 
+{
+    name conductor2;
+    geometric_mean_radius 0.00814;
+    resistance 0.592000;
+}
+
+// Phase Conductor 1/0 ACSR
+object overhead_line_conductor 
+{
+    name conductor3;
+    geometric_mean_radius 0.004460;
+    resistance 1.120000;
+}
+
+
+// Phase Conductor 250,000 AA,CN
+object underground_line_conductor 
+{
+     name conductor4;
+     outer_diameter 1.290000;
+     conductor_gmr 0.017100;
+     conductor_diameter 0.567000;
+     conductor_resistance 0.410000;
+     neutral_gmr 0.0020800; 
+     neutral_resistance 14.87200;  
+     neutral_diameter 0.0640837;
+     neutral_strands 13.000000;
+     shield_gmr 0.000000;
+     shield_resistance 0.000000;
+}
+
+// Phase Conductor 1/0 AA,TS N: 1/0 Cu
+object underground_line_conductor 
+{ 
+     name conductor5;
+     outer_diameter 1.060000;
+     conductor_gmr 0.011100;
+     conductor_diameter 0.368000;
+     conductor_resistance 0.970000;
+     neutral_gmr 0.011100;
+     neutral_resistance 0.970000; // Unsure whether this is correct
+     neutral_diameter 0.0640837;
+     neutral_strands 6.000000;
+     shield_gmr 0.000000;
+     shield_resistance 0.000000;
+}
+
+// Overhead line spacings
+
+// ID-500abcn
+object line_spacing 
+{
+    name line_spacing1;
+    distance_AB 2.5;
+    distance_AC 4.5;
+    distance_BC 7.0;
+    distance_BN 5.656854;
+    distance_AN 4.272002;
+    distance_CN 5.0;
+}
+// ID-500 acbn
+object line_spacing 
+{
+    name line_spacing2;
+    distance_AC 2.5;
+    distance_AB 4.5;
+    distance_BC 7.0;
+    distance_CN 5.656854;
+    distance_AN 4.272002;
+    distance_BN 5.0;
+}
+// ID-505 bcn
+object line_spacing 
+{
+    name line_spacing3;
+    distance_AC 0.0;
+    distance_AB 0.0;
+    distance_BC 7.0;
+    distance_AN 0.0;
+    distance_CN 5.656854;
+    distance_BN 5.0;
+}
+// ID-505 acn
+object line_spacing 
+{
+    name line_spacing4;
+    distance_AC 7.0;
+    distance_AB 0.0;
+    distance_BC 0.0;
+    distance_AN 5.656854;
+    distance_CN 5.0;
+    distance_BN 0.0;
+}
+// ID-510 cn
+object line_spacing 
+{
+    name line_spacing5;
+    distance_AC 0.0;
+    distance_AB 0.0;
+    distance_BC 0.0;
+    distance_AN 0.0;
+    distance_CN 5.0;
+    distance_BN 0.0;
+}
+// ID-515 abc
+//Underground line spacing
+object line_spacing 
+{
+     name line_spacing6;
+     distance_AB 0.500000;
+     distance_BC 0.500000;
+     distance_AC 1.000000;
+     distance_AN 0.000000;
+     distance_BN 0.000000;
+     distance_CN 0.000000;
+}
+// ID-520 an
+object line_spacing 
+{
+    name line_spacing_7;
+     distance_AB 0.000000;
+     distance_BC 0.000000;
+     distance_AC 0.000000;
+     distance_AN 0.083333;
+     distance_BN 0.000000;
+     distance_CN 0.000000;
+}
+
+// Line configurations
+// Configuration 601
+object line_configuration 
+{
+    name line_configuration1;
+    conductor_A conductor1;
+    conductor_B conductor1;
+    conductor_C conductor1;
+    conductor_N conductor2;
+    spacing line_spacing1;
+}
+// Configuration 602
+object line_configuration 
+{
+    name line_configuration2;
+    conductor_A conductor2;
+    conductor_B conductor2;
+    conductor_C conductor2;
+    conductor_N conductor2;
+    spacing line_spacing2;
+}
+// Configuration 603
+object line_configuration 
+{
+    name line_configuration3;
+    conductor_B conductor3;
+    conductor_C conductor3;
+    conductor_N conductor3;
+    spacing line_spacing3;
+}
+// Configuration 604
+object line_configuration 
+{
+    name line_configuration4;
+    conductor_A conductor3;
+    conductor_C conductor3;
+    conductor_N conductor3;
+    spacing line_spacing4;
+}
+// Configuration 605
+object line_configuration 
+{
+    name line_configuration5;
+    conductor_C conductor3;
+    conductor_N conductor3;
+    spacing line_spacing5;
+}
+
+
+// Configuration 606
+object line_configuration 
+{
+     name line_configuration6;
+     conductor_A conductor4;
+     conductor_B conductor4;
+     conductor_C conductor4;
+     spacing line_spacing6;
+}
+// Configuration 607
+object line_configuration 
+{
+     name line_configuration7;
+     conductor_A conductor5;
+     conductor_N conductor5;
+     spacing line_spacing6;
+}
+
+// Transformer configuration
+object transformer_configuration 
+{
+    name transformer_configuration1;
+    connect_type WYE_WYE;
+      install_type PADMOUNT;
+      power_rating 500;
+      primary_voltage 4160;
+      secondary_voltage 480;
+      resistance 0.011;
+      reactance 0.02;
+}
+
+// Regulator configuration
+object regulator_configuration 
+{
+    name regulator_configuration1;
+    connect_type WYE_WYE;
+    band_center 2300;
+    band_width 20.0;
+    time_delay 30.0;
+    raise_taps 16;
+    lower_taps 16;
+    regulation 0.10;
+    Control REMOTE_NODE;// MANUAL OUTPUT_VOLTAGE;
+    //tap_pos_A 10; // Only state these if in manual mode
+    //tap_pos_B 8;
+    //tap_pos_C 11;
+}
+
+// Define line objects
+object overhead_line 
+{
+     name overhead_line1;
+     phases "BCN";
+     from Node632;
+     to Load645;
+     length 500;
+     configuration line_configuration3;
+}
+
+object overhead_line 
+{
+     name overhead_line2;
+     phases "BCN";
+     from Load645;
+     to Load646;
+     length 300;
+     configuration line_configuration3;
+}
+
+object overhead_line 
+{
+     name overhead_line3;
+     phases "ABCN";
+     from Node630;
+     to Node632;
+     length 2000;
+     configuration line_configuration1;
+}
+
+//Split line for distributed load
+object overhead_line 
+{
+     name overhead_line4;
+     phases "ABCN";
+     from Node632;
+     to Load6321;
+     length 500;
+     configuration line_configuration1;
+}
+
+object overhead_line 
+{
+     name overhead_line5;
+     phases "ABCN";
+     from Load6321;
+     to Load671;
+     length 1500;
+     configuration line_configuration1;
+}
+//End split line
+
+object overhead_line 
+{
+     name overhead_line6;
+     phases "ABCN";
+     from Load671;
+     to Node680;
+     length 1000;
+     configuration line_configuration1;
+}
+
+object overhead_line 
+{
+     name overhead_line7;
+     phases "ACN";
+     from Load671;
+     to Node684;
+     length 300;
+     configuration line_configuration4;
+}
+
+ object overhead_line 
+{
+      name overhead_line8;
+      phases "CN";
+      from Node684;
+      to Load611;
+      length 300;
+      configuration line_configuration5;
+}
+
+object underground_line 
+{
+      name overhead_line9;
+      phases "AN";
+      from Node684;
+      to Load652;
+      length 800;
+      configuration line_configuration7;
+}
+
+object underground_line 
+{
+     name overhead_line10;
+     phases "ABC";
+     from Load692;
+     to Load675;
+     length 500;
+     configuration line_configuration6;
+}
+
+object overhead_line 
+{
+     name overhead_line11;
+     phases "ABCN";
+     from Node632;
+     to Node633;
+     length 500;
+     configuration line_configuration2;
+}
+
+
+
+// Create node objects
+object node 
+{
+     name Node633;
+     phases "ABCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     nominal_voltage 2401.7771;
+}
+
+object node 
+{
+     name Node630;
+     phases "ABCN";
+     voltage_A 2401.7771+0j;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     nominal_voltage 2401.7771;
+}
+ 
+object node 
+{
+     name Node632;
+     phases "ABCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     nominal_voltage 2401.7771;
+}
+
+object node 
+{
+      name Node650;
+      phases "ABCN";
+      bustype SWING;
+      voltage_A 2401.7771;
+      voltage_B -1200.8886-2080.000j;
+      voltage_C -1200.8886+2080.000j;
+      nominal_voltage 2401.7771;
+} 
+ 
+object node 
+{
+       name Node680;
+       phases "ABCN";
+       voltage_A 2401.7771;
+       voltage_B -1200.8886-2080.000j;
+       voltage_C -1200.8886+2080.000j;
+       nominal_voltage 2401.7771;
+}
+ 
+ 
+object node 
+{
+      name Node684;
+      phases "ACN";
+      voltage_A 2401.7771;
+      voltage_B -1200.8886-2080.000j;
+      voltage_C -1200.8886+2080.000j;
+      nominal_voltage 2401.7771;
+} 
+ 
+ 
+ 
+// Create load objects 
+
+object load 
+{
+     name Load634;
+     phases "ABCN";
+     voltage_A 480.000+0j;
+     voltage_B -240.000-415.6922j;
+     voltage_C -240.000+415.6922j;
+     constant_power_A 160000+110000j;
+     constant_power_B 120000+90000j;
+     constant_power_C 120000+90000j;
+     nominal_voltage 480.000;
+}
+ 
+object load 
+{
+     name Load645;
+     phases "BCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_B 170000+125000j;
+     nominal_voltage 2401.7771;
+}
+ 
+object load 
+{
+     name Load646;
+     phases "BCD";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_impedance_B 56.5993+32.4831j;
+     nominal_voltage 2401.7771;
+}
+ 
+ 
+object load 
+{
+     name Load652;
+     phases "AN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_impedance_A 31.0501+20.8618j;
+     nominal_voltage 2401.7771;
+}
+ 
+object load 
+{
+     name Load671;
+     phases "ABCD";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 385000+220000j;
+     constant_power_B 385000+220000j;
+     constant_power_C 385000+220000j;
+     nominal_voltage 2401.7771;
+}
+ 
+object load 
+{
+     name Load675;
+     phases "ABC";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 485000+190000j;
+     constant_power_B 68000+60000j;
+     constant_power_C 290000+212000j;
+     constant_impedance_A 0.00-28.8427j;          //Shunt Capacitors
+     constant_impedance_B 0.00-28.8427j;
+     constant_impedance_C 0.00-28.8427j;
+     nominal_voltage 2401.7771;
+}
+ 
+object load 
+{
+     name Load692;
+     phases "ABCD";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_current_A 0+0j;
+     constant_current_B 0+0j;
+     constant_current_C -17.2414+51.8677j;
+     nominal_voltage 2401.7771;
+}
+ 
+object load 
+{
+     name Load611;
+     phases "CN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_current_C -6.5443+77.9524j;
+     constant_impedance_C 0.00-57.6854j;         //Shunt Capacitor
+     nominal_voltage 2401.7771;
+}
+ 
+// distributed load between node 632 and 671
+// 2/3 of load 1/4 of length down line: Kersting p.56
+object load 
+{
+     name Load6711;
+     parent Load671;
+     phases "ABC";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 5666.6667+3333.3333j;
+     constant_power_B 22000+12666.6667j;
+     constant_power_C 39000+22666.6667j;
+     nominal_voltage 2401.7771;
+}
+
+object load 
+{
+     name Load6321;
+     phases "ABCN";
+     voltage_A 2401.7771;
+     voltage_B -1200.8886-2080.000j;
+     voltage_C -1200.8886+2080.000j;
+     constant_power_A 11333.333+6666.6667j;
+     constant_power_B 44000+25333.3333j;
+     constant_power_C 78000+45333.3333j;
+     nominal_voltage 2401.7771;
+}
+ 
+
+ 
+// Switch
+object switch 
+{
+     name switch1;
+     phases "ABCN";
+     from Load671;
+     to Load692;
+     status CLOSED;
+}
+ 
+// Transformer
+
+  object transformer 
+{
+    name XFMR1;
+      phases "ABCN";
+      from Node633;
+      to Load634;
+      configuration transformer_configuration1;
+}
+  
+ 
+  // Regulator
+  
+object regulator 
+{
+    name Reg1;
+     phases "ABC";
+     from Node650;
+     to Node630;
+     sense_node Load671;
+     configuration regulator_configuration1;
+}

--- a/subcommands/autotest/test_model.glm
+++ b/subcommands/autotest/test_model.glm
@@ -1,0 +1,5 @@
+#model get IEEE/13
+
+#ifexist ../13.glm
+#on_exit 0 diff ../13.glm 13.glm > gridlabd.diff
+#endif

--- a/subcommands/gridlabd-json-get
+++ b/subcommands/gridlabd-json-get
@@ -61,8 +61,11 @@ try:
         for key in keys:
             if type(data) is dict and key in data.keys() :
                 data = data[key];
-            elif type(data) is list and int(key) >=0 and int(key) <= len(data) :
-                data = data[int(key)];
+            elif type(data) is list:
+                try:
+                    data = data[int(key)];
+                except:
+                    data = [x[key] for x in data]
             else :
                 error(2,"%s is not valid"%key);
         if keys_only:

--- a/subcommands/gridlabd-model
+++ b/subcommands/gridlabd-model
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Get models from the gridlabd-models repo
+#
+
+if [ $# -eq 0 ]; then
+    echo "Syntax: $(basename $0) SUBCOMMAND [ARGS...]"
+    exit 1
+fi
+
+GITBRANCH=master
+GITUSER=slacgismo
+GITREPO=gridlabd-models
+VERSION=4
+
+function error()
+{
+    RC=$1
+    shift 1
+    echo "ERROR [$EXECNAME]: $*" >/dev/stderr
+    exit $RC
+}
+
+while [ "${1:0:1}" == "-" ]; do
+    case "$1" in
+    (-b|--branch)
+        GITBRANCH="$2"
+        shift 1
+        ;;
+    (-r|--repository)
+        GITREPO="$2"
+        shift 1
+        ;;
+    (-u|--user)
+        GITUSER="$2"
+        shift 1
+        ;;
+    (-v|--version)
+        VERSION="$2"
+        shift 1
+        ;;
+    (-d|--debug)
+        set -x
+        ;;
+    (*)
+        error 1 "option '$1' is not valid"
+        ;;
+    esac
+    shift 1
+done
+
+if [ $1 == 'get' ]; then
+    if [ $# -lt 2 ]; then
+        error 2 "get missing GROUP/NAME"
+        exit 1
+    else
+        curl -sL https://raw.githubusercontent.com/$GITUSER/$GITREPO/$GITBRANCH/gridlabd-$VERSION/$2.glm -o $(basename $2).glm
+        exit 0
+    fi
+elif [ $1 == 'index' ]; then
+    if [ $# -eq 2 ]; then
+        PATTERN=$2
+    fi
+    curl -sL https://api.github.com/repos/slacgismo/gridlabd-models/git/trees/master\?recursive=1 | gridlabd json-get tree path -c | grep '\.glm$' | grep ^gridlabd-$VERSION/$PATTERN | sed -e 's/\.glm$//;s/gridlabd-[0-9]\///'
+    exit 0
+elif [ $1 == 'help' ]; then
+    echo "Syntax: $(basename $0) SUBCOMMAND [ARGS...]"
+    echo "Subcommands"
+    echo "  get GROUP/NAME"
+    echo "  help"
+    echo "  index [PATTERN]"
+    exit 0
+else
+    error 3 "'$1' is not a valid subcommand"
+fi


### PR DESCRIPTION
- [x] Add subcommand to get models from the `gridlabd-models` repository. Two command options are now available
  - [x] `gridlabd model index [PATTERN]` to get a list of available models.
  - [x] `gridlabd model get GROUP/NAME` to get a model.
- [x] Add validation autotest `test_model.glm`.
