### PR TITLE
Add wheel install

### DIFF
--- a/docs/Module/Python.md
+++ b/docs/Module/Python.md
@@ -2,7 +2,14 @@
 
 # Synopsis
 
-Python 3.6 or greater:
+Installation:
+~~~
+python3.10 -m venv myenv
+. myenv/bin/activate
+python3 -m pip install $(gridlabd --version=install)/share/gridlabd/*.whl
+~~~
+
+Python 3.10:
 ~~~
   >>> import gridlabd
   >>> gridlabd.title()

--- a/docs/Module/Python.md
+++ b/docs/Module/Python.md
@@ -263,6 +263,7 @@ Saves the full model to the file.  The currently supported formats are `.glm`, `
 The following model is `test.glm`:
 ~~~
   module test;
+  #set suppress_repeat_messages=FALSE
   clock {
   	starttime '2018-01-01 00:00:00';
   	stoptime '2018-01-01 01:00:00';

--- a/python/Makefile.mk
+++ b/python/Makefile.mk
@@ -1,20 +1,26 @@
 PYTHONVERSION=$(shell python$(PYVER) $(top_srcdir)/python/setup.py --version)
-PYPKG=$(PYENV)/lib/python$(PYVER)/site-packages/gridlabd
+PYPKG=$(PYENV)/lib/python$(PYVER)/site-packages/$(PACKAGE)
+INSTALL_WHEEL = $(datadir)/$(PACKAGE)/$(PACKAGE)-$(PYTHONVERSION).whl
 
-$(top_srcdir)/python/dist/gridlabd-$(PYTHONVERSION).tar.gz: $(top_srcdir)/source/build.h | $(PYENV)
-	@echo "building gridlabd-$(PYTHONVERSION)..."
+$(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/source/build.h | $(PYENV)
+	@echo "building $(PACKAGE)-$(PYTHONVERSION)..."
 	@rm -f $(PYPKG)-$(PYTHONVERSION)*.{whl,tar.gz}
 	@$(ENVPYTHON) -m pip install build 
 	@export SRCDIR=$(realpath $(top_srcdir)) ; export BLDDIR=$(shell pwd); $(ENVPYTHON) -m build $(top_srcdir)/python
 
-$(PYPKG)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/python/dist/gridlabd-$(PYTHONVERSION).tar.gz
+$(PYPKG)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION).tar.gz
 	@echo "copying $(top_srcdir)/python/dist to $(PYPKG)-$(PYTHONVERSION)..."
-	@cp $(top_srcdir)/python/dist/gridlabd-$(PYTHONVERSION)*.{tar.gz,whl} $(PYENV)/lib/python$(PYVER)/site-packages
+	@cp $(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION)*.{tar.gz,whl} $(PYENV)/lib/python$(PYVER)/site-packages
 
-python-install: $(PYPKG)-$(PYTHONVERSION).dist-info
+
+python-install: $(INSTALL_WHEEL)
+
+$(INSTALL_WHEEL): $(PYPKG)-$(PYTHONVERSION).dist-info
+	@echo "creating wheel '$(INSTALL_WHEEL)'..."
+	@cp $(PYPKG)-$(PYTHONVERSION)-*.whl $(INSTALL_WHEEL)
 
 $(PYPKG)-$(PYTHONVERSION).dist-info: $(PYPKG)-$(PYTHONVERSION).tar.gz
-	@echo "installing gridlabd-$(PYTHONVERSION)..."
+	@echo "installing $(PACKAGE)-$(PYTHONVERSION)..."
 	$(ENVPYTHON) -m pip install --ignore-installed $(PYPKG)-$(PYTHONVERSION)-*.whl
 	touch $@
 

--- a/python/Makefile.mk
+++ b/python/Makefile.mk
@@ -1,6 +1,5 @@
 PYTHONVERSION=$(shell python$(PYVER) $(top_srcdir)/python/setup.py --version)
 PYPKG=$(PYENV)/lib/python$(PYVER)/site-packages/$(PACKAGE)
-INSTALL_WHEEL = $(datadir)/$(PACKAGE)/$(PACKAGE)-$(PYTHONVERSION).whl
 
 $(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/source/build.h | $(PYENV)
 	@echo "building $(PACKAGE)-$(PYTHONVERSION)..."
@@ -13,15 +12,12 @@ $(PYPKG)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONV
 	@cp $(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION)*.{tar.gz,whl} $(PYENV)/lib/python$(PYVER)/site-packages
 
 
-python-install: $(INSTALL_WHEEL)
-
-$(INSTALL_WHEEL): $(PYPKG)-$(PYTHONVERSION).dist-info
-	@echo "creating wheel '$(INSTALL_WHEEL)'..."
-	@cp $(PYPKG)-$(PYTHONVERSION)-*.whl $(INSTALL_WHEEL)
+python-install: $(PYPKG)-$(PYTHONVERSION).dist-info
 
 $(PYPKG)-$(PYTHONVERSION).dist-info: $(PYPKG)-$(PYTHONVERSION).tar.gz
 	@echo "installing $(PACKAGE)-$(PYTHONVERSION)..."
 	$(ENVPYTHON) -m pip install --ignore-installed $(PYPKG)-$(PYTHONVERSION)-*.whl
+	@cp $(PYPKG)-$(PYTHONVERSION)-*.whl $(datadir)/$(PACKAGE)
 	touch $@
 
 python-clean:

--- a/python/Makefile.mk
+++ b/python/Makefile.mk
@@ -1,23 +1,23 @@
 PYTHONVERSION=$(shell python$(PYVER) $(top_srcdir)/python/setup.py --version)
-PYPKG=$(PYENV)/lib/python$(PYVER)/site-packages/$(PACKAGE)
+PYPKG=$(PYENV)/lib/python$(PYVER)/site-packages/gridlabd
 
-$(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/source/build.h | $(PYENV)
-	@echo "building $(PACKAGE)-$(PYTHONVERSION)..."
+$(top_srcdir)/python/dist/gridlabd-$(PYTHONVERSION).tar.gz: $(top_srcdir)/source/build.h | $(PYENV)
+	@echo "building gridlabd-$(PYTHONVERSION)..."
 	@rm -f $(PYPKG)-$(PYTHONVERSION)*.{whl,tar.gz}
 	@$(ENVPYTHON) -m pip install build 
 	@export SRCDIR=$(realpath $(top_srcdir)) ; export BLDDIR=$(shell pwd); $(ENVPYTHON) -m build $(top_srcdir)/python
 
-$(PYPKG)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION).tar.gz
+$(PYPKG)-$(PYTHONVERSION).tar.gz: $(top_srcdir)/python/dist/gridlabd-$(PYTHONVERSION).tar.gz
 	@echo "copying $(top_srcdir)/python/dist to $(PYPKG)-$(PYTHONVERSION)..."
-	@cp $(top_srcdir)/python/dist/$(PACKAGE)-$(PYTHONVERSION)*.{tar.gz,whl} $(PYENV)/lib/python$(PYVER)/site-packages
-
+	@cp $(top_srcdir)/python/dist/gridlabd-$(PYTHONVERSION)*.{tar.gz,whl} $(PYENV)/lib/python$(PYVER)/site-packages
 
 python-install: $(PYPKG)-$(PYTHONVERSION).dist-info
+	@mkdir -p $(datadir)/$(PACKAGE)/ 
+	@cp $(PYPKG)-$(PYTHONVERSION)-*.whl $(datadir)/$(PACKAGE)/ 
 
 $(PYPKG)-$(PYTHONVERSION).dist-info: $(PYPKG)-$(PYTHONVERSION).tar.gz
-	@echo "installing $(PACKAGE)-$(PYTHONVERSION)..."
+	@echo "installing gridlabd-$(PYTHONVERSION)..."
 	$(ENVPYTHON) -m pip install --ignore-installed $(PYPKG)-$(PYTHONVERSION)-*.whl
-	@cp $(PYPKG)-$(PYTHONVERSION)-*.whl $(datadir)/$(PACKAGE)
 	touch $@
 
 python-clean:


### PR DESCRIPTION
This PR fixes on item missed on issue #1250, i.e., the wheel was not installed in the shared folder so it was not possible to install the gridlabd module in any other `venv` created by the user after `gridlabd` was installed.  Now you can do the following anytime:

~~~
python3.10 -m venv example
. example/bin/activate
python3 -m pip install /usr/local/opt/gridlabd/current/gridlabd/share/*.whl
python3 -c 'import gridlabd; print(gridlabd.version())'
~~~

which should generation output like

~~~
{'major': 4, 'minor': 3, 'patch': 3, 'build': 230708, 'branch': 'develop_add_wheel_install'}
~~~

This PR also fixes a problem with output from the Python documentation example.