### PR TITLE
Fixes for duplicate admittance error for incorrect single-phase transformers

### DIFF
--- a/module/powerflow/autotest/test_transformer_not_SPCT_err.glm
+++ b/module/powerflow/autotest/test_transformer_not_SPCT_err.glm
@@ -1,0 +1,104 @@
+// Test to check "failure" for a single-phase
+// transformer and triplex phasing/connections
+// This should error out, per the checks added
+// as part of gridlabd/#1432 or slacgismo/#1277
+
+module powerflow 
+{
+	solver_method NR;
+}   
+
+// Phase Conductor 556,500 26/7 ACSR
+object overhead_line_conductor 
+{
+	name conductor1; 
+	geometric_mean_radius 0.031300;
+	resistance 0.185900;
+}
+
+// Phase Conductor 4/0 6/1 ACSR
+object overhead_line_conductor 
+{
+	name conductor2;
+	geometric_mean_radius 0.00814;
+	resistance 0.592000;
+}
+
+// Overhead line spacings
+
+// ID-500abcn
+object line_spacing 
+{
+	name line_spacing1;
+	distance_AB 2.5;
+	distance_AC 4.5;
+	distance_BC 7.0;
+	distance_BN 5.656854;
+	distance_AN 4.272002;
+	distance_CN 5.0;
+}
+
+// Line configurations
+// Configuration 601
+object line_configuration 
+{
+	name line_configuration1;
+	conductor_A conductor1;
+	conductor_B conductor1;
+	conductor_C conductor1;
+	conductor_N conductor2;
+	spacing line_spacing1;
+}
+
+object overhead_line 
+{
+	 name overhead_line3;
+	 phases "ABCN";
+	 from Swing_node;
+	 to three_phase_node;
+	 length 2000;
+	 configuration line_configuration1;
+}
+
+// Create node objects
+object node 
+{
+	name Swing_node;
+	bustype SWING;
+	phases "ABCN";
+	nominal_voltage 2401.7771;
+}
+
+object node 
+{
+	name three_phase_node;
+	phases "ABCN";
+	nominal_voltage 2401.7771;
+}
+
+//Added objects that would fail for #1432
+object transformer_configuration {
+	name "xfrmcfg_ABCN_480";
+	primary_voltage 480.0 V;
+	secondary_voltage 120 V;
+	connect_type SINGLE_PHASE;
+	// connect_type SINGLE_PHASE_CENTER_TAPPED;	//Correct transformer
+	resistance 0.01 Ohm;
+	reactance 0.06 Ohm;
+	install_type "PADMOUNT";
+	power_rating 80000.0;
+}
+object transformer {
+	name "broken_transformer";
+	from "three_phase_node";
+	to "node_5";
+	phases C;
+	// phases CS;	//Correct phases, with correct transformer
+	configuration "xfrmcfg_ABCN_480";
+}
+
+object triplex_node {
+	name "node_5";
+	phases CS;
+	nominal_voltage 120 V;
+}

--- a/module/powerflow/transformer.cpp
+++ b/module/powerflow/transformer.cpp
@@ -137,6 +137,8 @@ int transformer::init(OBJECT *parent)
 	violation_watch = violation_watchset&VW_XFRM;
 	
 	int idex;
+	gld_property *tphases_ref;
+	set tphases;
 
 	if (!configuration)
 		GL_THROW("no transformer configuration specified.");
@@ -184,6 +186,25 @@ int transformer::init(OBJECT *parent)
 		return 2;	//Return the deferment - no sense doing everything else!
 
 	OBJECT *obj = THISOBJECTHDR;
