### PR TITLE
Add shell subcommand

### DIFF
--- a/docs/Module/Python.md
+++ b/docs/Module/Python.md
@@ -2,8 +2,9 @@
 
 # Synopsis
 
-Installation:
+GridLAB-D Python venv:
 ~~~
+gridlabd shell
 python3.10 -m venv myenv
 . myenv/bin/activate
 python3 -m pip install $(gridlabd --version=install)/share/gridlabd/*.whl
@@ -316,7 +317,7 @@ bash$ python3
   2018-01-01 00:50:00 UTC,0.251099
   2018-01-01 00:55:00 UTC,2.778129
   2018-01-01 01:00:00 UTC,0.603100
-  4362511024
+  0
   >>> quit()
 ~~~
 The following example records all house temperature when the model commit if performed:
@@ -399,4 +400,6 @@ The first few lines of output are in `house.csv`:
 
 # See also
 
-* [[/Python subcommand]]
+* [[/Module/Python]]
+* [[/Subcommand/Shell]]
+

--- a/docs/Module/Python.md
+++ b/docs/Module/Python.md
@@ -5,12 +5,12 @@
 GridLAB-D Python venv:
 ~~~
 gridlabd shell
-python3.10 -m venv myenv
+python$PYTHON_VER -m venv myenv
 . myenv/bin/activate
-python3 -m pip install $(gridlabd --version=install)/share/gridlabd/*.whl
+python3 -m pip install $GLD_ETC/*.whl
 ~~~
 
-Python 3.10:
+Python 3:
 ~~~
   >>> import gridlabd
   >>> gridlabd.title()

--- a/docs/Subcommand/Shell.md
+++ b/docs/Subcommand/Shell.md
@@ -19,7 +19,6 @@ The following environment variables are set in the shell environment:
 - `CPPFLAGS`: C++ compiler flags
 - `CXXFLAGS`: C++ compiler flags
 - `GLD_BIN`: binary folder
-- `GLD_DOC`: documentation folder
 - `GLD_ETC`: shared files folder
 - `GLD_INC`: include files folder
 - `GLD_LIB`: library folder

--- a/docs/Subcommand/Shell.md
+++ b/docs/Subcommand/Shell.md
@@ -10,7 +10,7 @@ sh$ gridlabd shell
 
 # Description
 
-The `shell` subcommand opens a shell in the GridLAB-D environment. This can be used to run Python with the active python `venv` used for GridLAB-D.
+The `shell` subcommand opens a shell in the GridLAB-D environment. This can be used to run Python with the active python `venv` used for GridLAB-D, or to create a new Python virtual environment in which gridlabd can be run.
 
 The following environment variables are set in the shell environment:
 
@@ -34,6 +34,17 @@ The following environment variables are set in the shell environment:
 - `PYTHONPATH`: Python search path
 - `VIRTUAL_ENV`: Python virtual environment path
 - `VIRTUAL_ENV_PROMPT`: Python virtual environment prompt
+
+# Example
+
+The following commands open a GridLAB-D shell environment and create a Python virtual environment in which GridLAB-D is installed
+
+~~~
+gridlabd shell
+python$PYTHON_VER -m venv myenv
+. myenv/bin/activate
+python3 -m pip install $GLD_ETC/*.whl
+~~~
 
 # See also
 

--- a/docs/Subcommand/Shell.md
+++ b/docs/Subcommand/Shell.md
@@ -12,6 +12,30 @@ sh$ gridlabd shell
 
 The `shell` subcommand opens a shell in the GridLAB-D environment. This can be used to run Python with the active python `venv` used for GridLAB-D.
 
+The following environment variables are set in the shell environment:
+
+- `CCFLAGS`: C-compiler flags
+- `CFLAGS`: C-compiler flags
+- `CPPFLAGS`: C++ compiler flags
+- `CXXFLAGS`: C++ compiler flags
+- `GLD_BIN`: binary folder
+- `GLD_DOC`: documentation folder
+- `GLD_ETC`: shared files folder
+- `GLD_INC`: include files folder
+- `GLD_LIB`: library folder
+- `GLD_VER`: version folder
+- `GLPATH`: GridLAB-D file search path
+- `INCLUDE`: C-compiler include flags
+- `LDFLAGS`: linker flags
+- `LIB`: linker library path
+- `PYCCFLAGS`: python C-compiler flags
+- `PYLDFLAGS`: Python linker flags
+- `PYTHON_CONFIG` python config executable name
+- `PYTHON_VER`: python version number (major.minor)
+- `PYTHONPATH`: Python search path
+- `VIRTUAL_ENV`: Python virtual environment path
+- `VIRTUAL_ENV_PROMPT`: Python virtual environment prompt
+
 # See also
 
 * [[/Subcommand/Python]]

--- a/docs/Subcommand/Shell.md
+++ b/docs/Subcommand/Shell.md
@@ -5,12 +5,12 @@
 Shell:
 
 ~~~
-sh$ gridlabd shell
+sh$ gridlabd shell [OPTIONS ...]
 ~~~
 
 # Description
 
-The `shell` subcommand opens a shell in the GridLAB-D environment. This can be used to run Python with the active python `venv` used for GridLAB-D, or to create a new Python virtual environment in which gridlabd can be run.
+The `shell` subcommand opens a shell in the GridLAB-D environment. The shell used is the one currently running as specified by the `SHELL` environment variable. This can be used to run Python with the active python `venv` used for GridLAB-D, or to create a new Python virtual environment in which gridlabd can be run. The options are the same as for the shell current being used.
 
 The following environment variables are set in the shell environment:
 

--- a/docs/Subcommand/Shell.md
+++ b/docs/Subcommand/Shell.md
@@ -1,0 +1,17 @@
+[[/Subcommand/Shell]] -- Open GridLAB-D shell environment
+
+# Synopsis
+
+Shell:
+
+~~~
+sh$ gridlabd shell
+~~~
+
+# Description
+
+The `shell` subcommand opens a shell in the GridLAB-D environment. This can be used to run Python with the active python `venv` used for GridLAB-D.
+
+# See also
+
+* [[/Subcommand/Python]]

--- a/source/gridlabd.in
+++ b/source/gridlabd.in
@@ -265,7 +265,7 @@ as_nop=as_fn_nop
 ## -------------------- ##
 
 
-REALPATH=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $0); 
+REALPATH=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $0);
 export GLD_BIN=$(dirname $REALPATH)
 PREFIX=$(dirname $GLD_BIN)
 export GLD_ETC=$PREFIX/share/gridlabd
@@ -388,6 +388,11 @@ fi
 if test -f "${GLD_ETC}/gridlabd.rc"
 then :
   . ${GLD_ETC}/gridlabd.rc
+fi
+
+if test x$1 = xshell
+then :
+  $SHELL; exit $?
 fi
 
 if test -f "${GLD_ETC}/$1.py"

--- a/source/gridlabd.in
+++ b/source/gridlabd.in
@@ -392,7 +392,7 @@ fi
 
 if test x$1 = xshell
 then :
-  $SHELL; exit $?
+  shift 1; $SHELL $@; exit $?
 fi
 
 if test -f "${GLD_ETC}/$1.py"

--- a/source/gridlabd.m4sh
+++ b/source/gridlabd.m4sh
@@ -123,7 +123,7 @@ AS_IF([test -f "${GLD_ETC}/gridlabd.rc"],
   [])
 
 AS_IF([test x$1 = xshell],
-  [$SHELL; exit $?],
+  [shift 1; $SHELL $@; exit $?],
   [])
 
 AS_IF([test -f "${GLD_ETC}/$1.py"],

--- a/source/gridlabd.m4sh
+++ b/source/gridlabd.m4sh
@@ -1,7 +1,7 @@
 dnl run "autom4te -l m4sh gridlabd.m4sh > gridlabd.in"
 AS_INIT
 
-REALPATH=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' $0); 
+REALPATH=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[[1]]))' $0); 
 export GLD_BIN=$(dirname $REALPATH)
 PREFIX=$(dirname $GLD_BIN)
 export GLD_ETC=$PREFIX/share/gridlabd
@@ -78,10 +78,12 @@ fi
 ###############################################################################
 # Python Configuration Data and Flags
 ###############################################################################
+PY_OS="$(uname -s)"
+
 . $GLD_BIN/activate
 
 export PYTHON_VER=$(python3 --version | cut -f2 -d' ' | cut -f1-2 -d.)
-export PYTHON_CONFIG="$GLD_BIN/activate/python$PYTHON_VER-config"
+export PYTHON_CONFIG="python$PYTHON_VER-config"
 export PYCCFLAGS="$($PYTHON_CONFIG --cflags)"
 export INCLUDE="-I$GLD_ETC -I$GLD_VER/include -I/usr/include"
 export CFLAGS="${INCLUDE} ${PYCCFLAGS} ${CFLAGS}"
@@ -118,6 +120,10 @@ fi
 
 AS_IF([test -f "${GLD_ETC}/gridlabd.rc"],
   [. ${GLD_ETC}/gridlabd.rc],
+  [])
+
+AS_IF([test x$1 = xshell],
+  [$SHELL; exit $?],
   [])
 
 AS_IF([test -f "${GLD_ETC}/$1.py"],


### PR DESCRIPTION
This PR fixes #1311. The example works when python is run in the gridlabd environment. The `shell` subcommand allows the execution of commands in the correct environment.