+
+	//map and pull the phases
+	tphases_ref = new gld_property(to,"phases");
+
+	//Check it
+	if (!tphases_ref->is_set() || !tphases_ref->is_valid())
+	{
+		error("Transformer:%s failed to map the phases of the \"to\" node",obj->name?obj->name:"unnamed");
+		/*  TROUBLESHOOT
+		While attempting to map the phases property of the "to" node of the transformer, an error occurred.  Ensure that object
+		actually is a powerflow node and try again.  If the error persists, please submit an issue in issue tracker.
+		*/
+	}
+
+	//Map them back
+	tphases = tphases_ref->get_set();
+
+	//Remove it
+	delete tphases_ref;
 
 	V_base = config->V_secondary/(1-degradation_factor);
 	if ( degradation_factor < 0 || degradation_factor >= 1 )
@@ -245,6 +266,17 @@ int transformer::init(OBJECT *parent)
 				zt_c = complex(0,0);
 			}
 			
+			//General phase check - prevents issue that popped up in issue #1277
+			if (has_phase(PHASE_S) || ((tphases & PHASE_S) == PHASE_S))
+			{
+				error("Transformer:%s has a triplex phase or a triplex \"to\" node, but it is not an SPCT transformer",obj->name?obj->name:"unnamed");
+				/*  TROUBLESHOOT
+				A transformer has triplex characteristics (S phase or a triplex_node attached), but it is not
+				configured as an SPCT transformer.  Please check your transformer configuration or attached
+				node.
+				*/
+			}
+
 			if (solver_method==SM_FBS)
 			{
 				if (has_phase(PHASE_A)) 
@@ -505,6 +537,13 @@ int transformer::init(OBJECT *parent)
 			break;
 		case transformer_configuration::DELTA_DELTA:
 
+			//General phase check - prevents issue that popped up in issue #1277
+			if (has_phase(PHASE_S) || ((tphases & PHASE_S) == PHASE_S))
+			{
+				error("Transformer:%s has a triplex phase or a triplex \"to\" node, but it is not an SPCT transformer",obj->name?obj->name:"unnamed");
+				//Defined elsewhere
+			}
+
 			if (solver_method==SM_FBS)
 			{
 				a_mat[0][0] = a_mat[1][1] = a_mat[2][2] = nt * 2.0 / 3.0;
@@ -554,6 +593,13 @@ int transformer::init(OBJECT *parent)
 			break;
 		case transformer_configuration::DELTA_GWYE:
 			
+			//General phase check - prevents issue that popped up in issue #1277
+			if (has_phase(PHASE_S) || ((tphases & PHASE_S) == PHASE_S))
+			{
+				error("Transformer:%s has a triplex phase or a triplex \"to\" node, but it is not an SPCT transformer",obj->name?obj->name:"unnamed");
+				//Defined elsewhere
+			}
+
 			if (solver_method==SM_FBS)
 			{
 				if (nt>1.0)//step down transformer

--- a/module/powerflow/triplex_node.cpp
+++ b/module/powerflow/triplex_node.cpp
@@ -184,10 +184,12 @@ int triplex_node::init(OBJECT *parent)
 	if ( !(has_phase(PHASE_S)) )
 	{
 		OBJECT *obj = THISOBJECTHDR;
-		warning("Init() triplex_node (name:%s, id:%d): Phases specified did not include phase S. Adding phase S.", obj->name,obj->id);
+		warning("Init() triplex_node (name:%s, id:%d): Phases specified did not include phase S. Adding phase S. Check upstream devices.", obj->name,obj->id);
 		/* TROUBLESHOOT
 		Triplex nodes and meters require a single phase and a phase S component (for split-phase).
-		This particular triplex object did not include it, so it is being added.
+		This particular triplex object did not include it, so it is being added.  Check upstream devices
+		(mostly tranformers) to make sure they are appropriate.  A duplicate NR admittance entry can occur
+		if the upstream transformer is incorrect too.
 		*/
 		phases = (phases | PHASE_S);
 	}


### PR DESCRIPTION
Fix the issue documented in #1277
Adds checks for non-SPCT transformers to check for connections to triplex devices or having phase S.
Migration of fix from https://github.com/gridlab-d/gridlab-d/issues/1432

Added extra autotest to ensure this errors, though it could still technically pass on the previous failure.